### PR TITLE
Converting source object to string when building Bulk object

### DIFF
--- a/docs/elasticsearch_connector.rst
+++ b/docs/elasticsearch_connector.rst
@@ -82,14 +82,7 @@ is available in Elasticsearch::
        "_id" : "test-elasticsearch-sink+0+0",
        "_score" : 1.0,
        "_source" : {
-         "_children" : {
-           "f1" : {
-             "_value" : "value1"
-           }
-         },
-         "_nodeFactory" : {
-           "_cfgBigDecimalExact" : false
-         }
+         "f1" : "value1"
        }
      }]
    }

--- a/src/main/java/io/confluent/connect/elasticsearch/internals/HttpClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/internals/HttpClient.java
@@ -62,7 +62,7 @@ public class HttpClient implements Client<Response> {
       } catch (IOException e) {
         callback.onFailure(e);
       }
-      Index index = new Index.Builder(data)
+      Index index = new Index.Builder(data.toString())
           .index(request.getIndex())
           .type(request.getType())
           .id(request.getId())


### PR DESCRIPTION
The argument passed to Index.Builder is an ObjectNode (from jackson lib) in HttpClient class. When JestClient executes the action to ES, it serializes that object by means of Gson lib (to string) and creates a JSON object with another format that it actually is because of Gson is using ReflectiveTypeAdapterFactory -ObjectNode is not annotated with JsonAdapter-. Something like this happens:
- Original (source field):
{"field1": "value1", "field2" : "value2"}
- Converted (source field):
{"_children": {"field1" : {"_value" : "value1"}, "field2": {"_value" : "value2"}}}

