### PR TITLE
Preemptive HTTP Basic auth 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <lucene.version>5.5.2</lucene.version>
         <jna.version>4.2.1</jna.version>
         <hamcrest.version>2.0.0.0</hamcrest.version>
-        <jest.version>2.0.0</jest.version>
+        <jest.version>5.3.2</jest.version>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
     </properties>
 

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchAuth.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchAuth.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ **/
+
+package io.confluent.connect.elasticsearch;
+
+import com.google.common.collect.Sets;
+import io.searchbox.client.config.HttpClientConfig;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+
+import java.util.List;
+import java.util.Set;
+
+public class ElasticsearchAuth {
+  private Set<HttpHost> targetHosts;
+  private HttpClientConfig.Builder clientConfig;
+  private String username;
+  private String password;
+
+  public ElasticsearchAuth(List<String> address,
+                           HttpClientConfig.Builder clientConfig,
+                           String username,
+                           String password) {
+    this.clientConfig = clientConfig;
+    this.username = username;
+    this.password = password;
+    this.targetHosts = Sets.newHashSet();
+    for (String s : address) {
+      targetHosts.add(HttpHost.create(s));
+    }
+  }
+
+  public void invoke() {
+
+    BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+    for (HttpHost h : targetHosts) {
+      AuthScope as =  new AuthScope(h.getHostName(), h.getPort());
+      UsernamePasswordCredentials cr = new UsernamePasswordCredentials(username, password);
+      credentialsProvider.setCredentials(as,cr);
+    }
+    clientConfig.credentialsProvider(credentialsProvider);
+
+    clientConfig.preemptiveAuthTargetHosts(targetHosts);
+  }
+}

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -27,6 +27,14 @@ import java.util.Map;
 public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
 
   public static final String CONNECTION_URL_CONFIG = "connection.url";
+
+  public static final String CONNECTION_USERNAME_CONFIG = "connection.username";
+  public static final String CONNECTION_USERNAME_DOC =
+      "HTTP Basic Auth username (towards Elasticsearch)";
+  public static final String CONNECTION_PASSWORD_CONFIG = "connection.password";
+  public static final String CONNECTION_PASSWORD_DOC =
+      "HTTP Basic Auth password (towards Elasticsearch)";
+
   private static final String CONNECTION_URL_DOC =
       "List of Elasticsearch HTTP connection URLs e.g. ``http://eshost1:9200,"
       + "http://eshost2:9200``.";
@@ -117,6 +125,26 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
         ++order,
         Width.LONG,
         "Connection URLs"
+    ).define(
+        CONNECTION_USERNAME_CONFIG,
+        Type.STRING,
+        null,
+        Importance.MEDIUM,
+        CONNECTION_USERNAME_DOC,
+        group,
+        ++order,
+        Width.MEDIUM,
+        "ES User Name"
+    ).define(
+        CONNECTION_PASSWORD_CONFIG,
+        Type.STRING,
+        null,
+        Importance.MEDIUM,
+        CONNECTION_PASSWORD_DOC,
+        group,
+        ++order,
+        Width.MEDIUM,
+        "ES password"
     ).define(
         BATCH_SIZE_CONFIG,
         Type.INT,

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -16,6 +16,14 @@
 
 package io.confluent.connect.elasticsearch;
 
+import com.google.common.collect.Sets;
+import io.searchbox.client.JestClient;
+import io.searchbox.client.JestClientFactory;
+import io.searchbox.client.config.HttpClientConfig;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigException;
@@ -25,16 +33,14 @@ import org.apache.kafka.connect.sink.SinkTask;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import io.searchbox.client.JestClient;
-import io.searchbox.client.JestClientFactory;
-import io.searchbox.client.config.HttpClientConfig;
 
 public class ElasticsearchSinkTask extends SinkTask {
 
@@ -95,12 +101,20 @@ public class ElasticsearchSinkTask extends SinkTask {
       } else {
         List<String> address =
             config.getList(ElasticsearchSinkConnectorConfig.CONNECTION_URL_CONFIG);
-        JestClientFactory factory = new JestClientFactory();
-        factory.setHttpClientConfig(
-            new HttpClientConfig.Builder(address)
-                .multiThreaded(true)
-                .build()
-        );
+        final JestClientFactory factory = new JestClientFactory();
+
+        HttpClientConfig.Builder clientConfig = new HttpClientConfig.Builder(address);
+        clientConfig.multiThreaded(true);
+        String username =
+            config.getString(ElasticsearchSinkConnectorConfig.CONNECTION_USERNAME_CONFIG);
+        String password =
+            config.getString(ElasticsearchSinkConnectorConfig.CONNECTION_PASSWORD_CONFIG);
+
+        if (username != null && password != null) {
+          new ElasticsearchAuth(address, clientConfig, username, password).invoke();
+        }
+
+        factory.setHttpClientConfig(clientConfig.build());
         this.client = factory.getObject();
       }
 


### PR DESCRIPTION
The issue with non preemptive authentication is that it has to send first a non-authenticated request (resulting in a 401) and **only then** it sends the credentials across.

Since HTTP is stateless, this makes every connection very slow. I had to update to the latest Jest in order to achieve this.

Feel free to suggest any changes!