### PR TITLE
CC-1059 Changed ES connector to use exponential backoff with jitter

### DIFF
--- a/docs/configuration_options.rst
+++ b/docs/configuration_options.rst
@@ -55,7 +55,7 @@ Connector
   * Importance: low
 
 ``retry.backoff.ms``
-  How long to wait in milliseconds before attempting to retry a failed indexing request. This avoids retrying in a tight loop under failure scenarios.
+  How long to wait in milliseconds before attempting to retry a the first failed indexing request. This connector uses exponential backoff with jitter, which means that upon additional failures, this connector may wait up to twice as long as the previous wait, up to the maximum number of retries. This avoids retrying in a tight loop under failure scenarios.
 
   * Type: long
   * Default: 100

--- a/docs/elasticsearch_connector.rst
+++ b/docs/elasticsearch_connector.rst
@@ -250,7 +250,8 @@ uses an exponential backoff technique to give the Elasticsearch service time to 
 adds randomness, called jitter, to the calculated backoff times to prevent a thundering herd, where large
 numbers of requests from many tasks are submitted concurrently and overwhelm the service. Randomness spreads out
 the retries from many tasks and should reduce the overall time required to complete all outstanding requests
-compared to simple exponential backoff.
+compared to simple exponential backoff. The goal is to spread out the requests to Elasticsearch as much as
+possible.
 
 The number of retries is dictated by the ``max.retries`` connector configuration property, which defaults
 to 5 attempts. The backoff time, which is the amount of time to wait before retrying, is a function of the
@@ -264,11 +265,11 @@ before submitting each of the 5 retry attempts:
    =====  =====================  =====================  ==============================================
    Retry  Minimum Backoff (sec)  Maximum Backoff (sec)  Total Potential Delay from First Attempt (sec)
    =====  =====================  =====================  ==============================================
-     1         0.5                      0.5                              0.5
-     2         0.5                      1.0                              1.5
-     3         0.5                      2.0                              3.5
-     4         0.5                      4.0                              7.5
-     5         0.5                      8.0                             15.5
+     1         0.0                      0.5                              0.5
+     2         0.0                      1.0                              1.5
+     3         0.0                      2.0                              3.5
+     4         0.0                      4.0                              7.5
+     5         0.0                      8.0                             15.5
    =====  =====================  =====================  ==============================================
 
 Note how the maximum wait time is simply the normal exponential backoff, calculated as ``${retry.backoff.ms} * 2 ^ (retry-1)``.
@@ -280,14 +281,14 @@ Increasing the maximum number of retries adds more backoff:
    =====  =====================  =====================  ==============================================
    Retry  Minimum Backoff (sec)  Maximum Backoff (sec)  Total Potential Delay from First Attempt (sec)
    =====  =====================  =====================  ==============================================
-     6         0.5                     16.0                             31.5
-     7         0.5                     32.0                             63.5
-     8         0.5                     64.0                            127.5
-     9         0.5                    128.0                            256.5
-    10         0.5                    256.0                            511.5
-    11         0.5                    512.0                           1023.5
-    12         0.5                   1024.0                           2047.5
-    13         0.5                   2048.0                           4095.5
+     6         0.0                     16.0                             31.5
+     7         0.0                     32.0                             63.5
+     8         0.0                     64.0                            127.5
+     9         0.0                    128.0                            256.5
+    10         0.0                    256.0                            511.5
+    11         0.0                    512.0                           1023.5
+    12         0.0                   1024.0                           2047.5
+    13         0.0                   2048.0                           4095.5
    =====  =====================  =====================  ==============================================
 
 By increasing ``max.retries`` to 10, the connector may take up to 511.5 seconds, or a little over 8.5 minutes,

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -78,7 +78,8 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
                   + "If the retry attempts are exhausted the task will fail.",
                   group, ++order, Width.SHORT, "Max Retries")
           .define(RETRY_BACKOFF_MS_CONFIG, Type.LONG, 100L, Importance.LOW,
-                  "How long to wait in milliseconds before attempting to retry a failed indexing request. "
+                  "How long to wait in milliseconds before attempting the first retry of a failed indexing request. "
+                  + "Upon a failure, this connector may wait up to twice as long as the previous wait, up to the maximum number of retries. "
                   + "This avoids retrying in a tight loop under failure scenarios.",
                   group, ++order, Width.SHORT, "Retry Backoff (ms)");
     }

--- a/src/main/java/io/confluent/connect/elasticsearch/RetryUtil.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/RetryUtil.java
@@ -36,8 +36,7 @@ public class RetryUtil {
 
   /**
    * Compute the time to sleep using exponential backoff with jitter. This method computes the normal exponential backoff
-   * as {@code initialRetryBackoffMs << retryAttempt}, and then chooses a random value between {@code initialRetryBackoffMs}
-   * and that value.
+   * as {@code initialRetryBackoffMs << retryAttempt}, and then chooses a random value between 0 and that value.
    *
    * @param retryAttempts the number of previous retry attempts; must be non-negative
    * @param initialRetryBackoffMs the initial time to wait before retrying; assumed to be 0 if value is negative
@@ -45,14 +44,14 @@ public class RetryUtil {
    */
   public static long computeRandomRetryWaitTimeInMillis(int retryAttempts, long initialRetryBackoffMs) {
     if (initialRetryBackoffMs < 0) return 0;
-    if (retryAttempts <= 0) return initialRetryBackoffMs;
+    if (retryAttempts < 0) return initialRetryBackoffMs;
     long maxRetryTime = computeRetryWaitTimeInMillis(retryAttempts, initialRetryBackoffMs);
-    return ThreadLocalRandom.current().nextLong(initialRetryBackoffMs, maxRetryTime);
+    return ThreadLocalRandom.current().nextLong(0, maxRetryTime);
   }
 
   /**
    * Compute the time to sleep using exponential backoff. This method computes the normal exponential backoff
-   * as {@code initialRetryBackoffMs << retryAttempt}. bounded to always be less than {@link #MAX_RETRY_TIME_MS}.
+   * as {@code initialRetryBackoffMs << retryAttempt}, bounded to always be less than {@link #MAX_RETRY_TIME_MS}.
    *
    * @param retryAttempts the number of previous retry attempts; must be non-negative
    * @param initialRetryBackoffMs the initial time to wait before retrying; assumed to be 0 if value is negative

--- a/src/main/java/io/confluent/connect/elasticsearch/RetryUtil.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/RetryUtil.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ **/
+package io.confluent.connect.elasticsearch;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Utility to compute the retry times for a given attempt, using exponential backoff.
+ * <p>
+ * The purposes of using exponential backoff is to give the ES service time to recover when it becomes overwhelmed.
+ * Adding jitter attempts to prevent a thundering herd, where large numbers of requests from many tasks overwhelm the
+ * ES service, and without randomization all tasks retry at the same time. Randomization should spread the retries
+ * out and should reduce the overall time required to complete all attempts.
+ * See <a href="https://www.awsarchitectureblog.com/2015/03/backoff.html">this blog post</a> for details.
+ */
+public class RetryUtil {
+
+  /**
+   * An arbitrary absolute maximum practical retry time.
+   */
+  public static final long MAX_RETRY_TIME_MS = TimeUnit.HOURS.toMillis(24);
+
+  /**
+   * Compute the time to sleep using exponential backoff with jitter. This method computes the normal exponential backoff
+   * as {@code initialRetryBackoffMs << retryAttempt}, and then chooses a random value between {@code initialRetryBackoffMs}
+   * and that value.
+   *
+   * @param retryAttempts the number of previous retry attempts; must be non-negative
+   * @param initialRetryBackoffMs the initial time to wait before retrying; assumed to be 0 if value is negative
+   * @return the non-negative time in milliseconds to wait before the next retry attempt, or 0 if {@code initialRetryBackoffMs} is negative
+   */
+  public static long computeRandomRetryWaitTimeInMillis(int retryAttempts, long initialRetryBackoffMs) {
+    if (initialRetryBackoffMs < 0) return 0;
+    if (retryAttempts <= 0) return initialRetryBackoffMs;
+    long maxRetryTime = computeRetryWaitTimeInMillis(retryAttempts, initialRetryBackoffMs);
+    return ThreadLocalRandom.current().nextLong(initialRetryBackoffMs, maxRetryTime);
+  }
+
+  /**
+   * Compute the time to sleep using exponential backoff. This method computes the normal exponential backoff
+   * as {@code initialRetryBackoffMs << retryAttempt}. bounded to always be less than {@link #MAX_RETRY_TIME_MS}.
+   *
+   * @param retryAttempts the number of previous retry attempts; must be non-negative
+   * @param initialRetryBackoffMs the initial time to wait before retrying; assumed to be 0 if value is negative
+   * @return the non-negative time in milliseconds to wait before the next retry attempt, or 0 if {@code initialRetryBackoffMs} is negative
+   */
+  public static long computeRetryWaitTimeInMillis(int retryAttempts, long initialRetryBackoffMs) {
+    if (initialRetryBackoffMs < 0) return 0;
+    if (retryAttempts <= 0) return initialRetryBackoffMs;
+    if (retryAttempts > 32) {
+      // This would overflow the exponential algorithm ...
+      return MAX_RETRY_TIME_MS;
+    }
+    long result = initialRetryBackoffMs << retryAttempts;
+    return result < 0L ? MAX_RETRY_TIME_MS : Math.min(MAX_RETRY_TIME_MS, result);
+  }
+
+
+}

--- a/src/test/java/io/confluent/connect/elasticsearch/RetryUtilTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/RetryUtilTest.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ **/
+package io.confluent.connect.elasticsearch;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class RetryUtilTest {
+  @Test
+  public void computeRetryBackoffForValidRanges() {
+    assertComputeRetryInRange(10, 10L);
+    assertComputeRetryInRange(10, 100L);
+    assertComputeRetryInRange(10, 1000L);
+    assertComputeRetryInRange(100, 1000L);
+  }
+
+  @Test
+  public void computeRetryBackoffForNegativeRetryTimes() {
+    assertComputeRetryInRange(1, -100L);
+    assertComputeRetryInRange(10, -100L);
+    assertComputeRetryInRange(100, -100L);
+  }
+
+  @Test
+  public void computeNonRandomRetryTimes() {
+    assertEquals(100L, RetryUtil.computeRetryWaitTimeInMillis(0, 100L));
+    assertEquals(200L, RetryUtil.computeRetryWaitTimeInMillis(1, 100L));
+    assertEquals(400L, RetryUtil.computeRetryWaitTimeInMillis(2, 100L));
+    assertEquals(800L, RetryUtil.computeRetryWaitTimeInMillis(3, 100L));
+    assertEquals(1600L, RetryUtil.computeRetryWaitTimeInMillis(4, 100L));
+    assertEquals(3200L, RetryUtil.computeRetryWaitTimeInMillis(5, 100L));
+  }
+
+  protected void assertComputeRetryInRange(int retryAttempts, long initialRetryBackoffMs) {
+    for (int retries = 0; retries <= retryAttempts; ++retries) {
+      long result = RetryUtil.computeRetryWaitTimeInMillis(retries, initialRetryBackoffMs);
+      if (initialRetryBackoffMs < 0) {
+        assertEquals(0, result);
+      } else {
+        assertTrue(result >= initialRetryBackoffMs);
+      }
+    }
+  }
+}

--- a/src/test/java/io/confluent/connect/elasticsearch/RetryUtilTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/RetryUtilTest.java
@@ -46,13 +46,17 @@ public class RetryUtilTest {
     assertEquals(3200L, RetryUtil.computeRetryWaitTimeInMillis(5, 100L));
   }
 
-  protected void assertComputeRetryInRange(int retryAttempts, long initialRetryBackoffMs) {
-    for (int retries = 0; retries <= retryAttempts; ++retries) {
-      long result = RetryUtil.computeRetryWaitTimeInMillis(retries, initialRetryBackoffMs);
-      if (initialRetryBackoffMs < 0) {
-        assertEquals(0, result);
-      } else {
-        assertTrue(result >= initialRetryBackoffMs);
+  protected void assertComputeRetryInRange(int retryAttempts, long retryBackoffMs) {
+    for (int i = 0; i != 20; ++i) {
+      for (int retries = 0; retries <= retryAttempts; ++retries) {
+        long maxResult = RetryUtil.computeRetryWaitTimeInMillis(retries, retryBackoffMs);
+        long result = RetryUtil.computeRandomRetryWaitTimeInMillis(retries, retryBackoffMs);
+        if (retryBackoffMs < 0) {
+          assertEquals(0, result);
+        } else {
+          assertTrue(result >= 0L);
+          assertTrue(result <= maxResult);
+        }
       }
     }
   }


### PR DESCRIPTION
With lots of ES connector tasks all hitting the ES backend, when the ES backend becomes overloaded all of the tasks will experience timeouts (possibly at nearly the same time) and thus retry. Prior to this change, all tasks would use the same constant backoff time and would thus all retry at about the same point in time and possibly overwhelming the ES backend. This is known as a thundering herd, and when many attempts fail it takes a long time and many attempts to recover.

A solution to this problem is to use expontential backoff to give the ES backend time to recover, except that this alone doesn’t really reduce the thundering herd problem. To solve both problems we use expontential backoff but with jitter, which is a randomization of the sleep times for each of the attempts. This PR adds exponential backoff with jitter.

This new algorithm computes the normal maximum time to wait for a particular retry attempt using exponential backoff and then choosing a random value less than that maximum time.

Since this exponential algorithm breaks down after a large number of retry attempts, rather than adding a constraint for `max.retries` this change simply uses a practical (and arbitrary) absolute upper limit on the backoff time of 24 hours, and it logs a warning if this upper limit is exceeded.