### PR TITLE
Add support for optional schema for non primitive types.

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
@@ -175,6 +175,11 @@ public class DataConverter {
       switch (schemaName) {
         case Decimal.LOGICAL_NAME:
           builder = SchemaBuilder.float64();
+          if (schema.isOptional())
+            builder.optional();
+
+          if (schema.defaultValue() != null)
+            builder.defaultValue(preProcessValue(schema.defaultValue(), schema, schema));
           return builder.build();
         case Date.LOGICAL_NAME:
         case Time.LOGICAL_NAME:
@@ -190,6 +195,8 @@ public class DataConverter {
       case ARRAY:
         valueSchema = schema.valueSchema();
         builder = SchemaBuilder.array(preProcessSchema(valueSchema));
+        if (schema.isOptional())
+          builder.optional();
         return builder.build();
       case MAP:
         keySchema = schema.keySchema();
@@ -200,12 +207,16 @@ public class DataConverter {
             .field(MAP_KEY, preProcessSchema(keySchema))
             .field(MAP_VALUE, preProcessSchema(valueSchema))
             .build());
+        if (schema.isOptional())
+          builder.optional();
         return builder.build();
       case STRUCT:
         builder = SchemaBuilder.struct().name(schema.name());
         for (Field field: schema.fields()) {
           builder.field(field.name(), preProcessSchema(field.schema()));
         }
+        if (schema.isOptional())
+          builder.optional();
         return builder.build();
       default:
         return schema;
@@ -216,6 +227,13 @@ public class DataConverter {
   static Object preProcessValue(Object value, Schema schema, Schema newSchema) {
     if (schema == null) {
       return value;
+    }
+    if (value == null) {
+      if (schema.defaultValue() != null)
+        return schema.defaultValue();
+      if (schema.isOptional())
+        return null;
+      throw new DataException("Conversion error: null value for field that is required and has no default value");
     }
 
     // Handle logical types

--- a/src/main/java/io/confluent/connect/elasticsearch/internals/BulkProcessor.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/internals/BulkProcessor.java
@@ -93,11 +93,11 @@ public class BulkProcessor implements Runnable {
           if (guaranteeOrdering) {
             muted = true;
           }
+          synchronized (requests) {
+            batch = requests.pollFirst();
+          }
           executorService.submit(new BulkTask(batch));
           batch.setLastAttemptMs(now);
-          synchronized (requests) {
-            requests.pollFirst();
-          }
         }
       }
     } catch (InterruptedException e) {


### PR DESCRIPTION
Two issues addressed here in this commit:
1) NPE thrown in preProcessValue when a field is of type optional Struct and its value is null.
The input value is perfectly valid but preProcessValue is called on the null struct which then attempts to dereference its fields according to the schema. Added null check to preProcessValue to return the default value or null if the field is optional.

2) Concurrent collection modification exception throw during batch request processing in HTTPClient#constructBulk line 58.

task.put() -> writer.write() can attempt to append a SinkRecord to the first batch in the 'requests' list at the same time that a BulkTask attempts to send it to the HTTP client. This arises from the peekFirst() result being enqueued and after that happens then the records.pollFirst() removes the batch. This code locks requests and dequeues the batch we intend to use with BulkTask first so a batch cannot have records added to it once it is associated with a BulkTask.
