### PR TITLE
CC-350, CC-1097: Added support for delete and null handling

### DIFF
--- a/docs/configuration_options.rst
+++ b/docs/configuration_options.rst
@@ -129,3 +129,11 @@ Data Conversion
   * Type: list
   * Default: ""
   * Importance: low
+
+``behavior.on.null.values``
+  How to handle records with a non-null key and a null value (i.e. Kafka tombstone records). Valid options are 'ignore', 'delete', and 'fail'.
+
+  * Type: string
+  * Default: ignore
+  * Valid Values: [ignore, delete, fail]
+  * Importance: low

--- a/src/main/java/io/confluent/connect/elasticsearch/BulkIndexingClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/BulkIndexingClient.java
@@ -47,7 +47,7 @@ public class BulkIndexingClient implements BulkClient<IndexableRecord, Bulk> {
   public Bulk bulkRequest(List<IndexableRecord> batch) {
     final Bulk.Builder builder = new Bulk.Builder();
     for (IndexableRecord record : batch) {
-      builder.addAction(record.toIndexRequest());
+      builder.addAction(record.toBulkableAction());
     }
     return builder.build();
   }

--- a/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
@@ -16,6 +16,7 @@
 
 package io.confluent.connect.elasticsearch;
 
+import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.data.ConnectSchema;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
@@ -38,7 +39,9 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConstants.MAP_KEY;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConstants.MAP_VALUE;
@@ -52,9 +55,23 @@ public class DataConverter {
   }
 
   private final boolean useCompactMapEntries;
+  private final BehaviorOnNullValues behaviorOnNullValues;
 
-  public DataConverter(boolean useCompactMapEntries) {
+  /**
+   * Create a DataConverter, specifying how map entries with string keys within record
+   * values should be written to JSON. Compact map entries are written as
+   * <code>"entryKey": "entryValue"</code>, while the non-compact form are written as a nested
+   * document such as <code>{"key": "entryKey", "value": "entryValue"}</code>. All map entries
+   * with non-string keys are always written as nested documents.
+   *
+   * @param useCompactMapEntries true for compact map entries with string keys, or false for
+   *                             the nested document form.
+   * @param behaviorOnNullValues behavior for handling records with null values; may not be null
+   */
+  public DataConverter(boolean useCompactMapEntries, BehaviorOnNullValues behaviorOnNullValues) {
     this.useCompactMapEntries = useCompactMapEntries;
+    this.behaviorOnNullValues =
+        Objects.requireNonNull(behaviorOnNullValues, "behaviorOnNullValues cannot be null.");
   }
 
   private String convertKey(Schema keySchema, Object key) {
@@ -85,6 +102,45 @@ public class DataConverter {
   }
 
   public IndexableRecord convertRecord(SinkRecord record, String index, String type, boolean ignoreKey, boolean ignoreSchema) {
+    if (record.value() == null) {
+      switch (behaviorOnNullValues) {
+        case IGNORE:
+          return null;
+        case DELETE:
+          if (record.key() == null) {
+            // Since the record key is used as the ID of the index to delete and we don't have a key
+            // for this record, we can't delete anything anyways, so we ignore the record.
+            // We can also disregard the value of the ignoreKey parameter, since even if it's true
+            // the resulting index we'd try to delete would be based solely off topic/partition/
+            // offset information for the SinkRecord. Since that information is guaranteed to be
+            // unique per message, we can be confident that there wouldn't be any corresponding
+            // index present in ES to delete anyways.
+            return null;
+          }
+          // Will proceed as normal, ultimately creating an IndexableRecord with a null payload
+          break;
+        case FAIL:
+          throw new DataException(String.format(
+              "Sink record with key of %s and null value encountered for topic/partition/offset "
+              + "%s/%s/%s (to ignore future records like this change the configuration property "
+              + "'%s' from '%s' to '%s')",
+              record.key(),
+              record.topic(),
+              record.kafkaPartition(),
+              record.kafkaOffset(),
+              ElasticsearchSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG,
+              BehaviorOnNullValues.FAIL,
+              BehaviorOnNullValues.IGNORE
+          ));
+        default:
+          throw new RuntimeException(String.format(
+              "Unknown value for %s enum: %s",
+              BehaviorOnNullValues.class.getSimpleName(),
+              behaviorOnNullValues
+          ));
+      }
+    }
+
     final String id;
     if (ignoreKey) {
       id = record.topic() + "+" + String.valueOf((int) record.kafkaPartition()) + "+" + String.valueOf(record.kafkaOffset());
@@ -92,17 +148,22 @@ public class DataConverter {
       id = convertKey(record.keySchema(), record.key());
     }
 
-    final Schema schema;
-    final Object value;
-    if (!ignoreSchema) {
-      schema = preProcessSchema(record.valueSchema());
-      value = preProcessValue(record.value(), record.valueSchema(), schema);
+    final String payload;
+    if (record.value() != null) {
+      Schema schema = ignoreSchema
+          ? record.valueSchema()
+          : preProcessSchema(record.valueSchema());
+
+      Object value = ignoreSchema
+          ? record.value()
+          : preProcessValue(record.value(), record.valueSchema(), schema);
+
+      byte[] rawJsonPayload = JSON_CONVERTER.fromConnectData(record.topic(), schema, value);
+      payload = new String(rawJsonPayload, StandardCharsets.UTF_8);
     } else {
-      schema = record.valueSchema();
-      value = record.value();
+      payload = null;
     }
 
-    final String payload = new String(JSON_CONVERTER.fromConnectData(record.topic(), schema, value), StandardCharsets.UTF_8);
     final Long version = ignoreKey ? null : record.kafkaOffset();
     return new IndexableRecord(new Key(index, type, id), payload, version);
   }
@@ -240,6 +301,53 @@ public class DataConverter {
         return newStruct;
       default:
         return value;
+    }
+  }
+  public enum BehaviorOnNullValues {
+    IGNORE,
+    DELETE,
+    FAIL;
+
+    public static final BehaviorOnNullValues DEFAULT = IGNORE;
+
+    // Want values for "behavior.on.null.values" property to be case-insensitive
+    public static final ConfigDef.Validator VALIDATOR = new ConfigDef.Validator() {
+      private final ConfigDef.ValidString validator = ConfigDef.ValidString.in(names());
+
+      @Override
+      public void ensureValid(String name, Object value) {
+        if (value instanceof String) {
+          value = ((String) value).toLowerCase(Locale.ROOT);
+        }
+        validator.ensureValid(name, value);
+      }
+
+      // Overridden here so that ConfigDef.toEnrichedRst shows possible values correctly
+      @Override
+      public String toString() {
+        return validator.toString();
+      }
+
+    };
+
+    public static String[] names() {
+      BehaviorOnNullValues[] behaviors = values();
+      String[] result = new String[behaviors.length];
+
+      for (int i = 0; i < behaviors.length; i++) {
+        result[i] = behaviors[i].toString();
+      }
+
+      return result;
+    }
+
+    public static BehaviorOnNullValues forValue(String value) {
+      return valueOf(value.toUpperCase(Locale.ROOT));
+    }
+
+    @Override
+    public String toString() {
+      return name().toLowerCase(Locale.ROOT);
     }
   }
 }

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -85,7 +85,8 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
                   group, ++order, Width.SHORT, "Max Retries")
           .define(RETRY_BACKOFF_MS_CONFIG, Type.LONG, 100L, Importance.LOW,
                   "How long to wait in milliseconds before attempting the first retry of a failed indexing request. "
-                  + "Upon a failure, this connector may wait up to twice as long as the previous wait, up to the maximum number of retries. "
+                  + "This connector uses exponential backoff with jitter, which means that upon "
+                  + "additional failures, this connector may wait up to twice as long as the previous wait, up to the maximum number of retries. "
                   + "This avoids retrying in a tight loop under failure scenarios.",
                   group, ++order, Width.SHORT, "Retry Backoff (ms)")
           .define(CONNECTION_TIMEOUT_MS_CONFIG, Type.INT, 1000, Importance.LOW, "How long to wait "

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -24,6 +24,8 @@ import org.apache.kafka.common.config.ConfigDef.Width;
 
 import java.util.Map;
 
+import static io.confluent.connect.elasticsearch.DataConverter.BehaviorOnNullValues;
+
 public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
 
   public static final String CONNECTION_URL_CONFIG = "connection.url";
@@ -43,6 +45,7 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   public static final String COMPACT_MAP_ENTRIES_CONFIG = "compact.map.entries";
   public static final String CONNECTION_TIMEOUT_MS_CONFIG = "connection.timeout.ms";
   public static final String READ_TIMEOUT_MS_CONFIG = "read.timeout.ms";
+  public static final String BEHAVIOR_ON_NULL_VALUES_CONFIG = "behavior.on.null.values";
 
   protected static ConfigDef baseConfigDef() {
     final ConfigDef configDef = new ConfigDef();
@@ -132,7 +135,13 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
                   group, ++order, Width.LONG, "Topics for 'Ignore Key' mode")
           .define(TOPIC_SCHEMA_IGNORE_CONFIG, Type.LIST, "", Importance.LOW,
                   "List of topics for which ``" + SCHEMA_IGNORE_CONFIG + "`` should be ``true``.",
-                  group, ++order, Width.LONG, "Topics for 'Ignore Schema' mode");
+                  group, ++order, Width.LONG, "Topics for 'Ignore Schema' mode")
+          .define(BEHAVIOR_ON_NULL_VALUES_CONFIG, Type.STRING,
+                  BehaviorOnNullValues.DEFAULT.toString(), BehaviorOnNullValues.VALIDATOR,
+                  Importance.LOW,
+                  "How to handle records with a non-null key and a null value (i.e. Kafka tombstone "
+                  + "records). Valid options are 'ignore', 'delete', and 'fail'.",
+                  group, ++order, Width.SHORT, "Behavior for null-valued records");
     }
 
     return configDef;

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -37,6 +37,8 @@ import io.searchbox.client.JestClient;
 import io.searchbox.client.JestClientFactory;
 import io.searchbox.client.config.HttpClientConfig;
 
+import static io.confluent.connect.elasticsearch.DataConverter.BehaviorOnNullValues;
+
 public class ElasticsearchSinkTask extends SinkTask {
 
   private static final Logger log = LoggerFactory.getLogger(ElasticsearchSinkTask.class);
@@ -78,6 +80,11 @@ public class ElasticsearchSinkTask extends SinkTask {
       int connTimeout = config.getInt(ElasticsearchSinkConnectorConfig.CONNECTION_TIMEOUT_MS_CONFIG);
       int readTimeout = config.getInt(ElasticsearchSinkConnectorConfig.READ_TIMEOUT_MS_CONFIG);
 
+      BehaviorOnNullValues behaviorOnNullValues =
+          BehaviorOnNullValues.forValue(
+              config.getString(ElasticsearchSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG)
+          );
+
       // Calculate the maximum possible backoff time ...
       long maxRetryBackoffMs = RetryUtil.computeRetryWaitTimeInMillis(maxRetry, retryBackoffMs);
       if (maxRetryBackoffMs > RetryUtil.MAX_RETRY_TIME_MS) {
@@ -114,7 +121,8 @@ public class ElasticsearchSinkTask extends SinkTask {
           .setBatchSize(batchSize)
           .setLingerMs(lingerMs)
           .setRetryBackoffMs(retryBackoffMs)
-          .setMaxRetry(maxRetry);
+          .setMaxRetry(maxRetry)
+          .setBehaviorOnNullValues(behaviorOnNullValues);
 
       writer = builder.build();
       writer.start();

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
@@ -221,7 +221,7 @@ public class ElasticsearchWriter {
   public void write(Collection<SinkRecord> records) {
     for (SinkRecord sinkRecord : records) {
       // Preemptively skip records with null values if they're going to be ignored anyways
-      if (sinkRecord.value() == null && behaviorOnNullValues.equals(BehaviorOnNullValues.IGNORE)) {
+      if (sinkRecord.value() == null && behaviorOnNullValues == BehaviorOnNullValues.IGNORE) {
         continue;
       }
 

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
@@ -23,11 +23,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.Collection;
 import java.util.Collections;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import io.confluent.connect.elasticsearch.bulk.BulkProcessor;
@@ -36,6 +37,8 @@ import io.searchbox.client.JestClient;
 import io.searchbox.client.JestResult;
 import io.searchbox.indices.CreateIndex;
 import io.searchbox.indices.IndicesExists;
+
+import static io.confluent.connect.elasticsearch.DataConverter.BehaviorOnNullValues;
 
 public class ElasticsearchWriter {
   private static final Logger log = LoggerFactory.getLogger(ElasticsearchWriter.class);
@@ -68,7 +71,8 @@ public class ElasticsearchWriter {
       int batchSize,
       long lingerMs,
       int maxRetries,
-      long retryBackoffMs
+      long retryBackoffMs,
+      BehaviorOnNullValues behaviorOnNullValues
   ) {
     this.client = client;
     this.type = type;
@@ -78,7 +82,7 @@ public class ElasticsearchWriter {
     this.ignoreSchemaTopics = ignoreSchemaTopics;
     this.topicToIndexMap = topicToIndexMap;
     this.flushTimeoutMs = flushTimeoutMs;
-    this.converter = new DataConverter(useCompactMapEntries);
+    this.converter = new DataConverter(useCompactMapEntries, behaviorOnNullValues);
 
     bulkProcessor = new BulkProcessor<>(
         new SystemTime(),
@@ -110,6 +114,7 @@ public class ElasticsearchWriter {
     private long lingerMs;
     private int maxRetry;
     private long retryBackoffMs;
+    private BehaviorOnNullValues behaviorOnNullValues = BehaviorOnNullValues.DEFAULT;
 
     public Builder(JestClient client) {
       this.client = client;
@@ -177,6 +182,18 @@ public class ElasticsearchWriter {
       return this;
     }
 
+    /**
+     * Change the behavior that the resulting {@link ElasticsearchWriter} will have when it
+     * encounters records with null values.
+     * @param behaviorOnNullValues Cannot be null. If in doubt, {@link BehaviorOnNullValues#DEFAULT}
+     *                             can be used.
+     */
+    public Builder setBehaviorOnNullValues(BehaviorOnNullValues behaviorOnNullValues) {
+      this.behaviorOnNullValues =
+          Objects.requireNonNull(behaviorOnNullValues, "behaviorOnNullValues cannot be null");
+      return this;
+    }
+
     public ElasticsearchWriter build() {
       return new ElasticsearchWriter(
           client,
@@ -193,7 +210,8 @@ public class ElasticsearchWriter {
           batchSize,
           lingerMs,
           maxRetry,
-          retryBackoffMs
+          retryBackoffMs,
+          behaviorOnNullValues
       );
     }
   }
@@ -220,7 +238,19 @@ public class ElasticsearchWriter {
       final IndexableRecord indexableRecord = converter.convertRecord(sinkRecord, index, type,
                                                                       ignoreKey, ignoreSchema);
 
-      bulkProcessor.add(indexableRecord, flushTimeoutMs);
+      // In the event that the sink record's value was null and the data converter has been told to
+      // ignore null values, the returned record will be null.
+      if (indexableRecord != null) {
+        bulkProcessor.add(indexableRecord, flushTimeoutMs);
+      } else {
+        log.debug(
+            "Ignoring sink record with key {} and null value for topic/partition/offset {}/{}/{}",
+            sinkRecord.key(),
+            sinkRecord.topic(),
+            sinkRecord.kafkaPartition(),
+            sinkRecord.kafkaOffset()
+        );
+      }
     }
   }
 

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTestBase.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTestBase.java
@@ -42,6 +42,8 @@ import io.searchbox.client.http.JestHttpClient;
 import io.searchbox.core.Search;
 import io.searchbox.core.SearchResult;
 
+import static io.confluent.connect.elasticsearch.DataConverter.BehaviorOnNullValues;
+
 public class ElasticsearchSinkTestBase extends ESIntegTestCase {
 
   protected static final String TYPE = "kafka-connect";
@@ -67,7 +69,9 @@ public class ElasticsearchSinkTestBase extends ESIntegTestCase {
             .multiThreaded(true).build()
     );
     client = (JestHttpClient) factory.getObject();
-    converter = new DataConverter(true);
+    // Shouldn't be told to verify any records with null values; if that happens, the test should
+    // automatically fail
+    converter = new DataConverter(true, BehaviorOnNullValues.FAIL);
   }
 
   @After

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTestBase.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTestBase.java
@@ -69,9 +69,7 @@ public class ElasticsearchSinkTestBase extends ESIntegTestCase {
             .multiThreaded(true).build()
     );
     client = (JestHttpClient) factory.getObject();
-    // Shouldn't be told to verify any records with null values; if that happens, the test should
-    // automatically fail
-    converter = new DataConverter(true, BehaviorOnNullValues.FAIL);
+    converter = new DataConverter(true, BehaviorOnNullValues.IGNORE);
   }
 
   @After

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchWriterTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchWriterTest.java
@@ -111,7 +111,7 @@ public class ElasticsearchWriterTest extends ElasticsearchSinkTestBase {
         Collections.<String>emptySet(),
         Collections.<String>emptySet(),
         Collections.singletonMap(TOPIC, indexOverride),
-        BehaviorOnNullValues.FAIL
+        BehaviorOnNullValues.IGNORE
     );
     writeDataAndRefresh(writer, records);
     verifySearchResults(records, indexOverride);
@@ -423,7 +423,7 @@ public class ElasticsearchWriterTest extends ElasticsearchSinkTestBase {
   }
 
   private ElasticsearchWriter initWriter(JestClient client) {
-    return initWriter(client, BehaviorOnNullValues.FAIL);
+    return initWriter(client, BehaviorOnNullValues.IGNORE);
   }
 
   private ElasticsearchWriter initWriter(JestClient client, BehaviorOnNullValues behavior) {

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchWriterTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchWriterTest.java
@@ -24,7 +24,9 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.math.BigDecimal;
@@ -41,6 +43,8 @@ import java.util.Set;
 
 import io.searchbox.client.JestClient;
 
+import static io.confluent.connect.elasticsearch.DataConverter.BehaviorOnNullValues;
+
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class ElasticsearchWriterTest extends ElasticsearchSinkTestBase {
 
@@ -50,67 +54,86 @@ public class ElasticsearchWriterTest extends ElasticsearchSinkTestBase {
   private final Schema otherSchema = createOtherSchema();
   private final Struct otherRecord = createOtherRecord(otherSchema);
 
+  private boolean ignoreKey;
+  private boolean ignoreSchema;
+
+  @Before
+  public void setUp() throws Exception {
+    ignoreKey = false;
+    ignoreSchema = false;
+
+    super.setUp();
+  }
+
   @Test
   public void testWriter() throws Exception {
-    final boolean ignoreKey = false;
-    final boolean ignoreSchema = false;
-
     Collection<SinkRecord> records = prepareData(2);
-    ElasticsearchWriter writer = initWriter(client, ignoreKey, ignoreSchema);
+    ElasticsearchWriter writer = initWriter(client);
     writeDataAndRefresh(writer, records);
 
-    Collection<SinkRecord> expected = Collections.singletonList(new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, 1));
-    verifySearchResults(expected, ignoreKey, ignoreSchema);
+    Collection<SinkRecord> expected = Collections.singletonList(
+        new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, 1)
+    );
+    verifySearchResults(expected);
   }
 
   @Test
   public void testWriterIgnoreKey() throws Exception {
-    final boolean ignoreKey = true;
-    final boolean ignoreSchema = false;
+    ignoreKey = true;
 
     Collection<SinkRecord> records = prepareData(2);
-    ElasticsearchWriter writer = initWriter(client, ignoreKey, ignoreSchema);
+    ElasticsearchWriter writer = initWriter(client);
     writeDataAndRefresh(writer, records);
-    verifySearchResults(records, ignoreKey, ignoreSchema);
+    verifySearchResults(records);
   }
 
   @Test
   public void testWriterIgnoreSchema() throws Exception {
-    final boolean ignoreKey = true;
-    final boolean ignoreSchema = true;
+    ignoreKey = true;
+    ignoreSchema = true;
 
     Collection<SinkRecord> records = prepareData(2);
-    ElasticsearchWriter writer = initWriter(client, ignoreKey, ignoreSchema);
+    ElasticsearchWriter writer = initWriter(client);
     writeDataAndRefresh(writer, records);
-    verifySearchResults(records, ignoreKey, ignoreSchema);
+    verifySearchResults(records);
   }
 
   @Test
   public void testTopicIndexOverride() throws Exception {
-    final boolean ignoreKey = true;
-    final boolean ignoreSchema = true;
+    ignoreKey = true;
+    ignoreSchema = true;
 
-    final String indexOverride = "index";
+    String indexOverride = "index";
 
     Collection<SinkRecord> records = prepareData(2);
-    ElasticsearchWriter writer = initWriter(client, ignoreKey, Collections.<String>emptySet(), ignoreSchema, Collections.<String>emptySet(), Collections.singletonMap(TOPIC, indexOverride));
+    ElasticsearchWriter writer = initWriter(
+        client,
+        Collections.<String>emptySet(),
+        Collections.<String>emptySet(),
+        Collections.singletonMap(TOPIC, indexOverride),
+        BehaviorOnNullValues.FAIL
+    );
     writeDataAndRefresh(writer, records);
-    verifySearchResults(records, indexOverride, ignoreKey, ignoreSchema);
+    verifySearchResults(records, indexOverride);
   }
 
   @Test
   public void testIncompatible() throws Exception {
+    ignoreKey = true;
+
     Collection<SinkRecord> records = new ArrayList<>();
-    SinkRecord sinkRecord = new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, otherSchema, otherRecord, 0);
+    SinkRecord sinkRecord =
+        new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, otherSchema, otherRecord, 0);
     records.add(sinkRecord);
 
-    ElasticsearchWriter writer = initWriter(client, true, false);
+    ElasticsearchWriter writer = initWriter(client);
 
     writer.write(records);
     Thread.sleep(5000);
     records.clear();
 
-    sinkRecord = new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, 1);
+    sinkRecord =
+        new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, 1);
     records.add(sinkRecord);
     writer.write(records);
 
@@ -124,51 +147,53 @@ public class ElasticsearchWriterTest extends ElasticsearchSinkTestBase {
 
   @Test
   public void testCompatible() throws Exception {
-    final boolean ignoreKey = true;
-    final boolean ignoreSchema = false;
+    ignoreKey = true;
 
     Collection<SinkRecord> records = new ArrayList<>();
     Collection<SinkRecord> expected = new ArrayList<>();
-    SinkRecord sinkRecord = new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, 0);
+    SinkRecord sinkRecord =
+        new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, 0);
     records.add(sinkRecord);
     expected.add(sinkRecord);
-    sinkRecord = new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, 1);
+    sinkRecord =
+        new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, 1);
     records.add(sinkRecord);
     expected.add(sinkRecord);
 
-    ElasticsearchWriter writer = initWriter(client, ignoreKey, ignoreSchema);
+    ElasticsearchWriter writer = initWriter(client);
 
     writer.write(records);
     records.clear();
 
-    sinkRecord = new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, otherSchema, otherRecord, 2);
+    sinkRecord =
+        new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, otherSchema, otherRecord, 2);
     records.add(sinkRecord);
     expected.add(sinkRecord);
 
-    sinkRecord = new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, otherSchema, otherRecord, 3);
+    sinkRecord =
+        new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, otherSchema, otherRecord, 3);
     records.add(sinkRecord);
     expected.add(sinkRecord);
 
     writeDataAndRefresh(writer, records);
-    verifySearchResults(expected, ignoreKey, ignoreSchema);
+    verifySearchResults(expected);
   }
 
   @Test
   public void testSafeRedeliveryRegularKey() throws Exception {
-    final boolean ignoreKey = false;
-    final boolean ignoreSchema = false;
-
-    final Struct value0 = new Struct(schema);
+    Struct value0 = new Struct(schema);
     value0.put("user", "foo");
     value0.put("message", "hi");
-    final SinkRecord sinkRecord0 = new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, value0, 0);
+    SinkRecord sinkRecord0 =
+        new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, value0, 0);
 
-    final Struct value1 = new Struct(schema);
+    Struct value1 = new Struct(schema);
     value1.put("user", "foo");
     value1.put("message", "bye");
-    final SinkRecord sinkRecord1 = new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, value1, 1);
+    SinkRecord sinkRecord1 =
+        new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, value1, 1);
 
-    final ElasticsearchWriter writer = initWriter(client, ignoreKey, ignoreSchema);
+    ElasticsearchWriter writer = initWriter(client);
     writer.write(Arrays.asList(sinkRecord0, sinkRecord1));
     writer.flush();
 
@@ -176,27 +201,28 @@ public class ElasticsearchWriterTest extends ElasticsearchSinkTestBase {
     writeDataAndRefresh(writer, Collections.singleton(sinkRecord0));
 
     // last write should have been ignored due to version conflict
-    verifySearchResults(Collections.singleton(sinkRecord1), ignoreKey, ignoreSchema);
+    verifySearchResults(Collections.singleton(sinkRecord1));
   }
 
   @Test
   public void testSafeRedeliveryOffsetInKey() throws Exception {
-    final boolean ignoreKey = true;
-    final boolean ignoreSchema = false;
+    ignoreKey = true;
 
-    final Struct value0 = new Struct(schema);
+    Struct value0 = new Struct(schema);
     value0.put("user", "foo");
     value0.put("message", "hi");
-    final SinkRecord sinkRecord0 = new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, value0, 0);
+    SinkRecord sinkRecord0 =
+        new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, value0, 0);
 
-    final Struct value1 = new Struct(schema);
+    Struct value1 = new Struct(schema);
     value1.put("user", "foo");
     value1.put("message", "bye");
-    final SinkRecord sinkRecord1 = new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, value1, 1);
+    SinkRecord sinkRecord1 =
+        new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, value1, 1);
 
-    final List<SinkRecord> records = Arrays.asList(sinkRecord0, sinkRecord1);
+    List<SinkRecord> records = Arrays.asList(sinkRecord0, sinkRecord1);
 
-    final ElasticsearchWriter writer = initWriter(client, ignoreKey, ignoreSchema);
+    ElasticsearchWriter writer = initWriter(client);
     writer.write(records);
     writer.flush();
 
@@ -204,14 +230,11 @@ public class ElasticsearchWriterTest extends ElasticsearchSinkTestBase {
     writeDataAndRefresh(writer, records);
 
     // last write should have been ignored due to version conflict
-    verifySearchResults(records, ignoreKey, ignoreSchema);
+    verifySearchResults(records);
   }
 
   @Test
   public void testMap() throws Exception {
-    final boolean ignoreKey = false;
-    final boolean ignoreSchema = false;
-
     Schema structSchema = SchemaBuilder.struct().name("struct")
         .field("map", SchemaBuilder.map(Schema.INT32_SCHEMA, Schema.STRING_SCHEMA).build())
         .build();
@@ -224,39 +247,36 @@ public class ElasticsearchWriterTest extends ElasticsearchSinkTestBase {
     struct.put("map", map);
 
     Collection<SinkRecord> records = new ArrayList<>();
-    SinkRecord sinkRecord = new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, structSchema, struct, 0);
+    SinkRecord sinkRecord =
+        new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, structSchema, struct, 0);
     records.add(sinkRecord);
 
-    ElasticsearchWriter writer = initWriter(client, ignoreKey, ignoreSchema);
+    ElasticsearchWriter writer = initWriter(client);
     writeDataAndRefresh(writer, records);
-    verifySearchResults(records, ignoreKey, ignoreSchema);
+    verifySearchResults(records);
   }
 
   @Test
   public void testStringKeyedMap() throws Exception {
-    boolean ignoreKey = false;
-    boolean ignoreSchema = false;
-
     Schema mapSchema = SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.INT32_SCHEMA).build();
 
     Map<String, Integer> map = new HashMap<>();
     map.put("One", 1);
     map.put("Two", 2);
 
-    SinkRecord sinkRecord = new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, mapSchema, map, 0);
+    SinkRecord sinkRecord =
+        new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, mapSchema, map, 0);
 
-    ElasticsearchWriter writer = initWriter(client, ignoreKey, ignoreSchema);
+    ElasticsearchWriter writer = initWriter(client);
     writeDataAndRefresh(writer, Collections.singletonList(sinkRecord));
 
-    Collection<?> expectedRecords = Collections.singletonList(new ObjectMapper().writeValueAsString(map));
-    verifySearchResults(expectedRecords, TOPIC, ignoreKey, ignoreSchema);
+    Collection<?> expectedRecords =
+        Collections.singletonList(new ObjectMapper().writeValueAsString(map));
+    verifySearchResults(expectedRecords, TOPIC);
   }
 
   @Test
   public void testDecimal() throws Exception {
-    final boolean ignoreKey = false;
-    final boolean ignoreSchema = false;
-
     int scale = 2;
     byte[] bytes = ByteBuffer.allocate(4).putInt(2).array();
     BigDecimal decimal = new BigDecimal(new BigInteger(bytes), scale);
@@ -269,19 +289,17 @@ public class ElasticsearchWriterTest extends ElasticsearchSinkTestBase {
     struct.put("decimal", decimal);
 
     Collection<SinkRecord> records = new ArrayList<>();
-    SinkRecord sinkRecord = new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, structSchema, struct, 0);
+    SinkRecord sinkRecord =
+        new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, structSchema, struct, 0);
     records.add(sinkRecord);
 
-    ElasticsearchWriter writer = initWriter(client, ignoreKey, ignoreSchema);
+    ElasticsearchWriter writer = initWriter(client);
     writeDataAndRefresh(writer, records);
-    verifySearchResults(records, ignoreKey, ignoreSchema);
+    verifySearchResults(records);
   }
 
   @Test
   public void testBytes() throws Exception {
-    final boolean ignoreKey = false;
-    final boolean ignoreSchema = false;
-
     Schema structSchema = SchemaBuilder.struct().name("struct")
         .field("bytes", SchemaBuilder.BYTES_SCHEMA)
         .build();
@@ -290,28 +308,141 @@ public class ElasticsearchWriterTest extends ElasticsearchSinkTestBase {
     struct.put("bytes", new byte[]{42});
 
     Collection<SinkRecord> records = new ArrayList<>();
-    SinkRecord sinkRecord = new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, structSchema, struct, 0);
+    SinkRecord sinkRecord =
+        new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, structSchema, struct, 0);
     records.add(sinkRecord);
 
-    ElasticsearchWriter writer = initWriter(client, ignoreKey, ignoreSchema);
+    ElasticsearchWriter writer = initWriter(client);
     writeDataAndRefresh(writer, records);
-    verifySearchResults(records, ignoreKey, ignoreSchema);
+    verifySearchResults(records);
+  }
+
+  @Test
+  public void testIgnoreNullValue() throws Exception {
+    Collection<SinkRecord> records = new ArrayList<>();
+    SinkRecord sinkRecord =
+        new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, null, 0);
+    records.add(sinkRecord);
+
+    ElasticsearchWriter writer = initWriter(client, BehaviorOnNullValues.IGNORE);
+    writeDataAndRefresh(writer, records);
+    // Send an empty list of records to the verify method, since the empty record should have been
+    // skipped
+    verifySearchResults(new ArrayList<SinkRecord>());
+  }
+
+  @Test
+  public void testDeleteOnNullValue() throws Exception {
+    String key1 = "key1";
+    String key2 = "key2";
+
+    ElasticsearchWriter writer = initWriter(client, BehaviorOnNullValues.DELETE);
+
+    Collection<SinkRecord> records = new ArrayList<>();
+
+    // First, write a couple of actual (non-null-valued) records
+    SinkRecord insertRecord1 =
+        new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key1, schema, record, 0);
+    records.add(insertRecord1);
+    SinkRecord insertRecord2 =
+        new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key2, otherSchema, otherRecord, 1);
+    records.add(insertRecord2);
+    // Can't call writeDataAndRefresh(writer, records) since it stops the writer
+    writer.write(records);
+    writer.flush();
+    refresh();
+    // Make sure the record made it there successfully
+    verifySearchResults(records);
+
+    // Then, write a record with the same key as the first inserted record but a null value
+    SinkRecord deleteRecord =
+        new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key1, schema, null, 2);
+
+    // Don't want to resend the first couple of records
+    records.clear();
+    records.add(deleteRecord);
+    writeDataAndRefresh(writer, records);
+
+    // The only remaining record should be the second inserted record
+    records.clear();
+    records.add(insertRecord2);
+    verifySearchResults(records);
+  }
+
+  @Test
+  public void testIneffectiveDelete() throws Exception {
+    // Just a sanity check to make sure things don't blow up if an attempt is made to delete a
+    // record that doesn't exist in the first place
+
+    Collection<SinkRecord> records = new ArrayList<>();
+    SinkRecord sinkRecord =
+        new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, null, 0);
+    records.add(sinkRecord);
+
+    ElasticsearchWriter writer = initWriter(client, BehaviorOnNullValues.DELETE);
+    writeDataAndRefresh(writer, records);
+    verifySearchResults(new ArrayList<SinkRecord>());
+  }
+
+  @Test
+  public void testDeleteWithNullKey() throws Exception {
+    Collection<SinkRecord> records = new ArrayList<>();
+    SinkRecord sinkRecord =
+        new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, null, schema, null, 0);
+    records.add(sinkRecord);
+
+    ElasticsearchWriter writer = initWriter(client, BehaviorOnNullValues.DELETE);
+    writeDataAndRefresh(writer, records);
+    verifySearchResults(new ArrayList<SinkRecord>());
+  }
+
+  @Test
+  public void testFailOnNullValue() throws Exception {
+    Collection<SinkRecord> records = new ArrayList<>();
+    SinkRecord sinkRecord =
+        new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, null, 0);
+    records.add(sinkRecord);
+
+    ElasticsearchWriter writer = initWriter(client, BehaviorOnNullValues.FAIL);
+    try {
+      writeDataAndRefresh(writer, records);
+      fail("should fail because of behavior.on.null.values=fail");
+    } catch (DataException e) {
+      // expected
+    }
   }
 
   private Collection<SinkRecord> prepareData(int numRecords) {
     Collection<SinkRecord> records = new ArrayList<>();
     for (int i = 0; i < numRecords; ++i) {
-      SinkRecord sinkRecord = new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, i);
+      SinkRecord sinkRecord =
+          new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, i);
       records.add(sinkRecord);
     }
     return records;
   }
 
-  private ElasticsearchWriter initWriter(JestClient client, boolean ignoreKey, boolean ignoreSchema) {
-    return initWriter(client, ignoreKey, Collections.<String>emptySet(), ignoreSchema, Collections.<String>emptySet(), Collections.<String, String>emptyMap());
+  private ElasticsearchWriter initWriter(JestClient client) {
+    return initWriter(client, BehaviorOnNullValues.FAIL);
   }
 
-  private ElasticsearchWriter initWriter(JestClient client, boolean ignoreKey, Set<String> ignoreKeyTopics, boolean ignoreSchema, Set<String> ignoreSchemaTopics, Map<String, String> topicToIndexMap) {
+  private ElasticsearchWriter initWriter(JestClient client, BehaviorOnNullValues behavior) {
+    return initWriter(
+        client,
+        Collections.<String>emptySet(),
+        Collections.<String>emptySet(),
+        Collections.<String, String>emptyMap(),
+        behavior
+    );
+  }
+
+  private ElasticsearchWriter initWriter(
+      JestClient client,
+      Set<String> ignoreKeyTopics,
+      Set<String> ignoreSchemaTopics,
+      Map<String, String> topicToIndexMap,
+      BehaviorOnNullValues behavior
+  ) {
     ElasticsearchWriter writer = new ElasticsearchWriter.Builder(client)
         .setType(TYPE)
         .setIgnoreKey(ignoreKey, ignoreKeyTopics)
@@ -324,16 +455,26 @@ public class ElasticsearchWriterTest extends ElasticsearchSinkTestBase {
         .setLingerMs(1000)
         .setRetryBackoffMs(1000)
         .setMaxRetry(3)
+        .setBehaviorOnNullValues(behavior)
         .build();
     writer.start();
     writer.createIndicesForTopics(Collections.singleton(TOPIC));
     return writer;
   }
 
-  private void writeDataAndRefresh(ElasticsearchWriter writer, Collection<SinkRecord> records) throws Exception {
+  private void writeDataAndRefresh(ElasticsearchWriter writer, Collection<SinkRecord> records)
+      throws Exception {
     writer.write(records);
     writer.flush();
     writer.stop();
     refresh();
+  }
+
+  private void verifySearchResults(Collection<SinkRecord> records) throws Exception {
+    verifySearchResults(records, ignoreKey, ignoreSchema);
+  }
+
+  private void verifySearchResults(Collection<?> records, String index) throws Exception {
+    verifySearchResults(records, index, ignoreKey, ignoreSchema);
   }
 }

--- a/src/test/java/io/confluent/connect/elasticsearch/MappingTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/MappingTest.java
@@ -29,6 +29,8 @@ import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.InternalTestCluster;
 import org.junit.Test;
 
+import static io.confluent.connect.elasticsearch.DataConverter.BehaviorOnNullValues;
+
 public class MappingTest extends ElasticsearchSinkTestBase {
 
   private static final String INDEX = "kafka-connect";
@@ -109,7 +111,7 @@ public class MappingTest extends ElasticsearchSinkTestBase {
       }
     }
 
-    DataConverter converter = new DataConverter(true);
+    DataConverter converter = new DataConverter(true, BehaviorOnNullValues.FAIL);
     Schema.Type schemaType = schema.type();
     switch (schemaType) {
       case ARRAY:

--- a/src/test/java/io/confluent/connect/elasticsearch/MappingTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/MappingTest.java
@@ -111,7 +111,7 @@ public class MappingTest extends ElasticsearchSinkTestBase {
       }
     }
 
-    DataConverter converter = new DataConverter(true, BehaviorOnNullValues.FAIL);
+    DataConverter converter = new DataConverter(true, BehaviorOnNullValues.IGNORE);
     Schema.Type schemaType = schema.type();
     switch (schemaType) {
       case ARRAY:


### PR DESCRIPTION
Added a configuration to control how records with null values (e.g., tombstone messages) are handled, with three options: `IGNORE`, `DELETE`, and `FAIL`.

The `FAIL` option is identical to the previous behavior. The `DELETE` option generates a corresponding delete operation in the Elasticsearch system only when the record has an explicit key; if `key.ignore` is true, the keys will be generated and delete does not make sense. And finally the `IGNORE` option tells the connector to quietly skip over any records that have a null value.

Although the previous behavior is equivalent to `FAIL`, that cause the connector for fail and stop whenever it came across a null value. A more sensible default is `IGNORE`.

NOTE: This is an alternative PR with nearly the same changes as #163 but with fewer commits and without the other formatting/style changes.