### PR TITLE
NCS-151. specify routing field

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,1 @@
+@echo-xu @krzysztof-everbridge @timxi @mveitas

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,14 @@
         </repository>
     </repositories>
 
+    <pluginRepositories>
+        <pluginRepository>
+            <id>confluentplugin</id>
+            <name>confluentplugins</name>
+            <url>${confluent.maven.repo}</url>
+        </pluginRepository>
+    </pluginRepositories>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.kafka</groupId>

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -79,6 +79,7 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   public static final String SCHEMA_IGNORE_CONFIG = "schema.ignore";
   public static final String TOPIC_SCHEMA_IGNORE_CONFIG = "topic.schema.ignore";
   public static final String DROP_INVALID_MESSAGE_CONFIG = "drop.invalid.message";
+  public static final String ROUTING_FIELD_NAME = "routing.field.name";
 
   private static final String KEY_IGNORE_DOC =
       "Whether to ignore the record key for the purpose of forming the Elasticsearch document ID."
@@ -98,6 +99,8 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
       "List of topics for which ``" + SCHEMA_IGNORE_CONFIG + "`` should be ``true``.";
   private static final String DROP_INVALID_MESSAGE_DOC =
           "Whether to drop kafka message when it cannot be converted to output message.";
+  private static final String ROUTING_FIELD_NAME_DOC =
+          "Specify which filed should be used for routing, it must be a leaf field.";
 
   public static final String COMPACT_MAP_ENTRIES_CONFIG = "compact.map.entries";
   private static final String COMPACT_MAP_ENTRIES_DOC =
@@ -283,7 +286,17 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
         group,
         ++order,
         Width.LONG,
-        "Drop invalid messages");
+        "Drop invalid messages"
+    ).define(
+        ROUTING_FIELD_NAME,
+        Type.STRING,
+        null,
+        Importance.LOW,
+        ROUTING_FIELD_NAME_DOC,
+        group,
+        ++order,
+        Width.SHORT,
+        "Field used for routing");
   }
 
   public static final ConfigDef CONFIG = baseConfigDef();

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -92,6 +92,8 @@ public class ElasticsearchSinkTask extends SinkTask {
           config.getInt(ElasticsearchSinkConnectorConfig.MAX_RETRIES_CONFIG);
       boolean dropInvalidMessage =
           config.getBoolean(ElasticsearchSinkConnectorConfig.DROP_INVALID_MESSAGE_CONFIG);
+      String routingFieldName =
+              config.getString(ElasticsearchSinkConnectorConfig.ROUTING_FIELD_NAME);
 
       // Calculate the maximum possible backoff time ...
       long maxRetryBackoffMs = RetryUtil.computeRetryWaitTimeInMillis(maxRetry, retryBackoffMs);
@@ -131,7 +133,8 @@ public class ElasticsearchSinkTask extends SinkTask {
           .setLingerMs(lingerMs)
           .setRetryBackoffMs(retryBackoffMs)
           .setMaxRetry(maxRetry)
-          .setDropInvalidMessage(dropInvalidMessage);
+          .setDropInvalidMessage(dropInvalidMessage)
+          .setRoutingFieldName(routingFieldName);
 
       writer = builder.build();
       writer.start();

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
@@ -50,6 +50,7 @@ public class ElasticsearchWriter {
   private final long flushTimeoutMs;
   private final BulkProcessor<IndexableRecord, ?> bulkProcessor;
   private final boolean dropInvalidMessage;
+  private String routingFieldName;
   private final DataConverter converter;
 
   private final Set<String> existingMappings;
@@ -70,7 +71,8 @@ public class ElasticsearchWriter {
       long lingerMs,
       int maxRetries,
       long retryBackoffMs,
-      boolean dropInvalidMessage
+      boolean dropInvalidMessage,
+      String routingFieldName
   ) {
     this.client = client;
     this.type = type;
@@ -81,6 +83,7 @@ public class ElasticsearchWriter {
     this.topicToIndexMap = topicToIndexMap;
     this.flushTimeoutMs = flushTimeoutMs;
     this.dropInvalidMessage = dropInvalidMessage;
+    this.routingFieldName = routingFieldName;
     this.converter = new DataConverter(useCompactMapEntries);
 
     bulkProcessor = new BulkProcessor<>(
@@ -114,6 +117,7 @@ public class ElasticsearchWriter {
     private int maxRetry;
     private long retryBackoffMs;
     private boolean dropInvalidMessage;
+    private String routingFieldName;
 
     public Builder(JestClient client) {
       this.client = client;
@@ -186,6 +190,11 @@ public class ElasticsearchWriter {
       return this;
     }
 
+    public Builder setRoutingFieldName(String routingFieldName) {
+      this.routingFieldName = routingFieldName;
+      return this;
+    }
+
     public ElasticsearchWriter build() {
       return new ElasticsearchWriter(
           client,
@@ -203,7 +212,8 @@ public class ElasticsearchWriter {
           lingerMs,
           maxRetry,
           retryBackoffMs,
-          dropInvalidMessage
+          dropInvalidMessage,
+          routingFieldName
       );
     }
   }
@@ -255,6 +265,7 @@ public class ElasticsearchWriter {
               sinkRecord,
               index,
               type,
+              routingFieldName,
               ignoreKey,
               ignoreSchema);
     } catch (ConnectException convertException) {

--- a/src/main/java/io/confluent/connect/elasticsearch/IndexableRecord.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/IndexableRecord.java
@@ -17,15 +17,18 @@
 package io.confluent.connect.elasticsearch;
 
 import io.searchbox.core.Index;
+import io.searchbox.params.Parameters;
 
 public class IndexableRecord {
 
   public final Key key;
   public final String payload;
   public final Long version;
+  public final String routing;
 
-  public IndexableRecord(Key key, String payload, Long version) {
+  public IndexableRecord(Key key, String routing, String payload, Long version) {
     this.key = key;
+    this.routing = routing;
     this.version = version;
     this.payload = payload;
   }
@@ -37,6 +40,9 @@ public class IndexableRecord {
         .id(key.id);
     if (version != null) {
       req.setParameter("version_type", "external").setParameter("version", version);
+    }
+    if (routing != null) {
+      req.setParameter(Parameters.ROUTING, routing);
     }
     return req.build();
   }


### PR DESCRIPTION
@echo-xu @krzysztof-everbridge @timxi @mveitas

This pull request enables us to specify which field to be used as routing via ""routing.field.name" (it must be a leaf field, primitive, wrapper primitive or string type) config when initiate the connector in Kafka Connect. 

Note,
1. this is not a general purpose implementation thus is not ready to be contributed to the official repo, it takes more time to get deeper understanding on the schema usage to make it more generalized.
2. the official repo uses 2 spaces indentation, and it forces style check, I just followed that 