### PR TITLE
CC-1191: Added feature flag to control string-keyed map entry JSON serialization

### DIFF
--- a/docs/configuration_options.rst
+++ b/docs/configuration_options.rst
@@ -88,6 +88,13 @@ Data Conversion
   * Default: false
   * Importance: low
 
+``compact.map.entries``
+  Defines how map entries with string keys within record values should be written to JSON. When this is set to ``true``, these entries are written compactly as ``"entryKey": "entryValue"``. Otherwise, map entries with string keys are written as a nested document ``{"key": "entryKey", "value": "entryValue"}``. All map entries with non-string keys are always written as nested documents. Prior to 3.3.0, this connector always wrote map entries as nested documents, so set this to ``false`` to use that older behavior.
+
+  * Type: boolean
+  * Default: true
+  * Importance: low
+
 ``topic.index.map``
   A map from Kafka topic name to the destination Elasticsearch index, represented as a list of ``topic:index`` pairs.
 

--- a/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
@@ -111,6 +111,7 @@ public class DataConverter {
   // expects a different JSON format from the current JSON converter provides. Rather than completely
   // rewrite a converter for Elasticsearch, we will refactor the JSON converter to support customized
   // translation. The pre process is no longer needed once we have the JSON converter refactored.
+  // visible for testing
   Schema preProcessSchema(Schema schema) {
     if (schema == null) {
       return null;
@@ -160,7 +161,7 @@ public class DataConverter {
     }
   }
 
-  SchemaBuilder copySchemaBasics(Schema source, SchemaBuilder target) {
+  private SchemaBuilder copySchemaBasics(Schema source, SchemaBuilder target) {
     if (source.isOptional()) {
       target.optional();
     }

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -40,6 +40,7 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   public static final String TOPIC_KEY_IGNORE_CONFIG = "topic.key.ignore";
   public static final String SCHEMA_IGNORE_CONFIG = "schema.ignore";
   public static final String TOPIC_SCHEMA_IGNORE_CONFIG = "topic.schema.ignore";
+  public static final String COMPACT_MAP_ENTRIES_CONFIG = "compact.map.entries";
 
   protected static ConfigDef baseConfigDef() {
     final ConfigDef configDef = new ConfigDef();
@@ -102,6 +103,15 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
                   + "Elasticsearch will infer the mapping from the data (dynamic mapping needs to be enabled by the user).\n"
                   + "Note that this is a global config that applies to all topics, use ``" + TOPIC_SCHEMA_IGNORE_CONFIG + "`` to override as ``true`` for specific topics.",
                   group, ++order, Width.SHORT, "Ignore Schema mode")
+          .define(COMPACT_MAP_ENTRIES_CONFIG, Type.BOOLEAN, true, Importance.LOW,
+                  "Defines how map entries with string keys within record values should be written to JSON. "
+                  + "When this is set to ``true``, these entries are written compactly as ``\"entryKey\": \"entryValue\"``. "
+                  + "Otherwise, map entries with string keys are written as a nested document "
+                  + "``{\"key\": \"entryKey\", \"value\": \"entryValue\"}``. "
+                  + "All map entries with non-string keys are always written as nested documents. "
+                  + "Prior to 3.3.0, this connector always wrote map entries as nested documents, so set this to ``false`` to use "
+                  + "that older behavior.",
+                  group, ++order, Width.SHORT, "Compact Map Entries")
           .define(TOPIC_INDEX_MAP_CONFIG, Type.LIST, "", Importance.LOW,
                   "A map from Kafka topic name to the destination Elasticsearch index, represented as a list of ``topic:index`` pairs.",
                   group, ++order, Width.LONG, "Topic to Index Map")

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -62,6 +62,7 @@ public class ElasticsearchSinkTask extends SinkTask {
       String type = config.getString(ElasticsearchSinkConnectorConfig.TYPE_NAME_CONFIG);
       boolean ignoreKey = config.getBoolean(ElasticsearchSinkConnectorConfig.KEY_IGNORE_CONFIG);
       boolean ignoreSchema = config.getBoolean(ElasticsearchSinkConnectorConfig.SCHEMA_IGNORE_CONFIG);
+      boolean useCompactMapEntries = config.getBoolean(ElasticsearchSinkConnectorConfig.COMPACT_MAP_ENTRIES_CONFIG);
 
       Map<String, String> topicToIndexMap = parseMapConfig(config.getList(ElasticsearchSinkConnectorConfig.TOPIC_INDEX_MAP_CONFIG));
       Set<String> topicIgnoreKey = new HashSet<>(config.getList(ElasticsearchSinkConnectorConfig.TOPIC_KEY_IGNORE_CONFIG));
@@ -98,6 +99,7 @@ public class ElasticsearchSinkTask extends SinkTask {
           .setType(type)
           .setIgnoreKey(ignoreKey, topicIgnoreKey)
           .setIgnoreSchema(ignoreSchema, topicIgnoreSchema)
+          .setCompactMapEntries(useCompactMapEntries)
           .setTopicToIndexMap(topicToIndexMap)
           .setFlushTimoutMs(flushTimeoutMs)
           .setMaxBufferedRecords(maxBufferedRecords)

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
@@ -49,12 +49,14 @@ public class ElasticsearchWriter {
   private final Map<String, String> topicToIndexMap;
   private final long flushTimeoutMs;
   private final BulkProcessor<IndexableRecord, ?> bulkProcessor;
+  private final DataConverter converter;
 
   private final Set<String> existingMappings;
 
   ElasticsearchWriter(
       JestClient client,
       String type,
+      boolean useCompactMapEntries,
       boolean ignoreKey,
       Set<String> ignoreKeyTopics,
       boolean ignoreSchema,
@@ -76,6 +78,7 @@ public class ElasticsearchWriter {
     this.ignoreSchemaTopics = ignoreSchemaTopics;
     this.topicToIndexMap = topicToIndexMap;
     this.flushTimeoutMs = flushTimeoutMs;
+    this.converter = new DataConverter(useCompactMapEntries);
 
     bulkProcessor = new BulkProcessor<>(
         new SystemTime(),
@@ -94,6 +97,7 @@ public class ElasticsearchWriter {
   public static class Builder {
     private final JestClient client;
     private String type;
+    private boolean useCompactMapEntries = true;
     private boolean ignoreKey = false;
     private Set<String> ignoreKeyTopics = Collections.emptySet();
     private boolean ignoreSchema = false;
@@ -125,6 +129,11 @@ public class ElasticsearchWriter {
     public Builder setIgnoreSchema(boolean ignoreSchema, Set<String> ignoreSchemaTopics) {
       this.ignoreSchema = ignoreSchema;
       this.ignoreSchemaTopics = ignoreSchemaTopics;
+      return this;
+    }
+
+    public Builder setCompactMapEntries(boolean useCompactMapEntries) {
+      this.useCompactMapEntries = useCompactMapEntries;
       return this;
     }
 
@@ -172,6 +181,7 @@ public class ElasticsearchWriter {
       return new ElasticsearchWriter(
           client,
           type,
+          useCompactMapEntries,
           ignoreKey,
           ignoreKeyTopics,
           ignoreSchema,
@@ -207,7 +217,8 @@ public class ElasticsearchWriter {
         existingMappings.add(index);
       }
 
-      final IndexableRecord indexableRecord = DataConverter.convertRecord(sinkRecord, index, type, ignoreKey, ignoreSchema);
+      final IndexableRecord indexableRecord = converter.convertRecord(sinkRecord, index, type,
+                                                                      ignoreKey, ignoreSchema);
 
       bulkProcessor.add(indexableRecord, flushTimeoutMs);
     }

--- a/src/test/java/io/confluent/connect/elasticsearch/DataConverterTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/DataConverterTest.java
@@ -20,6 +20,7 @@ import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.math.BigDecimal;
@@ -33,6 +34,13 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 
 public class DataConverterTest {
+  
+  private DataConverter converter;
+  
+  @Before
+  public void setUp() {
+    converter = new DataConverter(true);
+  }
 
   @Test
   public void primitives() {
@@ -67,58 +75,58 @@ public class DataConverterTest {
   }
 
   private void assertIdenticalAfterPreProcess(Schema schema) {
-    assertEquals(schema, DataConverter.preProcessSchema(schema));
+    assertEquals(schema, converter.preProcessSchema(schema));
   }
 
   @Test
   public void decimal() {
     Schema origSchema = Decimal.schema(2);
-    Schema preProcessedSchema = DataConverter.preProcessSchema(origSchema);
+    Schema preProcessedSchema = converter.preProcessSchema(origSchema);
     assertEquals(Schema.FLOAT64_SCHEMA, preProcessedSchema);
 
-    assertEquals(0.02, DataConverter.preProcessValue(new BigDecimal("0.02"), origSchema, preProcessedSchema));
+    assertEquals(0.02, converter.preProcessValue(new BigDecimal("0.02"), origSchema, preProcessedSchema));
 
     // optional
     assertEquals(
         Schema.OPTIONAL_FLOAT64_SCHEMA,
-        DataConverter.preProcessSchema(Decimal.builder(2).optional().build())
+        converter.preProcessSchema(Decimal.builder(2).optional().build())
     );
 
     // defval
     assertEquals(
         SchemaBuilder.float64().defaultValue(0.00).build(),
-        DataConverter.preProcessSchema(Decimal.builder(2).defaultValue(new BigDecimal("0.00")).build())
+        converter.preProcessSchema(Decimal.builder(2).defaultValue(new BigDecimal("0.00")).build())
     );
   }
 
   @Test
   public void array() {
     Schema origSchema = SchemaBuilder.array(Decimal.schema(2)).schema();
-    Schema preProcessedSchema = DataConverter.preProcessSchema(origSchema);
+    Schema preProcessedSchema = converter.preProcessSchema(origSchema);
     assertEquals(SchemaBuilder.array(Schema.FLOAT64_SCHEMA).build(), preProcessedSchema);
 
     assertEquals(
         Arrays.asList(0.02, 0.42),
-        DataConverter.preProcessValue(Arrays.asList(new BigDecimal("0.02"), new BigDecimal("0.42")), origSchema, preProcessedSchema)
+        converter.preProcessValue(Arrays.asList(new BigDecimal("0.02"), new BigDecimal("0.42")), origSchema, preProcessedSchema)
     );
 
     // optional
     assertEquals(
         SchemaBuilder.array(preProcessedSchema.valueSchema()).optional().build(),
-        DataConverter.preProcessSchema(SchemaBuilder.array(Decimal.schema(2)).optional().build())
+        converter.preProcessSchema(SchemaBuilder.array(Decimal.schema(2)).optional().build())
     );
 
     // defval
     assertEquals(
         SchemaBuilder.array(preProcessedSchema.valueSchema()).defaultValue(Collections.emptyList()).build(),
-        DataConverter.preProcessSchema(SchemaBuilder.array(Decimal.schema(2)).defaultValue(Collections.emptyList()).build())
+        converter.preProcessSchema(SchemaBuilder.array(Decimal.schema(2)).defaultValue(Collections.emptyList()).build())
     );
   }
 
   @Test
   public void map() {
     Schema origSchema = SchemaBuilder.map(Schema.INT32_SCHEMA, Decimal.schema(2)).build();
-    Schema preProcessedSchema = DataConverter.preProcessSchema(origSchema);
+    Schema preProcessedSchema = converter.preProcessSchema(origSchema);
     assertEquals(
         SchemaBuilder.array(
             SchemaBuilder.struct().name(Schema.INT32_SCHEMA.type().name() + "-" + Decimal.LOGICAL_NAME)
@@ -141,46 +149,79 @@ public class DataConverterTest {
                 .put(ElasticsearchSinkConnectorConstants.MAP_KEY, 2)
                 .put(ElasticsearchSinkConnectorConstants.MAP_VALUE, 0.42)
         )),
-        new HashSet<>((List) DataConverter.preProcessValue(origValue, origSchema, preProcessedSchema))
+        new HashSet<>((List) converter.preProcessValue(origValue, origSchema, preProcessedSchema))
     );
 
     // optional
     assertEquals(
         SchemaBuilder.array(preProcessedSchema.valueSchema()).optional().build(),
-        DataConverter.preProcessSchema(SchemaBuilder.map(Schema.INT32_SCHEMA, Decimal.schema(2)).optional().build())
+        converter.preProcessSchema(SchemaBuilder.map(Schema.INT32_SCHEMA, Decimal.schema(2)).optional().build())
     );
 
     // defval
     assertEquals(
         SchemaBuilder.array(preProcessedSchema.valueSchema()).defaultValue(Collections.emptyList()).build(),
-        DataConverter.preProcessSchema(SchemaBuilder.map(Schema.INT32_SCHEMA, Decimal.schema(2)).defaultValue(Collections.emptyMap()).build())
+        converter.preProcessSchema(SchemaBuilder.map(Schema.INT32_SCHEMA, Decimal.schema(2)).defaultValue(Collections.emptyMap()).build())
     );
   }
 
   @Test
-  public void stringKeyedMap() {
+  public void stringKeyedMapNonCompactFormat() {
     Schema origSchema = SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.INT32_SCHEMA).build();
-    Schema preProcessedSchema = DataConverter.preProcessSchema(origSchema);
-    assertEquals(
-            SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.INT32_SCHEMA).build(),
-            preProcessedSchema
-    );
 
     Map<Object, Object> origValue = new HashMap<>();
     origValue.put("field1", 1);
     origValue.put("field2", 2);
-    HashMap newValue = (HashMap) DataConverter.preProcessValue(origValue, origSchema, preProcessedSchema);
-    assertEquals(
-            origValue,
-            newValue
-    );
 
+    // Use the older non-compact format for map entries with string keys
+    converter = new DataConverter(false);
+
+    Schema preProcessedSchema = converter.preProcessSchema(origSchema);
+    assertEquals(
+        SchemaBuilder.array(
+            SchemaBuilder.struct().name(Schema.STRING_SCHEMA.type().name() + "-" + Schema.INT32_SCHEMA.type().name())
+                         .field(ElasticsearchSinkConnectorConstants.MAP_KEY, Schema.STRING_SCHEMA)
+                         .field(ElasticsearchSinkConnectorConstants.MAP_VALUE, Schema.INT32_SCHEMA)
+                         .build()
+        ).build(),
+        preProcessedSchema
+    );
+    assertEquals(
+        new HashSet<>(Arrays.asList(
+                new Struct(preProcessedSchema.valueSchema())
+                        .put(ElasticsearchSinkConnectorConstants.MAP_KEY, "field1")
+                        .put(ElasticsearchSinkConnectorConstants.MAP_VALUE, 1),
+                new Struct(preProcessedSchema.valueSchema())
+                        .put(ElasticsearchSinkConnectorConstants.MAP_KEY, "field2")
+                        .put(ElasticsearchSinkConnectorConstants.MAP_VALUE, 2)
+        )),
+        new HashSet<>((List) converter.preProcessValue(origValue, origSchema, preProcessedSchema))
+    );
+  }
+
+  @Test
+  public void stringKeyedMapCompactFormat() {
+    Schema origSchema = SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.INT32_SCHEMA).build();
+
+    Map<Object, Object> origValue = new HashMap<>();
+    origValue.put("field1", 1);
+    origValue.put("field2", 2);
+
+    // Use the newer compact format for map entries with string keys
+    converter = new DataConverter(true);
+    Schema preProcessedSchema = converter.preProcessSchema(origSchema);
+    assertEquals(
+        SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.INT32_SCHEMA).build(),
+        preProcessedSchema
+    );
+    HashMap newValue = (HashMap) converter.preProcessValue(origValue, origSchema, preProcessedSchema);
+    assertEquals(origValue, newValue);
   }
 
   @Test
   public void struct() {
     Schema origSchema = SchemaBuilder.struct().name("struct").field("decimal", Decimal.schema(2)).build();
-    Schema preProcessedSchema = DataConverter.preProcessSchema(origSchema);
+    Schema preProcessedSchema = converter.preProcessSchema(origSchema);
     assertEquals(
         SchemaBuilder.struct().name("struct").field("decimal", Schema.FLOAT64_SCHEMA).build(),
         preProcessedSchema
@@ -188,13 +229,13 @@ public class DataConverterTest {
 
     assertEquals(
         new Struct(preProcessedSchema).put("decimal", 0.02),
-        DataConverter.preProcessValue(new Struct(origSchema).put("decimal", new BigDecimal("0.02")), origSchema, preProcessedSchema)
+        converter.preProcessValue(new Struct(origSchema).put("decimal", new BigDecimal("0.02")), origSchema, preProcessedSchema)
     );
 
     // optional
     assertEquals(
         SchemaBuilder.struct().name("struct").field("decimal", Schema.FLOAT64_SCHEMA).optional().build(),
-        DataConverter.preProcessSchema(SchemaBuilder.struct().name("struct").field("decimal", Decimal.schema(2)).optional().build())
+        converter.preProcessSchema(SchemaBuilder.struct().name("struct").field("decimal", Decimal.schema(2)).optional().build())
     );
   }
 

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTestBase.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTestBase.java
@@ -55,6 +55,7 @@ public class ElasticsearchSinkTestBase extends ESIntegTestCase {
   protected static final TopicPartition TOPIC_PARTITION3 = new TopicPartition(TOPIC, PARTITION3);
 
   protected JestHttpClient client;
+  private DataConverter converter;
 
   @Before
   public void setUp() throws Exception {
@@ -66,6 +67,7 @@ public class ElasticsearchSinkTestBase extends ESIntegTestCase {
             .multiThreaded(true).build()
     );
     client = (JestHttpClient) factory.getObject();
+    converter = new DataConverter(true);
   }
 
   @After
@@ -130,7 +132,7 @@ public class ElasticsearchSinkTestBase extends ESIntegTestCase {
 
     for (Object record : records) {
       if (record instanceof SinkRecord) {
-        IndexableRecord indexableRecord = DataConverter.convertRecord((SinkRecord) record, index, TYPE, ignoreKey, ignoreSchema);
+        IndexableRecord indexableRecord = converter.convertRecord((SinkRecord) record, index, TYPE, ignoreKey, ignoreSchema);
         assertEquals(indexableRecord.payload, hits.get(indexableRecord.key.id));
       } else {
         assertEquals(record, hits.get("key"));

--- a/src/test/java/io/confluent/connect/elasticsearch/MappingTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/MappingTest.java
@@ -109,13 +109,14 @@ public class MappingTest extends ElasticsearchSinkTestBase {
       }
     }
 
+    DataConverter converter = new DataConverter(true);
     Schema.Type schemaType = schema.type();
     switch (schemaType) {
       case ARRAY:
         verifyMapping(schema.valueSchema(), mapping);
         break;
       case MAP:
-        Schema newSchema = DataConverter.preProcessSchema(schema);
+        Schema newSchema = converter.preProcessSchema(schema);
         JsonObject mapProperties = mapping.get("properties").getAsJsonObject();
         verifyMapping(newSchema.keySchema(), mapProperties.get(ElasticsearchSinkConnectorConstants.MAP_KEY).getAsJsonObject());
         verifyMapping(newSchema.valueSchema(), mapProperties.get(ElasticsearchSinkConnectorConstants.MAP_VALUE).getAsJsonObject());


### PR DESCRIPTION
Prior to 3.3.0, all map entries were serialized into JSON using a less compact form like the following that worked for all types of keys:

```
"metadata" : [ 
{ 
"key" : "lastUpdated", 
"value" : "20170209-23:58:26.420" 
}, { 
"key": "isSoftDeleted", 
"value": "false" 
}
...
]
```

In 3.3.0 this was changed so that the entries of all maps with string keys were written out in a more compact and natural JSON representation:

```
"metadata" : { 
   "lastUpdated": "Tue Feb 07 20:57:05 GMT 2017", 
   "isSoftDeleted": "false", 
   ...
}
```

Now, a new `compact.map.entries` configuration property allows users to control this behavior. This configuration defaults to `true` to match the newer 3.3.0 behavior for the entries of maps with string keys. However, simply set `compact.map.entries=false` for the older, pre-3.3.0 JSON representation.