### PR TITLE
fix for mapping exists check

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/Mapping.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/Mapping.java
@@ -79,8 +79,7 @@ public class Mapping {
     if (resultJson == null) {
       return false;
     }
-    JsonObject typeJson = resultJson.getAsJsonObject(type);
-    return typeJson != null;
+    return (resultJson.entrySet().size() != 0);
   }
 
   /**


### PR DESCRIPTION
doesMappingExist checks if the "type" root key exists but json result is:
```
{
  "mappings" : {
    "type" : {
    ...
    }
}
```
and if no mapping exists: {}

so just check if the result is not empty... or as alternative:
`JsonObject typeJson = resultJson.getAsJsonObject("mappings").getAsJsonObject(type);`