### PR TITLE
Fix map output for String keyed maps

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConstants.MAP_KEY;
@@ -135,9 +136,9 @@ public class DataConverter {
           return SchemaBuilder.map(preProcessSchema(keySchema), preProcessSchema(valueSchema)).build();
         }
         Schema elementSchema = SchemaBuilder.struct().name(keyName + "-" + valueName)
-                .field(MAP_KEY, preProcessSchema(keySchema))
-                .field(MAP_VALUE, preProcessSchema(valueSchema))
-                .build();
+             .field(MAP_KEY, preProcessSchema(keySchema))
+             .field(MAP_VALUE, preProcessSchema(valueSchema))
+             .build();
         return copySchemaBasics(schema, SchemaBuilder.array(elementSchema)).build();
       }
       case STRUCT: {
@@ -196,25 +197,25 @@ public class DataConverter {
     switch (schemaType) {
       case ARRAY:
         Collection collection = (Collection) value;
-        ArrayList<Object> result = new ArrayList<>();
+        List<Object> result = new ArrayList<>();
         for (Object element: collection) {
           result.add(preProcessValue(element, schema.valueSchema(), newSchema.valueSchema()));
         }
         return result;
       case MAP:
         Schema keySchema = schema.keySchema();
-        Schema newValueSchema = newSchema.valueSchema();
         Schema valueSchema = schema.valueSchema();
+        Schema newValueSchema = newSchema.valueSchema();
         Map<?, ?> map = (Map<?, ?>) value;
         if (keySchema.type() == Schema.Type.STRING) {
           Map<Object, Object> processedMap = new HashMap<>();
           for (Map.Entry<?, ?> entry: map.entrySet()) {
             processedMap.put(preProcessValue(entry.getKey(), keySchema, newSchema.keySchema()),
-                    preProcessValue(entry.getValue(), valueSchema, newValueSchema));
+                preProcessValue(entry.getValue(), valueSchema, newValueSchema));
           }
           return processedMap;
         }
-        ArrayList<Struct> mapStructs = new ArrayList<>();
+        List<Struct> mapStructs = new ArrayList<>();
         for (Map.Entry<?, ?> entry: map.entrySet()) {
           Struct mapStruct = new Struct(newValueSchema);
           mapStruct.put(MAP_KEY, preProcessValue(entry.getKey(), keySchema, newValueSchema.field(MAP_KEY).schema()));

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTestBase.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTestBase.java
@@ -113,7 +113,7 @@ public class ElasticsearchSinkTestBase extends ESIntegTestCase {
     verifySearchResults(records, TOPIC, ignoreKey, ignoreSchema);
   }
 
-  protected void verifySearchResults(Collection<SinkRecord> records, String index, boolean ignoreKey, boolean ignoreSchema) throws IOException {
+  protected void verifySearchResults(Collection<?> records, String index, boolean ignoreKey, boolean ignoreSchema) throws IOException {
     final SearchResult result = client.execute(new Search.Builder("").addIndex(index).build());
 
     final JsonArray rawHits = result.getJsonObject().getAsJsonObject("hits").getAsJsonArray("hits");
@@ -128,9 +128,13 @@ public class ElasticsearchSinkTestBase extends ESIntegTestCase {
       hits.put(id, source);
     }
 
-    for (SinkRecord record : records) {
-      final IndexableRecord indexableRecord = DataConverter.convertRecord(record, index, TYPE, ignoreKey, ignoreSchema);
-      assertEquals(indexableRecord.payload, hits.get(indexableRecord.key.id));
+    for (Object record : records) {
+      if (record instanceof SinkRecord) {
+        IndexableRecord indexableRecord = DataConverter.convertRecord((SinkRecord) record, index, TYPE, ignoreKey, ignoreSchema);
+        assertEquals(indexableRecord.payload, hits.get(indexableRecord.key.id));
+      } else {
+        assertEquals(record, hits.get("key"));
+      }
     }
   }
 

--- a/src/test/java/io/confluent/connect/elasticsearch/MappingTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/MappingTest.java
@@ -29,9 +29,6 @@ import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.InternalTestCluster;
 import org.junit.Test;
 
-import io.searchbox.client.JestResult;
-import io.searchbox.indices.mapping.GetMapping;
-
 public class MappingTest extends ElasticsearchSinkTestBase {
 
   private static final String INDEX = "kafka-connect";
@@ -119,7 +116,9 @@ public class MappingTest extends ElasticsearchSinkTestBase {
         break;
       case MAP:
         Schema newSchema = DataConverter.preProcessSchema(schema);
-        verifyMapping(newSchema, mapping);
+        JsonObject mapProperties = mapping.get("properties").getAsJsonObject();
+        verifyMapping(newSchema.keySchema(), mapProperties.get(ElasticsearchSinkConnectorConstants.MAP_KEY).getAsJsonObject());
+        verifyMapping(newSchema.valueSchema(), mapProperties.get(ElasticsearchSinkConnectorConstants.MAP_VALUE).getAsJsonObject());
         break;
       case STRUCT:
         JsonObject properties = mapping.get("properties").getAsJsonObject();


### PR DESCRIPTION
@kkonstantine this is a first run at fixing map output for String keyed maps. Things I know are problematic currently:
1. `MappingTest` ends up with a StackOverflowException because we are recursing on a map of strings in that test. Still looking into that.
2. We should decide if only String keyed maps should behave this way. I'm not sure what the ES standard is.
3. One weird thing I found was that if in `DataConverterTest.stringKeyedMap` I use a BigDecimal for validation instead of an INT32, I have a hard time validating the map values because the `DataConverter.preProcessValues` returns a `Double` object instead of a `BigDecimal` as I would expect it to. This seems to be consistent with and without my changes, so it's good to verify if that's expected behavior.

