### PR TITLE
Add config option to change elasticsearch document version source

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
@@ -102,7 +102,7 @@ public class DataConverter {
       id = DataConverter.convertKey(record.keySchema(), record.key());
     }
     if (versionSource == null) {
-      throw new IllegalArgumentException("Document must not be null");
+      throw new IllegalArgumentException("Document version source must not be null");
     }
 
     final Schema schema;

--- a/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
@@ -90,7 +90,7 @@ public class DataConverter {
       String type,
       boolean ignoreKey,
       boolean ignoreSchema,
-      ElasticsearchSinkConnectorConfig.DocumentVersionSource versionSource
+      DocumentVersionSource versionSource
   ) {
 
     final String id;
@@ -121,7 +121,9 @@ public class DataConverter {
     return new IndexableRecord(new Key(index, type, id), payload, version);
   }
 
-  private static Long getVersion(SinkRecord sinkRecord, ElasticsearchSinkConnectorConfig.DocumentVersionSource versionSource) {
+  private static Long getVersion(
+          SinkRecord sinkRecord,
+          DocumentVersionSource versionSource) {
 
     switch (versionSource) {
       case ignore:
@@ -130,7 +132,10 @@ public class DataConverter {
         return sinkRecord.kafkaOffset();
       case record_timestamp:
         if (sinkRecord.timestampType() == TimestampType.NO_TIMESTAMP_TYPE) {
-          throw new ConnectException("Kafka records must contain `timestamp` if ``" + ElasticsearchSinkConnectorConfig.DOCUMENT_VERSION_SOURCE_CONFIG + "=" + versionSource.name() + "`` set in connector config");
+          throw new ConnectException(
+                  "Kafka records must contain `timestamp` if ``"
+                  + ElasticsearchSinkConnectorConfig.DOCUMENT_VERSION_SOURCE_CONFIG
+                  + "set to ``" + versionSource.name() + "``in connector config");
         }
         return sinkRecord.timestamp();
       default:

--- a/src/main/java/io/confluent/connect/elasticsearch/DocumentVersionSource.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DocumentVersionSource.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ **/
+
+package io.confluent.connect.elasticsearch;
+
+public enum DocumentVersionSource {
+  partition_offset,
+  record_timestamp,
+  ignore;
+}

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -16,15 +16,12 @@
 
 package io.confluent.connect.elasticsearch;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.ConfigDef.Width;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 
 public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
@@ -100,14 +97,15 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
       "List of topics for which ``" + SCHEMA_IGNORE_CONFIG + "`` should be ``true``.";
   private static final String DROP_INVALID_MESSAGE_DOC =
           "Whether to drop kafka message when it cannot be converted to output message.";
-  private static final String DOCUMENT_VERSION_SOURCE_CONFIG =
-      "Version for elastic search document. Possible values: " + versionSourceDescription() + ". This parameter is used only when ``";
-
-  public enum DocumentVersionSource {
-    partition_offset,
-    record_timestamp,
-    ignore;
-  }
+  private static final String DOCUMENT_VERSION_SOURCE_DOC =
+      "Elasticsearch document version source. Possible values: "
+      + DocumentVersionSource.partition_offset.name()
+              + "(kafka record partition offset), "
+      + DocumentVersionSource.record_timestamp.name()
+              + "(kafka record timestamp), "
+      + DocumentVersionSource.ignore.name()
+              + "(don't set document version). "
+      + "This option applies only when ``" + KEY_IGNORE_CONFIG + "`` is set to false";
 
   protected static ConfigDef baseConfigDef() {
     final ConfigDef configDef = new ConfigDef();
@@ -272,31 +270,19 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
         group,
         ++order,
         Width.LONG,
-        "Drop invalid messages");
+        "Drop invalid messages"
+    ).define(
+        DOCUMENT_VERSION_SOURCE_CONFIG,
+        Type.STRING,
+        DocumentVersionSource.partition_offset.name(),
+        Importance.LOW,
+        DOCUMENT_VERSION_SOURCE_DOC,
+        group,
+        ++order,
+        Width.LONG,
+        "Elasticsearch document version source");
 
   }
-
-  private static String versionSourceDescription() {
-    List<String> versionSourceDocumentation = new ArrayList<>();
-    for (DocumentVersionSource versionSource : DocumentVersionSource.values()) {
-      switch (versionSource) {
-        case partition_offset:
-          versionSourceDocumentation.add(DocumentVersionSource.partition_offset.name() +
-                  "(kafka record offset)");
-          break;
-        case record_timestamp:
-          versionSourceDocumentation.add(DocumentVersionSource.record_timestamp.name() +
-                  "(kafka record timestamp)");
-          break;
-        case ignore:
-          versionSourceDocumentation.add(DocumentVersionSource.ignore.name() +
-                  "(don't set document version)");
-          break;
-      }
-    }
-    return StringUtils.join(versionSourceDocumentation, ',');
-  }
-
 
   public static final ConfigDef CONFIG = baseConfigDef();
 

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -16,6 +16,7 @@
 
 package io.confluent.connect.elasticsearch;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigException;
@@ -25,6 +26,7 @@ import org.apache.kafka.connect.sink.SinkTask;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -72,6 +74,14 @@ public class ElasticsearchSinkTask extends SinkTask {
       Set<String> topicIgnoreSchema = new HashSet<>(
           config.getList(ElasticsearchSinkConnectorConfig.TOPIC_SCHEMA_IGNORE_CONFIG)
       );
+      ElasticsearchSinkConnectorConfig.DocumentVersionSource versionSource = null;
+      try {
+        versionSource = ElasticsearchSinkConnectorConfig.DocumentVersionSource.valueOf(
+                config.getString(ElasticsearchSinkConnectorConfig.DOCUMENT_VERSION_SOURCE_CONFIG).toLowerCase());
+      } catch (IllegalArgumentException e) {
+           throw new IllegalArgumentException("Version may have one of the following values: " +
+                StringUtils.join(Arrays.asList(ElasticsearchSinkConnectorConfig.DocumentVersionSource.values()), ","));
+      }
 
       long flushTimeoutMs =
           config.getLong(ElasticsearchSinkConnectorConfig.FLUSH_TIMEOUT_MS_CONFIG);
@@ -116,7 +126,8 @@ public class ElasticsearchSinkTask extends SinkTask {
           .setLingerMs(lingerMs)
           .setRetryBackoffMs(retryBackoffMs)
           .setMaxRetry(maxRetry)
-          .setDropInvalidMessage(dropInvalidMessage);
+          .setDropInvalidMessage(dropInvalidMessage)
+          .setVersionSource(versionSource);
 
       writer = builder.build();
       writer.start();

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -74,13 +74,16 @@ public class ElasticsearchSinkTask extends SinkTask {
       Set<String> topicIgnoreSchema = new HashSet<>(
           config.getList(ElasticsearchSinkConnectorConfig.TOPIC_SCHEMA_IGNORE_CONFIG)
       );
-      ElasticsearchSinkConnectorConfig.DocumentVersionSource versionSource = null;
+      DocumentVersionSource versionSource = null;
       try {
-        versionSource = ElasticsearchSinkConnectorConfig.DocumentVersionSource.valueOf(
-                config.getString(ElasticsearchSinkConnectorConfig.DOCUMENT_VERSION_SOURCE_CONFIG).toLowerCase());
+        versionSource = DocumentVersionSource.valueOf(config
+                        .getString(ElasticsearchSinkConnectorConfig.DOCUMENT_VERSION_SOURCE_CONFIG)
+                        .toLowerCase());
       } catch (IllegalArgumentException e) {
-           throw new IllegalArgumentException("Version may have one of the following values: " +
-                StringUtils.join(Arrays.asList(ElasticsearchSinkConnectorConfig.DocumentVersionSource.values()), ","));
+        throw new IllegalArgumentException("Version may have one of the following values: "
+                + StringUtils.join(
+                        Arrays.asList(DocumentVersionSource.values()),
+                        ","));
       }
 
       long flushTimeoutMs =

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
@@ -52,7 +52,8 @@ public class ElasticsearchWriter {
   private final boolean dropInvalidMessage;
 
   private final Set<String> existingMappings;
-  private final ElasticsearchSinkConnectorConfig.DocumentVersionSource versionSource;
+  private final DocumentVersionSource versionSource;
+
 
   ElasticsearchWriter(
       JestClient client,
@@ -70,7 +71,7 @@ public class ElasticsearchWriter {
       int maxRetries,
       long retryBackoffMs,
       boolean dropInvalidMessage,
-      ElasticsearchSinkConnectorConfig.DocumentVersionSource versionSource
+      DocumentVersionSource versionSource
   ) {
     this.client = client;
     this.type = type;
@@ -114,7 +115,7 @@ public class ElasticsearchWriter {
     private int maxRetry;
     private long retryBackoffMs;
     private boolean dropInvalidMessage;
-    private ElasticsearchSinkConnectorConfig.DocumentVersionSource versionSource;
+    private DocumentVersionSource versionSource;
 
     public Builder(JestClient client) {
       this.client = client;
@@ -177,7 +178,7 @@ public class ElasticsearchWriter {
       return this;
     }
 
-    public Builder setVersionSource(ElasticsearchSinkConnectorConfig.DocumentVersionSource versionType) {
+    public Builder setVersionSource(DocumentVersionSource versionType) {
       this.versionSource = versionType;
       return this;
     }
@@ -257,7 +258,8 @@ public class ElasticsearchWriter {
               index,
               type,
               ignoreKey,
-              ignoreSchema);
+              ignoreSchema,
+              versionSource);
     } catch (ConnectException convertException) {
       if (dropInvalidMessage) {
         log.error("Can't convert record from topic {} with partition {} and offset {}."

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
@@ -52,6 +52,7 @@ public class ElasticsearchWriter {
   private final boolean dropInvalidMessage;
 
   private final Set<String> existingMappings;
+  private final ElasticsearchSinkConnectorConfig.DocumentVersionSource versionSource;
 
   ElasticsearchWriter(
       JestClient client,
@@ -68,7 +69,8 @@ public class ElasticsearchWriter {
       long lingerMs,
       int maxRetries,
       long retryBackoffMs,
-      boolean dropInvalidMessage
+      boolean dropInvalidMessage,
+      ElasticsearchSinkConnectorConfig.DocumentVersionSource versionSource
   ) {
     this.client = client;
     this.type = type;
@@ -79,6 +81,7 @@ public class ElasticsearchWriter {
     this.topicToIndexMap = topicToIndexMap;
     this.flushTimeoutMs = flushTimeoutMs;
     this.dropInvalidMessage = dropInvalidMessage;
+    this.versionSource = versionSource;
 
     bulkProcessor = new BulkProcessor<>(
         new SystemTime(),
@@ -89,6 +92,7 @@ public class ElasticsearchWriter {
         lingerMs,
         maxRetries,
         retryBackoffMs
+
     );
 
     existingMappings = new HashSet<>();
@@ -110,6 +114,7 @@ public class ElasticsearchWriter {
     private int maxRetry;
     private long retryBackoffMs;
     private boolean dropInvalidMessage;
+    private ElasticsearchSinkConnectorConfig.DocumentVersionSource versionSource;
 
     public Builder(JestClient client) {
       this.client = client;
@@ -172,6 +177,11 @@ public class ElasticsearchWriter {
       return this;
     }
 
+    public Builder setVersionSource(ElasticsearchSinkConnectorConfig.DocumentVersionSource versionType) {
+      this.versionSource = versionType;
+      return this;
+    }
+
     public Builder setDropInvalidMessage(boolean dropInvalidMessage) {
       this.dropInvalidMessage = dropInvalidMessage;
       return this;
@@ -193,7 +203,8 @@ public class ElasticsearchWriter {
           lingerMs,
           maxRetry,
           retryBackoffMs,
-          dropInvalidMessage
+          dropInvalidMessage,
+          versionSource
       );
     }
   }

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTestBase.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTestBase.java
@@ -137,7 +137,7 @@ public class ElasticsearchSinkTestBase extends ESIntegTestCase {
     verifySearchResults(records, TOPIC, ignoreKey, ignoreSchema);
   }
   protected void verifySearchResults(Collection<?> records, String index, boolean ignoreKey, boolean ignoreSchema ) throws IOException {
-    verifySearchResults(records, index, ignoreKey, ignoreSchema, ElasticsearchSinkConnectorConfig.DocumentVersionSource.partition_offset);
+    verifySearchResults(records, index, ignoreKey, ignoreSchema, DocumentVersionSource.partition_offset);
 
   }
 
@@ -145,7 +145,7 @@ public class ElasticsearchSinkTestBase extends ESIntegTestCase {
                                      String index,
                                      boolean ignoreKey,
                                      boolean ignoreSchema,
-                                     ElasticsearchSinkConnectorConfig.DocumentVersionSource versionSource) throws IOException {
+                                     DocumentVersionSource versionSource) throws IOException {
     final SearchResult result = client.execute(new Search.Builder("{ \"version\" : true }").setParameter("version", true).addIndex(index).build());
 
     final JsonArray rawHits = result.getJsonObject().getAsJsonObject("hits").getAsJsonArray("hits");

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchWriterTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchWriterTest.java
@@ -106,7 +106,7 @@ public class ElasticsearchWriterTest extends ElasticsearchSinkTestBase {
             Collections.<String>emptySet(),
             Collections.singletonMap(TOPIC, indexOverride),
             false,
-            ElasticsearchSinkConnectorConfig.DocumentVersionSource.partition_offset);
+            DocumentVersionSource.partition_offset);
     writeDataAndRefresh(writer, records);
     verifySearchResults(records, indexOverride, ignoreKey, ignoreSchema);
   }
@@ -212,7 +212,7 @@ public class ElasticsearchWriterTest extends ElasticsearchSinkTestBase {
     final ElasticsearchWriter writer = initWriter(client,
             ignoreKey,
             ignoreSchema,
-            ElasticsearchSinkConnectorConfig.DocumentVersionSource.record_timestamp);
+            DocumentVersionSource.record_timestamp);
     writer.write(Arrays.asList(sinkRecordWithTs0, sinkRecordWithTs1));
     writer.flush();
 
@@ -225,7 +225,7 @@ public class ElasticsearchWriterTest extends ElasticsearchSinkTestBase {
             TOPIC,
             ignoreKey,
             ignoreSchema,
-            ElasticsearchSinkConnectorConfig.DocumentVersionSource.record_timestamp);
+            DocumentVersionSource.record_timestamp);
 
   }
 
@@ -413,7 +413,7 @@ public class ElasticsearchWriterTest extends ElasticsearchSinkTestBase {
             Collections.<String>emptySet(),
             Collections.<String, String>emptyMap(),
             false,
-            ElasticsearchSinkConnectorConfig.DocumentVersionSource.partition_offset);
+            DocumentVersionSource.partition_offset);
   }
 
   private ElasticsearchWriter initWriter(JestClient client,
@@ -429,13 +429,13 @@ public class ElasticsearchWriterTest extends ElasticsearchSinkTestBase {
             Collections.<String>emptySet(),
             Collections.<String, String>emptyMap(),
             dropInvalidMessage,
-            ElasticsearchSinkConnectorConfig.DocumentVersionSource.partition_offset);
+            DocumentVersionSource.partition_offset);
   }
 
   private ElasticsearchWriter initWriter(JestClient client,
                                          boolean ignoreKey,
                                          boolean ignoreSchema,
-                                         ElasticsearchSinkConnectorConfig.DocumentVersionSource versionSource) {
+                                         DocumentVersionSource versionSource) {
 
     return initWriter(
             client,
@@ -455,7 +455,7 @@ public class ElasticsearchWriterTest extends ElasticsearchSinkTestBase {
                                          Set<String> ignoreSchemaTopics,
                                          Map<String, String> topicToIndexMap,
                                          boolean dropInvalidMessage,
-                                         ElasticsearchSinkConnectorConfig.DocumentVersionSource versionSource) {
+                                         DocumentVersionSource versionSource) {
 
     ElasticsearchWriter writer = new ElasticsearchWriter.Builder(client)
         .setType(TYPE)


### PR DESCRIPTION
Originally kafka record offset is always used.