### PR TITLE
CC-301: Lower default values of `max.buffered.records` and `batch.size`

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -67,12 +67,12 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   private static final String MAX_BUFFERED_RECORDS_DOC =
       "Approximately the max number of records each task will buffer. This config controls the memory usage for each task. When the number of "
       + "buffered records is larger than this value, the partitions assigned to this task will be paused.";
-  private static final long MAX_BUFFERED_RECORDS_DEFAULT = 100000;
+  private static final long MAX_BUFFERED_RECORDS_DEFAULT = 20000;
   private static final String MAX_BUFFERED_RECORDS_DISPLAY = "Max Number of Records to Buffer";
 
   public static final String BATCH_SIZE_CONFIG = "batch.size";
   private static final String BATCH_SIZE_DOC = "The number of requests to process as a batch when writing to Elasticsearch.";
-  private static final int BATCH_SIZE_DEFAULT = 10000;
+  private static final int BATCH_SIZE_DEFAULT = 2000;
   private static final String BATCH_SIZE_DISPLAY = "Batch Size";
 
   public static final String LINGER_MS_CONFIG = "linger.ms";

--- a/src/main/java/io/confluent/connect/elasticsearch/internals/BulkProcessor.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/internals/BulkProcessor.java
@@ -15,7 +15,6 @@
  **/
 package io.confluent.connect.elasticsearch.internals;
 
-import org.apache.kafka.connect.errors.RetriableException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -270,17 +269,14 @@ public class BulkProcessor implements Runnable {
     }
   }
 
-  public void exceedMaxBufferedRecords(long maxBufferedRecords, int batchSize) {
+  public int getTotalBufferedRecords() {
+    int total = 0;
     synchronized (requests) {
-      int total = 0;
       for (RecordBatch batch: requests) {
         total += batch.size();
       }
-      total += batchSize;
-      if (total > maxBufferedRecords) {
-        throw new RetriableException("Exceed max number of buffered records");
-      }
     }
+    return total;
   }
 
   // visible for testing


### PR DESCRIPTION
Also some slight cleanup around throwing `RetriableException` when `max.buffered.records` is hit