### PR TITLE
CC-1059 Changed ES connector to use exponential backoff with jitter

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -83,8 +83,10 @@ public class ElasticsearchSinkTask extends SinkTask {
           config.getLong(ElasticsearchSinkConnectorConfig.LINGER_MS_CONFIG);
       int maxInFlightRequests =
           config.getInt(ElasticsearchSinkConnectorConfig.MAX_IN_FLIGHT_REQUESTS_CONFIG);
-      long retryBackoffMs =
-          config.getLong(ElasticsearchSinkConnectorConfig.RETRY_BACKOFF_MS_CONFIG);
+      long minRetryBackoffMs =
+          config.getLong(ElasticsearchSinkConnectorConfig.MIN_RETRY_BACKOFF_MS_CONFIG);
+      long maxRetryBackoffMs =
+          config.getLong(ElasticsearchSinkConnectorConfig.MAX_RETRY_BACKOFF_MS_CONFIG);
       int maxRetry =
           config.getInt(ElasticsearchSinkConnectorConfig.MAX_RETRIES_CONFIG);
       boolean dropInvalidMessage =
@@ -114,7 +116,8 @@ public class ElasticsearchSinkTask extends SinkTask {
           .setMaxInFlightRequests(maxInFlightRequests)
           .setBatchSize(batchSize)
           .setLingerMs(lingerMs)
-          .setRetryBackoffMs(retryBackoffMs)
+          .setMinRetryBackoffMs(minRetryBackoffMs)
+          .setMaxRetryBackoffMs(maxRetryBackoffMs)
           .setMaxRetry(maxRetry)
           .setDropInvalidMessage(dropInvalidMessage);
 

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
@@ -67,7 +67,8 @@ public class ElasticsearchWriter {
       int batchSize,
       long lingerMs,
       int maxRetries,
-      long retryBackoffMs,
+      long minRetryBackoffMs,
+      long maxRetryBackoffMs,
       boolean dropInvalidMessage
   ) {
     this.client = client;
@@ -88,7 +89,8 @@ public class ElasticsearchWriter {
         batchSize,
         lingerMs,
         maxRetries,
-        retryBackoffMs
+        minRetryBackoffMs,
+        maxRetryBackoffMs
     );
 
     existingMappings = new HashSet<>();
@@ -108,7 +110,8 @@ public class ElasticsearchWriter {
     private int batchSize;
     private long lingerMs;
     private int maxRetry;
-    private long retryBackoffMs;
+    private long minRetryBackoffMs;
+    private long maxRetryBackoffMs;
     private boolean dropInvalidMessage;
 
     public Builder(JestClient client) {
@@ -167,8 +170,13 @@ public class ElasticsearchWriter {
       return this;
     }
 
-    public Builder setRetryBackoffMs(long retryBackoffMs) {
-      this.retryBackoffMs = retryBackoffMs;
+    public Builder setMinRetryBackoffMs(long retryBackoffMs) {
+      this.minRetryBackoffMs = retryBackoffMs;
+      return this;
+    }
+
+    public Builder setMaxRetryBackoffMs(long retryBackoffMs) {
+      this.maxRetryBackoffMs = retryBackoffMs;
       return this;
     }
 
@@ -192,7 +200,8 @@ public class ElasticsearchWriter {
           batchSize,
           lingerMs,
           maxRetry,
-          retryBackoffMs,
+          minRetryBackoffMs,
+          maxRetryBackoffMs,
           dropInvalidMessage
       );
     }

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchWriterTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchWriterTest.java
@@ -377,7 +377,8 @@ public class ElasticsearchWriterTest extends ElasticsearchSinkTestBase {
         .setMaxInFlightRequests(1)
         .setBatchSize(2)
         .setLingerMs(1000)
-        .setRetryBackoffMs(1000)
+        .setMinRetryBackoffMs(1000)
+        .setMaxRetryBackoffMs(10000)
         .setMaxRetry(3)
         .setDropInvalidMessage(dropInvalidMessage)
         .build();


### PR DESCRIPTION
With lots of ES connector tasks all hitting the ES backend, when the ES backend becomes overloaded all of the tasks will experience timeouts (possibly at nearly the same time) and thus retry. Prior to this change, all tasks would use the same constant backoff time and would thus all retry at about the same point in time and possibly overwhelming the ES backend. This is known as a thundering herd, and when many attempts fail it takes a long time and many attempts to recover.

A solution to this problem is to use expontential backoff to give the ES backend time to recover, except that this alone doesn’t really reduce the thundering herd problem. To solve both problems we use expontential backoff but with jitter, which is a randomization of the sleep times for each of the attempts. This PR adds exponential backoff with jitter.

We need at least two configuration parameters to control this approach. Since `retry.backoff.ms` already exists, we can co-opt it to define the minimum time to wait during retries, but we need another configuration property to define the maximum time to wait. (We could expose parameters to control the exponential part of the equation, but that’s unnecessarily complicated.) This new algorithm computes the normal exponential backoff based upon the `retry.backoff.ms` (the minimum value) and the `max.retry.backoff.ms` value, bounding the result to be within these two values, and then choosing a random value within that range.

Note that to maintain backward compatibility, we always wait for exactly the minimum time if it is equal to or exceeds the maximum time to wait. This might happen if an existing connector configuration defines the `retry.backoff.ms` value but doesn’t set the newer `max.retry.backoff.ms`. Note the default value of `max.retry.backoff.ms` is 10 seconds and hopefully larger than most values of `retry.backoff.ms` that might be used.

**This PR is for `3.4.x` and `master`; see #114 for the PR for `3.3.x`.**