### PR TITLE
Add space at front of error message text

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
@@ -77,7 +77,7 @@ public class DataConverter {
       case STRING:
         return String.valueOf(key);
       default:
-        throw new DataException(schemaType.name() + "is not supported as the document id.");
+        throw new DataException(schemaType.name() + " is not supported as the document id.");
     }
   }
 


### PR DESCRIPTION
The smallest of fixes :) So that instead of 

`org.apache.kafka.connect.errors.DataException: MAPis not supported as the document id.`

we get

`org.apache.kafka.connect.errors.DataException: MAP is not supported as the document id.`

It looks better, and makes for easier Googling!