### PR TITLE
handle org.apache.kafka.connect.data.Date in input avro schema

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
@@ -114,6 +114,7 @@ public class DataConverter {
         case Decimal.LOGICAL_NAME:
           return copySchemaBasics(schema, SchemaBuilder.float64()).build();
         case Date.LOGICAL_NAME:
+          return copySchemaBasics(schema, SchemaBuilder.int64()).build();
         case Time.LOGICAL_NAME:
         case Timestamp.LOGICAL_NAME:
           return schema;
@@ -182,6 +183,7 @@ public class DataConverter {
         case Decimal.LOGICAL_NAME:
           return ((BigDecimal) value).doubleValue();
         case Date.LOGICAL_NAME:
+	  return ((java.util.Date) value).getTime();
         case Time.LOGICAL_NAME:
         case Timestamp.LOGICAL_NAME:
           return value;


### PR DESCRIPTION
dates are currently handled as int epoch_days. when written to elasticsearch, ES interprets that value as epoch_millis, resulting in dates that are wildly off.