### PR TITLE
bump kafka to 0.10.2.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <properties>
         <confluent.version>3.1.0-SNAPSHOT</confluent.version>
-        <kafka.version>0.10.1.0-SNAPSHOT</kafka.version>
+        <kafka.version>0.10.2.0-SNAPSHOT</kafka.version>
         <junit.version>4.12</junit.version>
         <es.version>2.3.3</es.version>
         <lucene.version>5.5.0</lucene.version>


### PR DESCRIPTION
confluentinc/kafka@6acbf27aebbe5b6b4f230ce44ea5151c4c53ffbd makes using 0.10.1.0-SNAPSHOT quite challenging