### PR TITLE
CC-1059 Changed ES connector to use exponential backoff with jitter

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -71,7 +71,8 @@ public class ElasticsearchSinkTask extends SinkTask {
       int batchSize = config.getInt(ElasticsearchSinkConnectorConfig.BATCH_SIZE_CONFIG);
       long lingerMs = config.getLong(ElasticsearchSinkConnectorConfig.LINGER_MS_CONFIG);
       int maxInFlightRequests = config.getInt(ElasticsearchSinkConnectorConfig.MAX_IN_FLIGHT_REQUESTS_CONFIG);
-      long retryBackoffMs = config.getLong(ElasticsearchSinkConnectorConfig.RETRY_BACKOFF_MS_CONFIG);
+      long minRetryBackoffMs = config.getLong(ElasticsearchSinkConnectorConfig.MIN_RETRY_BACKOFF_MS_CONFIG);
+      long maxRetryBackoffMs = config.getLong(ElasticsearchSinkConnectorConfig.MAX_RETRY_BACKOFF_MS_CONFIG);
       int maxRetry = config.getInt(ElasticsearchSinkConnectorConfig.MAX_RETRIES_CONFIG);
 
       if (client != null) {
@@ -93,7 +94,8 @@ public class ElasticsearchSinkTask extends SinkTask {
           .setMaxInFlightRequests(maxInFlightRequests)
           .setBatchSize(batchSize)
           .setLingerMs(lingerMs)
-          .setRetryBackoffMs(retryBackoffMs)
+          .setMinRetryBackoffMs(minRetryBackoffMs)
+          .setMaxRetryBackoffMs(maxRetryBackoffMs)
           .setMaxRetry(maxRetry);
 
       writer = builder.build();

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
@@ -66,7 +66,8 @@ public class ElasticsearchWriter {
       int batchSize,
       long lingerMs,
       int maxRetries,
-      long retryBackoffMs
+      long minRetryBackoffMs,
+      long maxRetryBackoffMs
   ) {
     this.client = client;
     this.type = type;
@@ -85,7 +86,8 @@ public class ElasticsearchWriter {
         batchSize,
         lingerMs,
         maxRetries,
-        retryBackoffMs
+        minRetryBackoffMs,
+        maxRetryBackoffMs
     );
 
     existingMappings = new HashSet<>();
@@ -105,7 +107,8 @@ public class ElasticsearchWriter {
     private int batchSize;
     private long lingerMs;
     private int maxRetry;
-    private long retryBackoffMs;
+    private long minRetryBackoffMs;
+    private long maxRetryBackoffMs;
 
     public Builder(JestClient client) {
       this.client = client;
@@ -163,8 +166,13 @@ public class ElasticsearchWriter {
       return this;
     }
 
-    public Builder setRetryBackoffMs(long retryBackoffMs) {
-      this.retryBackoffMs = retryBackoffMs;
+    public Builder setMinRetryBackoffMs(long retryBackoffMs) {
+      this.minRetryBackoffMs = retryBackoffMs;
+      return this;
+    }
+
+    public Builder setMaxRetryBackoffMs(long retryBackoffMs) {
+      this.maxRetryBackoffMs = retryBackoffMs;
       return this;
     }
 
@@ -183,7 +191,8 @@ public class ElasticsearchWriter {
           batchSize,
           lingerMs,
           maxRetry,
-          retryBackoffMs
+          minRetryBackoffMs,
+          maxRetryBackoffMs
       );
     }
   }

--- a/src/main/java/io/confluent/connect/elasticsearch/bulk/BulkProcessor.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/bulk/BulkProcessor.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -50,7 +51,8 @@ public class BulkProcessor<R, B> {
   private final int batchSize;
   private final long lingerMs;
   private final int maxRetries;
-  private final long retryBackoffMs;
+  private final long minRetryBackoffMs;
+  private final long maxRetryBackoffMs;
 
   private final Thread farmer;
   private final ExecutorService executor;
@@ -73,7 +75,8 @@ public class BulkProcessor<R, B> {
       int batchSize,
       long lingerMs,
       int maxRetries,
-      long retryBackoffMs
+      long minRetryBackoffMs,
+      long maxRetryBackoffMs
   ) {
     this.time = time;
     this.bulkClient = bulkClient;
@@ -81,7 +84,8 @@ public class BulkProcessor<R, B> {
     this.batchSize = batchSize;
     this.lingerMs = lingerMs;
     this.maxRetries = maxRetries;
-    this.retryBackoffMs = retryBackoffMs;
+    this.minRetryBackoffMs = minRetryBackoffMs;
+    this.maxRetryBackoffMs = maxRetryBackoffMs;
 
     unsentRecords = new ArrayDeque<>(maxBufferedRecords);
 
@@ -341,28 +345,67 @@ public class BulkProcessor<R, B> {
         log.error("Failed to create bulk request from batch {} of {} records", batchId, batch.size(), e);
         throw e;
       }
-      for (int remainingRetries = maxRetries; true; remainingRetries--) {
+      int retryAttempt = 0;
+      int attempts = 0;
+      while (true) {
         boolean retriable = true;
+        ++attempts;
         try {
           log.trace("Executing batch {} of {} records", batchId, batch.size());
           final BulkResponse bulkRsp = bulkClient.execute(bulkReq);
           if (bulkRsp.isSucceeded()) {
+            if (attempts > 1) {
+              log.debug("Completed batch {} of {} records with attempt {}/{}", batchId, batch.size(), attempts, maxRetries + 1);
+            }
             return bulkRsp;
           }
           retriable = bulkRsp.isRetriable();
           throw new ConnectException("Bulk request failed: " + bulkRsp.getErrorInfo());
         } catch (Exception e) {
-          if (retriable && remainingRetries > 0) {
-            log.warn("Failed to execute batch {} of {} records, retrying after {} ms", batchId, batch.size(), retryBackoffMs, e);
-            time.sleep(retryBackoffMs);
+          if (retriable && retryAttempt < maxRetries) {
+            ++retryAttempt;
+            long sleepTimeMs = computeRetryWaitTimeInMillis(retryAttempt, minRetryBackoffMs, maxRetryBackoffMs);
+            if (log.isDebugEnabled()) {
+              log.debug("Failed to execute batch {} of {} records with attempt {}/{}, will attempt retry after {} ms",
+                      batchId, batch.size(), attempts, maxRetries + 1, sleepTimeMs, e);
+            } else {
+              log.warn("Failed to execute batch {} of {} records with attempt {}/{}, will attempt retry after {} ms: {}",
+                      batchId, batch.size(), attempts, maxRetries + 1, sleepTimeMs, e.getMessage());
+            }
+            time.sleep(minRetryBackoffMs);
           } else {
-            log.error("Failed to execute batch {} of {} records", batchId, batch.size(), e);
+            log.error("Failed to execute batch {} of {} records after total of {} attempt(s)", batchId, batch.size(), attempts, e);
             throw e;
           }
         }
       }
     }
 
+  }
+
+  /**
+   * Compute the time to sleep using exponential backoff with jitter. This method computes the normal exponential backoff
+   * based upon the {@code minRetryBackoffMs} and the {@code retryAttempt}, bounding the result to be within {@code minRetryBackoffMs}
+   * and {@code maxRetryBackoffMs}, and then choosing a random value within that range.
+   * <p>
+   * The purposes of using exponential backoff is to give the ES service time to recover when it becomes overwhelmed.
+   * Adding jitter attempts to prevent a thundering herd, where large numbers of requests from many tasks overwhelm the
+   * ES service, and without randomization all tasks retry at the same time. Randomization should spread the retries
+   * out and should reduce the overall time required to complete all attempts.
+   * See <a href="https://www.awsarchitectureblog.com/2015/03/backoff.html">this blog post</a> for details.
+   *
+   * @param retryAttempt the retry attempt number, starting with 1 for the first retry
+   * @param minRetryBackoffMs the minimum time to wait before retrying; assumed to be 0 if value is negative
+   * @param maxRetryBackoffMs the maximum amount of time to wait before retrying
+   * @return the time in milliseconds to wait before the next retry attempt, in the range {@code minRetryBackoffMs}
+   * and {@code maxRetryBackoffMs} (inclusive), or {@code minRetryBackoffMs} if {@code minRangeBackoffMs}
+   * is greater than or equal to {@code maxRetryBackoffMs}
+   */
+  protected static long computeRetryWaitTimeInMillis(int retryAttempt, long minRetryBackoffMs, long maxRetryBackoffMs) {
+    if (minRetryBackoffMs >= maxRetryBackoffMs) return minRetryBackoffMs; // this was the original value and likely what they're setting
+    if (minRetryBackoffMs < 0) minRetryBackoffMs = 0;
+    long nextMaxTimeMs = Math.max(minRetryBackoffMs + 1, Math.min(maxRetryBackoffMs, minRetryBackoffMs * 2 ^ retryAttempt));
+    return ThreadLocalRandom.current().nextLong(minRetryBackoffMs, nextMaxTimeMs);
   }
 
   private synchronized void onBatchCompletion(int batchSize) {

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchWriterTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchWriterTest.java
@@ -322,7 +322,8 @@ public class ElasticsearchWriterTest extends ElasticsearchSinkTestBase {
         .setMaxInFlightRequests(1)
         .setBatchSize(2)
         .setLingerMs(1000)
-        .setRetryBackoffMs(1000)
+        .setMinRetryBackoffMs(1000)
+        .setMaxRetryBackoffMs(10000)
         .setMaxRetry(3)
         .build();
     writer.start();


### PR DESCRIPTION
With lots of ES connector tasks all hitting the ES backend, when the ES backend becomes overloaded all of the tasks will experience timeouts (possibly at nearly the same time) and thus retry. Prior to this change, all tasks would use the same constant backoff time and would thus all retry at about the same point in time and possibly overwhelming the ES backend. This is known as a thundering herd, and when many attempts fail it takes a long time and many attempts to recover.

A solution to this problem is to use expontential backoff to give the ES backend time to recover, except that this alone doesn’t really reduce the thundering herd problem. To solve both problems we use expontential backoff but with jitter, which is a randomization of the sleep times for each of the attempts. This PR adds exponential backoff with jitter.

We need at least two configuration parameters to control this approach. Since `retry.backoff.ms` already exists, we can co-opt it to define the minimum time to wait during retries, but we need another configuration property to define the maximum time to wait. (We could expose parameters to control the exponential part of the equation, but that’s unnecessarily complicated.) This new algorithm computes the normal exponential backoff based upon the `retry.backoff.ms` (the minimum value) and the `max.retry.backoff.ms` value, bounding the result to be within these two values, and then choosing a random value within that range.

Note that to maintain backward compatibility, we always wait for exactly the minimum time if it is equal to or exceeds the maximum time to wait. This might happen if an existing connector configuration defines the `retry.backoff.ms` value but doesn’t set the newer `max.retry.backoff.ms`. Note the default value of `max.retry.backoff.ms` is 10 seconds and hopefully larger than most values of `retry.backoff.ms` that might be used.

**This PR should only be merged onto the `3.3.x` branch; see PR #115 for the `3.4.x` and `master` branches.**