### PR TITLE
CC-1385:  Enhance connector to use text type with ES 5+

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -15,7 +15,7 @@
     <!-- TODO: Undecided if this is too much -->
     <suppress
             checks="(ClassDataAbstractionCoupling)"
-            files="(BulkProcessor).java"
+            files="(BulkProcessor|JestElasticsearchClient).java"
     />
 
     <!-- TODO: Pass some parameters in common config object? -->

--- a/pom.xml
+++ b/pom.xml
@@ -39,16 +39,16 @@
     </scm>
 
     <properties>
+        <!--
         <es.version>6.0.0</es.version>
         <lucene.version>7.0.1</lucene.version>
-        <!--
         <es.version>5.0.0</es.version>
         <lucene.version>6.2.0</lucene.version>
+        -->
         <es.version>2.4.1</es.version>
         <lucene.version>5.5.2</lucene.version>
-        -->
         <hamcrest.version>1.3</hamcrest.version>
-        <jest.version>5.3.3</jest.version>
+        <jest.version>2.4.0</jest.version>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
     </properties>
 
@@ -113,7 +113,6 @@
             <scope>test</scope>
         </dependency>
         <!-- For ES 2.x -->
-        <!--
         <dependency>
             <groupId>org.elasticsearch</groupId>
             <artifactId>elasticsearch</artifactId>
@@ -121,7 +120,8 @@
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>
-        -->
+        <!-- For ES 5.x (requires Java 8) -->
+        <!--
         <dependency>
             <groupId>org.elasticsearch.test</groupId>
             <artifactId>framework</artifactId>
@@ -129,14 +129,15 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.elasticsearch</groupId>
-            <artifactId>elasticsearch</artifactId>
+            <groupId>org.elasticsearch.plugin</groupId>
+            <artifactId>transport-netty4-client</artifactId>
             <version>${es.version}</version>
             <scope>test</scope>
         </dependency>
+        -->
         <dependency>
-            <groupId>org.elasticsearch.plugin</groupId>
-            <artifactId>transport-netty4-client</artifactId>
+            <groupId>org.elasticsearch</groupId>
+            <artifactId>elasticsearch</artifactId>
             <version>${es.version}</version>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -39,11 +39,16 @@
     </scm>
 
     <properties>
+        <es.version>6.0.0</es.version>
+        <lucene.version>7.0.1</lucene.version>
+        <!--
+        <es.version>5.0.0</es.version>
+        <lucene.version>6.2.0</lucene.version>
         <es.version>2.4.1</es.version>
         <lucene.version>5.5.2</lucene.version>
-        <jna.version>4.2.1</jna.version>
-        <hamcrest.version>2.0.0.0</hamcrest.version>
-        <jest.version>2.0.0</jest.version>
+        -->
+        <hamcrest.version>1.3</hamcrest.version>
+        <jest.version>5.3.3</jest.version>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
     </properties>
 
@@ -72,14 +77,8 @@
             <version>${jest.version}</version>
         </dependency>
         <dependency>
-            <groupId>net.java.dev.jna</groupId>
-            <artifactId>jna</artifactId>
-            <version>${jna.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-junit</artifactId>
+            <artifactId>hamcrest-all</artifactId>
             <version>${hamcrest.version}</version>
             <scope>test</scope>
         </dependency>
@@ -102,15 +101,42 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.7</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.7</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- For ES 2.x -->
+        <!--
+        <dependency>
             <groupId>org.elasticsearch</groupId>
             <artifactId>elasticsearch</artifactId>
             <version>${es.version}</version>
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>
+        -->
+        <dependency>
+            <groupId>org.elasticsearch.test</groupId>
+            <artifactId>framework</artifactId>
+            <version>${es.version}</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.elasticsearch</groupId>
             <artifactId>elasticsearch</artifactId>
+            <version>${es.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.elasticsearch.plugin</groupId>
+            <artifactId>transport-netty4-client</artifactId>
             <version>${es.version}</version>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -39,15 +39,10 @@
     </scm>
 
     <properties>
-        <!--
-        <es.version>6.0.0</es.version>
-        <lucene.version>7.0.1</lucene.version>
-        <es.version>5.0.0</es.version>
-        <lucene.version>6.2.0</lucene.version>
-        -->
         <es.version>2.4.1</es.version>
         <lucene.version>5.5.2</lucene.version>
         <hamcrest.version>1.3</hamcrest.version>
+        <mockito.version>2.13.0</mockito.version>
         <jest.version>2.4.0</jest.version>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
     </properties>
@@ -83,6 +78,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>
@@ -100,7 +101,6 @@
             <version>${lucene.version}</version>
             <scope>test</scope>
         </dependency>
-        <!-- For ES 2.x -->
         <dependency>
             <groupId>org.elasticsearch</groupId>
             <artifactId>elasticsearch</artifactId>
@@ -108,33 +108,6 @@
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>
-        <!-- For ES 5.x (requires Java 8) -->
-        <!--
-        <dependency>
-            <groupId>org.elasticsearch.test</groupId>
-            <artifactId>framework</artifactId>
-            <version>${es.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.elasticsearch.plugin</groupId>
-            <artifactId>transport-netty4-client</artifactId>
-            <version>${es.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-            <version>2.7</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>2.7</version>
-            <scope>test</scope>
-        </dependency>
-        -->
         <dependency>
             <groupId>org.elasticsearch</groupId>
             <artifactId>elasticsearch</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -100,18 +100,6 @@
             <version>${lucene.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-            <version>2.7</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>2.7</version>
-            <scope>test</scope>
-        </dependency>
         <!-- For ES 2.x -->
         <dependency>
             <groupId>org.elasticsearch</groupId>
@@ -132,6 +120,18 @@
             <groupId>org.elasticsearch.plugin</groupId>
             <artifactId>transport-netty4-client</artifactId>
             <version>${es.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.7</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.7</version>
             <scope>test</scope>
         </dependency>
         -->

--- a/src/main/java/io/confluent/connect/elasticsearch/BulkIndexingClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/BulkIndexingClient.java
@@ -16,82 +16,29 @@
 
 package io.confluent.connect.elasticsearch;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import io.confluent.connect.elasticsearch.bulk.BulkClient;
+import io.confluent.connect.elasticsearch.bulk.BulkRequest;
+import io.confluent.connect.elasticsearch.bulk.BulkResponse;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 
-import io.confluent.connect.elasticsearch.bulk.BulkClient;
-import io.confluent.connect.elasticsearch.bulk.BulkResponse;
-import io.searchbox.client.JestClient;
-import io.searchbox.core.Bulk;
-import io.searchbox.core.BulkResult;
+public class BulkIndexingClient implements BulkClient<IndexableRecord, BulkRequest> {
 
-public class BulkIndexingClient implements BulkClient<IndexableRecord, Bulk> {
+  private final ElasticsearchClient client;
 
-  private static final Logger LOG = LoggerFactory.getLogger(BulkIndexingClient.class);
-
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-
-  private final JestClient client;
-
-  public BulkIndexingClient(JestClient client) {
+  public BulkIndexingClient(ElasticsearchClient client) {
     this.client = client;
   }
 
   @Override
-  public Bulk bulkRequest(List<IndexableRecord> batch) {
-    final Bulk.Builder builder = new Bulk.Builder();
-    for (IndexableRecord record : batch) {
-      builder.addAction(record.toBulkableAction());
-    }
-    return builder.build();
+  public BulkRequest bulkRequest(List<IndexableRecord> batch) {
+    return client.createBulkRequest(batch);
   }
 
   @Override
-  public BulkResponse execute(Bulk bulk) throws IOException {
-    final BulkResult result = client.execute(bulk);
-
-    if (result.isSucceeded()) {
-      return BulkResponse.success();
-    }
-
-    boolean retriable = true;
-
-    final List<Key> versionConflicts = new ArrayList<>();
-    final List<String> errors = new ArrayList<>();
-
-    for (BulkResult.BulkResultItem item : result.getItems()) {
-      if (item.error != null) {
-        final ObjectNode parsedError = (ObjectNode) OBJECT_MAPPER.readTree(item.error);
-        final String errorType = parsedError.get("type").asText("");
-        if ("version_conflict_engine_exception".equals(errorType)) {
-          versionConflicts.add(new Key(item.index, item.type, item.id));
-        } else if ("mapper_parse_exception".equals(errorType)) {
-          retriable = false;
-          errors.add(item.error);
-        } else {
-          errors.add(item.error);
-        }
-      }
-    }
-
-    if (!versionConflicts.isEmpty()) {
-      LOG.debug("Ignoring version conflicts for items: {}", versionConflicts);
-      if (errors.isEmpty()) {
-        // The only errors were version conflicts
-        return BulkResponse.success();
-      }
-    }
-
-    final String errorInfo = errors.isEmpty() ? result.getErrorMessage() : errors.toString();
-
-    return BulkResponse.failure(retriable, errorInfo);
+  public BulkResponse execute(BulkRequest bulk) throws IOException {
+    return client.executeBulk(bulk);
   }
 
 }

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ **/
+
+package io.confluent.connect.elasticsearch;
+
+import com.google.gson.JsonObject;
+import io.confluent.connect.elasticsearch.bulk.BulkRequest;
+import io.confluent.connect.elasticsearch.bulk.BulkResponse;
+import org.apache.kafka.connect.data.Schema;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+
+public interface ElasticsearchClient {
+
+  enum Version {
+    ONE, TWO, FIVE, SIX
+  }
+
+  /**
+   * Gets the Elasticsearch version.
+   *
+   * @return the version
+   */
+  Version getVersion();
+
+  /**
+   * Creates indices.
+   *
+   * @param indices the set of index names to create
+   */
+  void createIndices(Set<String> indices);
+
+  /**
+   * Creates an explicit mapping.
+   *
+   * @param index the index to write
+   * @param type the type for which to create the mapping
+   * @param schema the schema used to infer the mapping
+   * @throws IOException from underlying client
+   */
+  void createMapping(String index, String type, Schema schema) throws IOException;
+
+  /**
+   * Gets the JSON mapping for the given index and type. Returns {@code null} if it does not exist.
+   *
+   * @param index the index
+   * @param type the type
+   * @throws IOException from underlying client
+   */
+  JsonObject getMapping(String index, String type) throws IOException;
+
+  /**
+   * Creates a bulk request for the list of {@link IndexableRecord} records.
+   *
+   * @param batch the list of records
+   * @return the bulk request
+   */
+  BulkRequest createBulkRequest(List<IndexableRecord> batch);
+
+  /**
+   * Executes a bulk action.
+   *
+   * @param bulk the bulk request
+   * @return the bulk response
+   */
+  BulkResponse executeBulk(BulkRequest bulk) throws IOException;
+
+  /**
+   * Executes a search.
+   *
+   * @param query the search query
+   * @param index the index to search
+   * @param type the type to search
+   * @return the search result
+   */
+  JsonObject search(String query, String index, String type) throws IOException;
+
+  /**
+   * Shuts down the client.
+   */
+  void shutdown();
+}

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
@@ -25,23 +25,23 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 
-public interface ElasticsearchClient {
+public interface ElasticsearchClient extends AutoCloseable {
 
   enum Version {
-    ONE, TWO, FIVE, SIX
+    ES_V1, ES_V2, ES_V5, ES_V6
   }
 
   /**
    * Gets the Elasticsearch version.
    *
-   * @return the version
+   * @return the version, not null
    */
   Version getVersion();
 
   /**
    * Creates indices.
    *
-   * @param indices the set of index names to create
+   * @param indices the set of index names to create, not null
    */
   void createIndices(Set<String> indices);
 
@@ -51,7 +51,7 @@ public interface ElasticsearchClient {
    * @param index the index to write
    * @param type the type for which to create the mapping
    * @param schema the schema used to infer the mapping
-   * @throws IOException from underlying client
+   * @throws IOException if the client cannot execute the request
    */
   void createMapping(String index, String type, Schema schema) throws IOException;
 
@@ -60,7 +60,7 @@ public interface ElasticsearchClient {
    *
    * @param index the index
    * @param type the type
-   * @throws IOException from underlying client
+   * @throws IOException if the client cannot execute the request
    */
   JsonObject getMapping(String index, String type) throws IOException;
 
@@ -77,6 +77,7 @@ public interface ElasticsearchClient {
    *
    * @param bulk the bulk request
    * @return the bulk response
+   * @throws IOException if the client cannot execute the request
    */
   BulkResponse executeBulk(BulkRequest bulk) throws IOException;
 
@@ -87,11 +88,12 @@ public interface ElasticsearchClient {
    * @param index the index to search
    * @param type the type to search
    * @return the search result
+   * @throws IOException if the client cannot execute the request
    */
   JsonObject search(String query, String index, String type) throws IOException;
 
   /**
    * Shuts down the client.
    */
-  void shutdown();
+  void close();
 }

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConstants.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConstants.java
@@ -16,11 +16,6 @@
 
 package io.confluent.connect.elasticsearch;
 
-import org.apache.kafka.connect.data.Schema.Type;
-
-import java.util.HashMap;
-import java.util.Map;
-
 public class ElasticsearchSinkConnectorConstants {
   public static final String MAP_KEY = "key";
   public static final String MAP_VALUE = "value";
@@ -34,19 +29,6 @@ public class ElasticsearchSinkConnectorConstants {
   public static final String FLOAT_TYPE = "float";
   public static final String DOUBLE_TYPE = "double";
   public static final String STRING_TYPE = "string";
+  public static final String TEXT_TYPE = "text";
   public static final String DATE_TYPE = "date";
-
-  static final Map<Type, String> TYPES = new HashMap<>();
-
-  static {
-    TYPES.put(Type.BOOLEAN, BOOLEAN_TYPE);
-    TYPES.put(Type.INT8, BYTE_TYPE);
-    TYPES.put(Type.INT16, SHORT_TYPE);
-    TYPES.put(Type.INT32, INTEGER_TYPE);
-    TYPES.put(Type.INT64, LONG_TYPE);
-    TYPES.put(Type.FLOAT32, FLOAT_TYPE);
-    TYPES.put(Type.FLOAT64, DOUBLE_TYPE);
-    TYPES.put(Type.STRING, STRING_TYPE);
-    TYPES.put(Type.BYTES, BINARY_TYPE);
-  }
 }

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConstants.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConstants.java
@@ -30,5 +30,6 @@ public class ElasticsearchSinkConnectorConstants {
   public static final String DOUBLE_TYPE = "double";
   public static final String STRING_TYPE = "string";
   public static final String TEXT_TYPE = "text";
+  public static final String KEYWORD_TYPE = "keyword";
   public static final String DATE_TYPE = "date";
 }

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -56,47 +56,47 @@ public class ElasticsearchSinkTask extends SinkTask {
       log.info("Starting ElasticsearchSinkTask.");
 
       ElasticsearchSinkConnectorConfig config = new ElasticsearchSinkConnectorConfig(props);
-      final String type = config.getString(ElasticsearchSinkConnectorConfig.TYPE_NAME_CONFIG);
-      final boolean ignoreKey =
+      String type = config.getString(ElasticsearchSinkConnectorConfig.TYPE_NAME_CONFIG);
+      boolean ignoreKey =
           config.getBoolean(ElasticsearchSinkConnectorConfig.KEY_IGNORE_CONFIG);
-      final boolean ignoreSchema =
+      boolean ignoreSchema =
           config.getBoolean(ElasticsearchSinkConnectorConfig.SCHEMA_IGNORE_CONFIG);
-      final boolean useCompactMapEntries =
+      boolean useCompactMapEntries =
           config.getBoolean(ElasticsearchSinkConnectorConfig.COMPACT_MAP_ENTRIES_CONFIG);
 
 
-      final Map<String, String> topicToIndexMap =
+      Map<String, String> topicToIndexMap =
           parseMapConfig(config.getList(ElasticsearchSinkConnectorConfig.TOPIC_INDEX_MAP_CONFIG));
-      final Set<String> topicIgnoreKey =
+      Set<String> topicIgnoreKey =
           new HashSet<>(config.getList(ElasticsearchSinkConnectorConfig.TOPIC_KEY_IGNORE_CONFIG));
-      final Set<String> topicIgnoreSchema = new HashSet<>(
+      Set<String> topicIgnoreSchema = new HashSet<>(
           config.getList(ElasticsearchSinkConnectorConfig.TOPIC_SCHEMA_IGNORE_CONFIG)
       );
 
-      final long flushTimeoutMs =
+      long flushTimeoutMs =
           config.getLong(ElasticsearchSinkConnectorConfig.FLUSH_TIMEOUT_MS_CONFIG);
-      final int maxBufferedRecords =
+      int maxBufferedRecords =
           config.getInt(ElasticsearchSinkConnectorConfig.MAX_BUFFERED_RECORDS_CONFIG);
-      final int batchSize =
+      int batchSize =
           config.getInt(ElasticsearchSinkConnectorConfig.BATCH_SIZE_CONFIG);
-      final long lingerMs =
+      long lingerMs =
           config.getLong(ElasticsearchSinkConnectorConfig.LINGER_MS_CONFIG);
-      final int maxInFlightRequests =
+      int maxInFlightRequests =
           config.getInt(ElasticsearchSinkConnectorConfig.MAX_IN_FLIGHT_REQUESTS_CONFIG);
-      final long retryBackoffMs =
+      long retryBackoffMs =
           config.getLong(ElasticsearchSinkConnectorConfig.RETRY_BACKOFF_MS_CONFIG);
-      final int maxRetry =
+      int maxRetry =
           config.getInt(ElasticsearchSinkConnectorConfig.MAX_RETRIES_CONFIG);
-      final boolean dropInvalidMessage =
+      boolean dropInvalidMessage =
           config.getBoolean(ElasticsearchSinkConnectorConfig.DROP_INVALID_MESSAGE_CONFIG);
 
-      final DataConverter.BehaviorOnNullValues behaviorOnNullValues =
+      DataConverter.BehaviorOnNullValues behaviorOnNullValues =
           DataConverter.BehaviorOnNullValues.forValue(
               config.getString(ElasticsearchSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG)
           );
 
       // Calculate the maximum possible backoff time ...
-      final long maxRetryBackoffMs =
+      long maxRetryBackoffMs =
           RetryUtil.computeRetryWaitTimeInMillis(maxRetry, retryBackoffMs);
       if (maxRetryBackoffMs > RetryUtil.MAX_RETRY_TIME_MS) {
         log.warn("This connector uses exponential backoff with jitter for retries, "
@@ -173,7 +173,7 @@ public class ElasticsearchSinkTask extends SinkTask {
       writer.stop();
     }
     if (client != null) {
-      client.shutdown();
+      client.close();
     }
   }
 

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -102,9 +102,9 @@ public class ElasticsearchSinkTask extends SinkTask {
         log.warn("This connector uses exponential backoff with jitter for retries, "
                 + "and using '{}={}' and '{}={}' results in an impractical but possible maximum "
                 + "backoff time greater than {} hours.",
-                ElasticsearchSinkConnectorConfig.MAX_RETRIES_CONFIG, maxRetry,
-                ElasticsearchSinkConnectorConfig.RETRY_BACKOFF_MS_CONFIG, retryBackoffMs,
-                TimeUnit.MILLISECONDS.toHours(maxRetryBackoffMs));
+            ElasticsearchSinkConnectorConfig.MAX_RETRIES_CONFIG, maxRetry,
+            ElasticsearchSinkConnectorConfig.RETRY_BACKOFF_MS_CONFIG, retryBackoffMs,
+            TimeUnit.MILLISECONDS.toHours(maxRetryBackoffMs));
       }
 
       if (client != null) {
@@ -179,7 +179,7 @@ public class ElasticsearchSinkTask extends SinkTask {
 
   private Map<String, String> parseMapConfig(List<String> values) {
     Map<String, String> map = new HashMap<>();
-    for (String value: values) {
+    for (String value : values) {
       String[] parts = value.split(":");
       String topic = parts[0];
       String type = parts[1];

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
@@ -314,6 +314,9 @@ public class ElasticsearchWriter {
   }
 
   public void createIndicesForTopics(Set<String> assignedTopics) {
+    if (assignedTopics == null) {
+      throw new NullPointerException();
+    }
     client.createIndices(indicesForTopics(assignedTopics));
   }
 

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
@@ -264,18 +264,18 @@ public class ElasticsearchWriter {
   }
 
   private void tryWriteRecord(
-          SinkRecord sinkRecord,
-          String index,
-          boolean ignoreKey,
-          boolean ignoreSchema) {
+      SinkRecord sinkRecord,
+      String index,
+      boolean ignoreKey,
+      boolean ignoreSchema) {
 
     try {
       IndexableRecord record = converter.convertRecord(
-              sinkRecord,
-              index,
-              type,
-              ignoreKey,
-              ignoreSchema);
+          sinkRecord,
+          index,
+          type,
+          ignoreKey,
+          ignoreSchema);
       if (record != null) {
         bulkProcessor.add(record, flushTimeoutMs);
       }

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
@@ -16,6 +16,7 @@
 
 package io.confluent.connect.elasticsearch;
 
+import io.confluent.connect.elasticsearch.bulk.BulkProcessor;
 import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkRecord;
@@ -23,6 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+
 import java.util.Collections;
 import java.util.Collection;
 import java.util.HashMap;
@@ -31,19 +33,12 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-import io.confluent.connect.elasticsearch.bulk.BulkProcessor;
-import io.searchbox.action.Action;
-import io.searchbox.client.JestClient;
-import io.searchbox.client.JestResult;
-import io.searchbox.indices.CreateIndex;
-import io.searchbox.indices.IndicesExists;
-
 import static io.confluent.connect.elasticsearch.DataConverter.BehaviorOnNullValues;
 
 public class ElasticsearchWriter {
   private static final Logger log = LoggerFactory.getLogger(ElasticsearchWriter.class);
 
-  private final JestClient client;
+  private final ElasticsearchClient client;
   private final String type;
   private final boolean ignoreKey;
   private final Set<String> ignoreKeyTopics;
@@ -59,7 +54,7 @@ public class ElasticsearchWriter {
   private final Set<String> existingMappings;
 
   ElasticsearchWriter(
-      JestClient client,
+      ElasticsearchClient client,
       String type,
       boolean useCompactMapEntries,
       boolean ignoreKey,
@@ -104,7 +99,7 @@ public class ElasticsearchWriter {
   }
 
   public static class Builder {
-    private final JestClient client;
+    private final ElasticsearchClient client;
     private String type;
     private boolean useCompactMapEntries = true;
     private boolean ignoreKey = false;
@@ -122,7 +117,7 @@ public class ElasticsearchWriter {
     private boolean dropInvalidMessage;
     private BehaviorOnNullValues behaviorOnNullValues = BehaviorOnNullValues.DEFAULT;
 
-    public Builder(JestClient client) {
+    public Builder(ElasticsearchClient client) {
       this.client = client;
     }
 
@@ -318,31 +313,8 @@ public class ElasticsearchWriter {
     bulkProcessor.awaitStop(flushTimeoutMs);
   }
 
-  private boolean indexExists(String index) {
-    Action action = new IndicesExists.Builder(index).build();
-    try {
-      JestResult result = client.execute(action);
-      return result.isSucceeded();
-    } catch (IOException e) {
-      throw new ConnectException(e);
-    }
-  }
-
   public void createIndicesForTopics(Set<String> assignedTopics) {
-    for (String index : indicesForTopics(assignedTopics)) {
-      if (!indexExists(index)) {
-        CreateIndex createIndex = new CreateIndex.Builder(index).build();
-        try {
-          JestResult result = client.execute(createIndex);
-          if (!result.isSucceeded()) {
-            String msg = result.getErrorMessage() != null ? ": " + result.getErrorMessage() : "";
-            throw new ConnectException("Could not create index '" + index + "'" + msg);
-          }
-        } catch (IOException e) {
-          throw new ConnectException(e);
-        }
-      }
-    }
+    client.createIndices(indicesForTopics(assignedTopics));
   }
 
   private Set<String> indicesForTopics(Set<String> assignedTopics) {

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
@@ -24,7 +24,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-
 import java.util.Collections;
 import java.util.Collection;
 import java.util.HashMap;
@@ -314,9 +313,7 @@ public class ElasticsearchWriter {
   }
 
   public void createIndicesForTopics(Set<String> assignedTopics) {
-    if (assignedTopics == null) {
-      throw new NullPointerException();
-    }
+    Objects.requireNonNull(assignedTopics);
     client.createIndices(indicesForTopics(assignedTopics));
   }
 

--- a/src/main/java/io/confluent/connect/elasticsearch/IndexableRecord.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/IndexableRecord.java
@@ -16,10 +16,6 @@
 
 package io.confluent.connect.elasticsearch;
 
-import io.searchbox.action.BulkableAction;
-import io.searchbox.core.Delete;
-import io.searchbox.core.Index;
-
 import java.util.Objects;
 
 public class IndexableRecord {
@@ -32,31 +28,6 @@ public class IndexableRecord {
     this.key = key;
     this.version = version;
     this.payload = payload;
-  }
-
-  public BulkableAction toBulkableAction() {
-    // If payload is null, the record was a tombstone and we should delete from the index.
-    return payload != null ? toIndexRequest() : toDeleteRequest();
-  }
-
-  public Delete toDeleteRequest() {
-    Delete.Builder req = new Delete.Builder(key.id)
-        .index(key.index)
-        .type(key.type);
-
-    // TODO: Should version information be set here?
-    return req.build();
-  }
-
-  public Index toIndexRequest() {
-    Index.Builder req = new Index.Builder(payload)
-        .index(key.index)
-        .type(key.type)
-        .id(key.id);
-    if (version != null) {
-      req.setParameter("version_type", "external").setParameter("version", version);
-    }
-    return req.build();
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/elasticsearch/IndexableRecord.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/IndexableRecord.java
@@ -40,8 +40,8 @@ public class IndexableRecord {
     }
     IndexableRecord that = (IndexableRecord) o;
     return Objects.equals(key, that.key)
-           && Objects.equals(payload, that.payload)
-           && Objects.equals(version, that.version);
+        && Objects.equals(payload, that.payload)
+        && Objects.equals(version, that.version);
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/elasticsearch/Mapping.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/Mapping.java
@@ -16,12 +16,11 @@
 
 package io.confluent.connect.elasticsearch;
 
-import com.google.gson.JsonObject;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-
+import com.google.common.annotations.VisibleForTesting;
+import com.google.gson.JsonObject;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Field;
@@ -30,23 +29,24 @@ import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.DataException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
-import io.searchbox.client.JestClient;
-import io.searchbox.client.JestResult;
-import io.searchbox.indices.mapping.GetMapping;
-import io.searchbox.indices.mapping.PutMapping;
-
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConstants.BINARY_TYPE;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConstants.BOOLEAN_TYPE;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConstants.BYTE_TYPE;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConstants.DOUBLE_TYPE;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConstants.FLOAT_TYPE;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConstants.INTEGER_TYPE;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConstants.LONG_TYPE;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConstants.MAP_KEY;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConstants.MAP_VALUE;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConstants.SHORT_TYPE;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConstants.STRING_TYPE;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConstants.TEXT_TYPE;
 
 public class Mapping {
-
-  private static final Logger log = LoggerFactory.getLogger(Mapping.class);
 
   /**
    * Create an explicit mapping.
@@ -56,43 +56,27 @@ public class Mapping {
    * @param schema The schema used to infer mapping.
    * @throws IOException from underlying JestClient
    */
-  public static void createMapping(JestClient client, String index, String type, Schema schema)
+  public static void createMapping(ElasticsearchClient client,
+                                   String index,
+                                   String type,
+                                   Schema schema)
       throws IOException {
-    ObjectNode obj = JsonNodeFactory.instance.objectNode();
-    obj.set(type, inferMapping(schema));
-    PutMapping putMapping = new PutMapping.Builder(index, type, obj.toString()).build();
-    JestResult result = client.execute(putMapping);
-    if (!result.isSucceeded()) {
-      throw new ConnectException(
-          "Cannot create mapping " + obj + " -- " + result.getErrorMessage()
-      );
-    }
+    client.createMapping(index, type, schema);
   }
 
   /**
    * Get the JSON mapping for given index and type. Returns {@code null} if it does not exist.
    */
-  public static JsonObject getMapping(JestClient client, String index, String type)
+  public static JsonObject getMapping(ElasticsearchClient client, String index, String type)
       throws IOException {
-    final JestResult result = client.execute(
-        new GetMapping.Builder().addIndex(index).addType(type).build()
-    );
-    final JsonObject indexRoot = result.getJsonObject().getAsJsonObject(index);
-    if (indexRoot == null) {
-      return null;
-    }
-    final JsonObject mappingsJson = indexRoot.getAsJsonObject("mappings");
-    if (mappingsJson == null) {
-      return  null;
-    }
-    return mappingsJson.getAsJsonObject(type);
+    return client.getMapping(index, type);
   }
 
   /**
    * Infer mapping from the provided schema.
    * @param schema The schema used to infer mapping.
    */
-  public static JsonNode inferMapping(Schema schema) {
+  public static JsonNode inferMapping(ElasticsearchClient client, Schema schema) {
     if (schema == null) {
       throw new DataException("Cannot infer mapping without schema.");
     }
@@ -108,21 +92,55 @@ public class Mapping {
     ObjectNode fields = JsonNodeFactory.instance.objectNode();
     switch (schemaType) {
       case ARRAY:
-        return inferMapping(schema.valueSchema());
+        return inferMapping(client, schema.valueSchema());
       case MAP:
         properties.set("properties", fields);
-        fields.set(MAP_KEY, inferMapping(schema.keySchema()));
-        fields.set(MAP_VALUE, inferMapping(schema.valueSchema()));
+        fields.set(MAP_KEY, inferMapping(client, schema.keySchema()));
+        fields.set(MAP_VALUE, inferMapping(client, schema.valueSchema()));
         return properties;
       case STRUCT:
         properties.set("properties", fields);
         for (Field field : schema.fields()) {
-          fields.set(field.name(), inferMapping(field.schema()));
+          fields.set(field.name(), inferMapping(client, field.schema()));
         }
         return properties;
       default:
-        String esType = ElasticsearchSinkConnectorConstants.TYPES.get(schemaType);
+        String esType = getElasticsearchType(client, schemaType);
         return inferPrimitive(esType, schema.defaultValue());
+    }
+  }
+
+  @VisibleForTesting
+  public static String getElasticsearchType(ElasticsearchClient client, Schema.Type schemaType) {
+    switch (schemaType) {
+      case BOOLEAN:
+        return BOOLEAN_TYPE;
+      case INT8:
+        return BYTE_TYPE;
+      case INT16:
+        return SHORT_TYPE;
+      case INT32:
+        return INTEGER_TYPE;
+      case INT64:
+        return LONG_TYPE;
+      case FLOAT32:
+        return FLOAT_TYPE;
+      case FLOAT64:
+        return DOUBLE_TYPE;
+      case STRING:
+        switch (client.getVersion()) {
+          case ONE:
+          case TWO:
+            return STRING_TYPE;
+          case FIVE:
+          case SIX:
+          default:
+            return TEXT_TYPE;
+        }
+      case BYTES:
+        return BINARY_TYPE;
+      default:
+        return null;
     }
   }
 
@@ -175,6 +193,7 @@ public class Mapping {
           defaultValueNode = JsonNodeFactory.instance.numberNode((double) defaultValue);
           break;
         case ElasticsearchSinkConnectorConstants.STRING_TYPE:
+        case ElasticsearchSinkConnectorConstants.TEXT_TYPE:
           defaultValueNode = JsonNodeFactory.instance.textNode((String) defaultValue);
           break;
         case ElasticsearchSinkConnectorConstants.BINARY_TYPE:

--- a/src/main/java/io/confluent/connect/elasticsearch/Mapping.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/Mapping.java
@@ -49,16 +49,19 @@ public class Mapping {
 
   /**
    * Create an explicit mapping.
+   *
    * @param client The client to connect to Elasticsearch.
-   * @param index The index to write to Elasticsearch.
-   * @param type The type to create mapping for.
+   * @param index  The index to write to Elasticsearch.
+   * @param type   The type to create mapping for.
    * @param schema The schema used to infer mapping.
    * @throws IOException from underlying JestClient
    */
-  public static void createMapping(ElasticsearchClient client,
-                                   String index,
-                                   String type,
-                                   Schema schema)
+  public static void createMapping(
+      ElasticsearchClient client,
+      String index,
+      String type,
+      Schema schema
+  )
       throws IOException {
     client.createMapping(index, type, schema);
   }
@@ -73,6 +76,7 @@ public class Mapping {
 
   /**
    * Infer mapping from the provided schema.
+   *
    * @param schema The schema used to infer mapping.
    */
   public static JsonNode inferMapping(ElasticsearchClient client, Schema schema) {

--- a/src/main/java/io/confluent/connect/elasticsearch/Mapping.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/Mapping.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2016 Confluent Inc.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -19,7 +19,6 @@ package io.confluent.connect.elasticsearch;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.JsonObject;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
@@ -110,8 +109,8 @@ public class Mapping {
     }
   }
 
-  @VisibleForTesting
-  public static String getElasticsearchType(ElasticsearchClient client, Schema.Type schemaType) {
+  // visible for testing
+  protected static String getElasticsearchType(ElasticsearchClient client, Schema.Type schemaType) {
     switch (schemaType) {
       case BOOLEAN:
         return BOOLEAN_TYPE;
@@ -129,11 +128,11 @@ public class Mapping {
         return DOUBLE_TYPE;
       case STRING:
         switch (client.getVersion()) {
-          case ONE:
-          case TWO:
+          case ES_V1:
+          case ES_V2:
             return STRING_TYPE;
-          case FIVE:
-          case SIX:
+          case ES_V5:
+          case ES_V6:
           default:
             return TEXT_TYPE;
         }

--- a/src/main/java/io/confluent/connect/elasticsearch/bulk/BulkRequest.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/bulk/BulkRequest.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ **/
+
+package io.confluent.connect.elasticsearch.bulk;
+
+public interface BulkRequest {
+}

--- a/src/main/java/io/confluent/connect/elasticsearch/bulk/BulkRequest.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/bulk/BulkRequest.java
@@ -16,5 +16,15 @@
 
 package io.confluent.connect.elasticsearch.bulk;
 
+
+import java.util.List;
+
+/**
+ * BulkRequest is a marker interface for use with
+ * {@link io.confluent.connect.elasticsearch.ElasticsearchClient#createBulkRequest(List)} and
+ * {@link io.confluent.connect.elasticsearch.ElasticsearchClient#executeBulk(BulkRequest)}.
+ * Implementations will typically hold state comprised of instances of classes that are
+ * specific to the client library.
+ */
 public interface BulkRequest {
 }

--- a/src/main/java/io/confluent/connect/elasticsearch/jest/JestBulkRequest.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/JestBulkRequest.java
@@ -21,7 +21,7 @@ import io.searchbox.core.Bulk;
 
 public class JestBulkRequest implements BulkRequest {
 
-  private Bulk bulk;
+  private final Bulk bulk;
 
   public JestBulkRequest(Bulk bulk) {
     this.bulk = bulk;

--- a/src/main/java/io/confluent/connect/elasticsearch/jest/JestBulkRequest.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/JestBulkRequest.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ **/
+
+package io.confluent.connect.elasticsearch.jest;
+
+import io.confluent.connect.elasticsearch.bulk.BulkRequest;
+import io.searchbox.core.Bulk;
+
+public class JestBulkRequest implements BulkRequest {
+
+  private Bulk bulk;
+
+  public JestBulkRequest(Bulk bulk) {
+    this.bulk = bulk;
+  }
+
+  public Bulk getBulk() {
+    return bulk;
+  }
+}

--- a/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
@@ -92,30 +92,30 @@ public class JestElasticsearchClient implements ElasticsearchClient {
     try {
       ElasticsearchSinkConnectorConfig config = new ElasticsearchSinkConnectorConfig(props);
       final int connTimeout = config.getInt(
-              ElasticsearchSinkConnectorConfig.CONNECTION_TIMEOUT_MS_CONFIG);
+          ElasticsearchSinkConnectorConfig.CONNECTION_TIMEOUT_MS_CONFIG);
       final int readTimeout = config.getInt(
-              ElasticsearchSinkConnectorConfig.READ_TIMEOUT_MS_CONFIG);
+          ElasticsearchSinkConnectorConfig.READ_TIMEOUT_MS_CONFIG);
 
       List<String> address =
-              config.getList(ElasticsearchSinkConnectorConfig.CONNECTION_URL_CONFIG);
+          config.getList(ElasticsearchSinkConnectorConfig.CONNECTION_URL_CONFIG);
       JestClientFactory factory = new JestClientFactory();
       factory.setHttpClientConfig(new HttpClientConfig.Builder(address)
-              .connTimeout(connTimeout)
-              .readTimeout(readTimeout)
-              .multiThreaded(true)
-              .build()
+          .connTimeout(connTimeout)
+          .readTimeout(readTimeout)
+          .multiThreaded(true)
+          .build()
       );
       this.client = factory.getObject();
       this.version = getServerVersion();
     } catch (IOException e) {
       throw new ConnectException(
-              "Couldn't start ElasticsearchSinkTask due to connection error:",
-              e
+          "Couldn't start ElasticsearchSinkTask due to connection error:",
+          e
       );
     } catch (ConfigException e) {
       throw new ConnectException(
-              "Couldn't start ElasticsearchSinkTask due to configuration error:",
-              e
+          "Couldn't start ElasticsearchSinkTask due to configuration error:",
+          e
       );
     }
   }
@@ -197,7 +197,7 @@ public class JestElasticsearchClient implements ElasticsearchClient {
     JestResult result = client.execute(putMapping);
     if (!result.isSucceeded()) {
       throw new ConnectException(
-              "Cannot create mapping " + obj + " -- " + result.getErrorMessage()
+          "Cannot create mapping " + obj + " -- " + result.getErrorMessage()
       );
     }
   }
@@ -207,7 +207,7 @@ public class JestElasticsearchClient implements ElasticsearchClient {
    */
   public JsonObject getMapping(String index, String type) throws IOException {
     final JestResult result = client.execute(
-            new GetMapping.Builder().addIndex(index).addType(type).build()
+        new GetMapping.Builder().addIndex(index).addType(type).build()
     );
     final JsonObject indexRoot = result.getJsonObject().getAsJsonObject(index);
     if (indexRoot == null) {
@@ -215,7 +215,7 @@ public class JestElasticsearchClient implements ElasticsearchClient {
     }
     final JsonObject mappingsJson = indexRoot.getAsJsonObject("mappings");
     if (mappingsJson == null) {
-      return  null;
+      return null;
     }
     return mappingsJson.getAsJsonObject(type);
   }

--- a/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
@@ -1,0 +1,317 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ **/
+
+package io.confluent.connect.elasticsearch.jest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.gson.JsonObject;
+import io.confluent.connect.elasticsearch.bulk.BulkRequest;
+import io.confluent.connect.elasticsearch.ElasticsearchClient;
+import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig;
+import io.confluent.connect.elasticsearch.IndexableRecord;
+import io.confluent.connect.elasticsearch.Key;
+import io.confluent.connect.elasticsearch.Mapping;
+import io.confluent.connect.elasticsearch.bulk.BulkResponse;
+import io.searchbox.action.Action;
+import io.searchbox.action.BulkableAction;
+import io.searchbox.client.JestClient;
+import io.searchbox.client.JestClientFactory;
+import io.searchbox.client.JestResult;
+import io.searchbox.client.config.HttpClientConfig;
+import io.searchbox.cluster.NodesInfo;
+import io.searchbox.core.Bulk;
+import io.searchbox.core.BulkResult;
+import io.searchbox.core.Delete;
+import io.searchbox.core.Index;
+import io.searchbox.core.Search;
+import io.searchbox.core.SearchResult;
+import io.searchbox.indices.CreateIndex;
+import io.searchbox.indices.IndicesExists;
+import io.searchbox.indices.mapping.GetMapping;
+import io.searchbox.indices.mapping.PutMapping;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class JestElasticsearchClient implements ElasticsearchClient {
+  private static final Logger LOG = LoggerFactory.getLogger(JestElasticsearchClient.class);
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private final JestClient client;
+  private final Version version;
+
+  @VisibleForTesting
+  public JestElasticsearchClient(String address) {
+    try {
+      JestClientFactory factory = new JestClientFactory();
+      factory.setHttpClientConfig(new HttpClientConfig.Builder(address)
+          .multiThreaded(true)
+          .build()
+      );
+      this.client = factory.getObject();
+      this.version = getServerVersion();
+    } catch (IOException e) {
+      throw new ConnectException(
+          "Couldn't start ElasticsearchSinkTask due to connection error:",
+          e
+      );
+    } catch (ConfigException e) {
+      throw new ConnectException(
+          "Couldn't start ElasticsearchSinkTask due to configuration error:",
+          e
+      );
+    }
+  }
+
+  public JestElasticsearchClient(Map<String, String> props) {
+    try {
+      ElasticsearchSinkConnectorConfig config = new ElasticsearchSinkConnectorConfig(props);
+      final int connTimeout = config.getInt(
+              ElasticsearchSinkConnectorConfig.CONNECTION_TIMEOUT_MS_CONFIG);
+      final int readTimeout = config.getInt(
+              ElasticsearchSinkConnectorConfig.READ_TIMEOUT_MS_CONFIG);
+
+      List<String> address =
+              config.getList(ElasticsearchSinkConnectorConfig.CONNECTION_URL_CONFIG);
+      JestClientFactory factory = new JestClientFactory();
+      factory.setHttpClientConfig(new HttpClientConfig.Builder(address)
+              .connTimeout(connTimeout)
+              .readTimeout(readTimeout)
+              .multiThreaded(true)
+              .build()
+      );
+      this.client = factory.getObject();
+      this.version = getServerVersion();
+    } catch (IOException e) {
+      throw new ConnectException(
+              "Couldn't start ElasticsearchSinkTask due to connection error:",
+              e
+      );
+    } catch (ConfigException e) {
+      throw new ConnectException(
+              "Couldn't start ElasticsearchSinkTask due to configuration error:",
+              e
+      );
+    }
+  }
+
+  private Version getServerVersion() throws IOException {
+    // Default to newest version for forward compatibility
+    Version defaultVersion = Version.SIX;
+
+    NodesInfo info = new NodesInfo.Builder().addCleanApiParameter("version").build();
+    JsonObject result = this.client.execute(info).getJsonObject();
+    if (result == null) {
+      LOG.warn("Couldn't get Elasticsearch version");
+      return defaultVersion;
+    }
+
+    JsonObject nodesRoot = result.get("nodes").getAsJsonObject();
+    if (nodesRoot == null || nodesRoot.entrySet().size() == 0) {
+      LOG.warn("Couldn't get Elasticsearch version");
+      return defaultVersion;
+    }
+
+    JsonObject nodeRoot = nodesRoot.entrySet().iterator().next().getValue().getAsJsonObject();
+    if (nodeRoot == null) {
+      LOG.warn("Couldn't get Elasticsearch version");
+      return defaultVersion;
+    }
+
+    String esVersion = nodeRoot.get("version").getAsString();
+    if (esVersion == null) {
+      LOG.warn("Couldn't get Elasticsearch version");
+      return defaultVersion;
+    } else if (esVersion.startsWith("1.")) {
+      return Version.ONE;
+    } else if (esVersion.startsWith("2.")) {
+      return Version.TWO;
+    } else if (esVersion.startsWith("5.")) {
+      return Version.FIVE;
+    } else if (esVersion.startsWith("6.")) {
+      return Version.SIX;
+    }
+    return defaultVersion;
+  }
+
+  public Version getVersion() {
+    return version;
+  }
+
+  private boolean indexExists(String index) {
+    Action action = new IndicesExists.Builder(index).build();
+    try {
+      JestResult result = client.execute(action);
+      return result.isSucceeded();
+    } catch (IOException e) {
+      throw new ConnectException(e);
+    }
+  }
+
+  public void createIndices(Set<String> indices) {
+    for (String index : indices) {
+      if (!indexExists(index)) {
+        CreateIndex createIndex = new CreateIndex.Builder(index).build();
+        try {
+          JestResult result = client.execute(createIndex);
+          if (!result.isSucceeded()) {
+            String msg = result.getErrorMessage() != null ? ": " + result.getErrorMessage() : "";
+            throw new ConnectException("Could not create index '" + index + "'" + msg);
+          }
+        } catch (IOException e) {
+          throw new ConnectException(e);
+        }
+      }
+    }
+  }
+
+  public void createMapping(String index, String type, Schema schema) throws IOException {
+    ObjectNode obj = JsonNodeFactory.instance.objectNode();
+    obj.set(type, Mapping.inferMapping(this, schema));
+    PutMapping putMapping = new PutMapping.Builder(index, type, obj.toString()).build();
+    JestResult result = client.execute(putMapping);
+    if (!result.isSucceeded()) {
+      throw new ConnectException(
+              "Cannot create mapping " + obj + " -- " + result.getErrorMessage()
+      );
+    }
+  }
+
+  /**
+   * Get the JSON mapping for given index and type. Returns {@code null} if it does not exist.
+   */
+  public JsonObject getMapping(String index, String type) throws IOException {
+    final JestResult result = client.execute(
+            new GetMapping.Builder().addIndex(index).addType(type).build()
+    );
+    final JsonObject indexRoot = result.getJsonObject().getAsJsonObject(index);
+    if (indexRoot == null) {
+      return null;
+    }
+    final JsonObject mappingsJson = indexRoot.getAsJsonObject("mappings");
+    if (mappingsJson == null) {
+      return  null;
+    }
+    return mappingsJson.getAsJsonObject(type);
+  }
+
+  public BulkRequest createBulkRequest(List<IndexableRecord> batch) {
+    final Bulk.Builder builder = new Bulk.Builder();
+    for (IndexableRecord record : batch) {
+      builder.addAction(toBulkableAction(record));
+    }
+    return new JestBulkRequest(builder.build());
+  }
+
+  private BulkableAction toBulkableAction(IndexableRecord record) {
+    // If payload is null, the record was a tombstone and we should delete from the index.
+    return record.payload != null ? toIndexRequest(record) : toDeleteRequest(record);
+  }
+
+  private Delete toDeleteRequest(IndexableRecord record) {
+    Delete.Builder req = new Delete.Builder(record.key.id)
+        .index(record.key.index)
+        .type(record.key.type);
+
+    // TODO: Should version information be set here?
+    return req.build();
+  }
+
+  private Index toIndexRequest(IndexableRecord record) {
+    Index.Builder req = new Index.Builder(record.payload)
+        .index(record.key.index)
+        .type(record.key.type)
+        .id(record.key.id);
+    if (record.version != null) {
+      req.setParameter("version_type", "external").setParameter("version", record.version);
+    }
+    return req.build();
+  }
+
+  public BulkResponse executeBulk(BulkRequest bulk) throws IOException {
+    final BulkResult result = client.execute(((JestBulkRequest) bulk).getBulk());
+
+    if (result.isSucceeded()) {
+      return BulkResponse.success();
+    }
+
+    boolean retriable = true;
+
+    final List<Key> versionConflicts = new ArrayList<>();
+    final List<String> errors = new ArrayList<>();
+
+    for (BulkResult.BulkResultItem item : result.getItems()) {
+      if (item.error != null) {
+        final ObjectNode parsedError = (ObjectNode) OBJECT_MAPPER.readTree(item.error);
+        final String errorType = parsedError.get("type").asText("");
+        if ("version_conflict_engine_exception".equals(errorType)) {
+          versionConflicts.add(new Key(item.index, item.type, item.id));
+        } else if ("mapper_parse_exception".equals(errorType)) {
+          retriable = false;
+          errors.add(item.error);
+        } else {
+          errors.add(item.error);
+        }
+      }
+    }
+
+    if (!versionConflicts.isEmpty()) {
+      LOG.debug("Ignoring version conflicts for items: {}", versionConflicts);
+      if (errors.isEmpty()) {
+        // The only errors were version conflicts
+        return BulkResponse.success();
+      }
+    }
+
+    final String errorInfo = errors.isEmpty() ? result.getErrorMessage() : errors.toString();
+
+    return BulkResponse.failure(retriable, errorInfo);
+  }
+
+  public JsonObject search(String query, String index, String type) throws IOException {
+    final Search.Builder search = new Search.Builder(query);
+    if (index != null) {
+      search.addIndex(index);
+    }
+    if (type != null) {
+      search.addType(type);
+    }
+
+    final SearchResult result = client.execute(search.build());
+
+    return result.getJsonObject();
+  }
+
+  public void shutdown() {
+    try {
+      client.close();
+    } catch (IOException e) {
+      LOG.warn("Could not close client");
+    }
+  }
+}

--- a/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
@@ -308,10 +308,6 @@ public class JestElasticsearchClient implements ElasticsearchClient {
   }
 
   public void shutdown() {
-    try {
-      client.close();
-    } catch (IOException e) {
-      LOG.warn("Could not close client");
-    }
+    client.shutdownClient();
   }
 }

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTestBase.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTestBase.java
@@ -33,7 +33,6 @@ import org.junit.After;
 import org.junit.Before;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTestBase.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTestBase.java
@@ -66,7 +66,7 @@ public class ElasticsearchSinkTestBase extends ESIntegTestCase {
   public void tearDown() throws Exception {
     super.tearDown();
     if (client != null) {
-      client.shutdown();
+      client.close();
     }
     client = null;
   }

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTestBase.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTestBase.java
@@ -25,12 +25,10 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.sink.SinkRecord;
-import org.elasticsearch.common.network.NetworkModule;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.http.HttpTransportSettings;
-import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.node.Node;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.transport.Netty4Plugin;
 import org.junit.After;
 import org.junit.Before;
 
@@ -134,6 +132,19 @@ public class ElasticsearchSinkTestBase extends ESIntegTestCase {
     }
   }
 
+  /* For ES 2.x */
+  @Override
+  protected Settings nodeSettings(int nodeOrdinal) {
+    return Settings.settingsBuilder()
+        .put(super.nodeSettings(nodeOrdinal))
+        .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
+        .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 1)
+        .put(Node.HTTP_ENABLED, true)
+        .build();
+  }
+
+  /* For ES 5.x (requires Java 8) */
+  /*
   @Override
   protected Settings nodeSettings(int nodeOrdinal) {
     int randomPort = randomIntBetween(49152, 65525);
@@ -152,5 +163,6 @@ public class ElasticsearchSinkTestBase extends ESIntegTestCase {
     al.add(Netty4Plugin.class);
     return al;
   }
+  */
 
 }

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchWriterTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchWriterTest.java
@@ -42,7 +42,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import io.searchbox.client.JestClient;
 import org.junit.rules.ExpectedException;
 
 import static io.confluent.connect.elasticsearch.DataConverter.BehaviorOnNullValues;
@@ -472,20 +471,20 @@ public class ElasticsearchWriterTest extends ElasticsearchSinkTestBase {
     return records;
   }
 
-  private ElasticsearchWriter initWriter(JestClient client) {
+  private ElasticsearchWriter initWriter(ElasticsearchClient client) {
     return initWriter(client, false, BehaviorOnNullValues.IGNORE);
   }
 
-  private ElasticsearchWriter initWriter(JestClient client, boolean dropInvalidMessage) {
+  private ElasticsearchWriter initWriter(ElasticsearchClient client, boolean dropInvalidMessage) {
     return initWriter(client, dropInvalidMessage, BehaviorOnNullValues.IGNORE);
   }
 
-  private ElasticsearchWriter initWriter(JestClient client, BehaviorOnNullValues behavior) {
+  private ElasticsearchWriter initWriter(ElasticsearchClient client, BehaviorOnNullValues behavior) {
     return initWriter(client, false, behavior);
   }
 
   private ElasticsearchWriter initWriter(
-      JestClient client,
+      ElasticsearchClient client,
       boolean dropInvalidMessage,
       BehaviorOnNullValues behavior) {
     return initWriter(
@@ -499,7 +498,7 @@ public class ElasticsearchWriterTest extends ElasticsearchSinkTestBase {
   }
 
   private ElasticsearchWriter initWriter(
-      JestClient client,
+      ElasticsearchClient client,
       Set<String> ignoreKeyTopics,
       Set<String> ignoreSchemaTopics,
       Map<String, String> topicToIndexMap,

--- a/src/test/java/io/confluent/connect/elasticsearch/MappingTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/MappingTest.java
@@ -130,7 +130,7 @@ public class MappingTest extends ElasticsearchSinkTestBase {
         }
         break;
       default:
-        assertEquals("\"" + ElasticsearchSinkConnectorConstants.TYPES.get(schemaType) + "\"", type.toString());
+        assertEquals("\"" + Mapping.getElasticsearchType(client, schemaType) + "\"", type.toString());
     }
   }
 }

--- a/src/test/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClientTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClientTest.java
@@ -1,0 +1,287 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ **/
+
+package io.confluent.connect.elasticsearch.jest;
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import io.confluent.connect.elasticsearch.ElasticsearchClient;
+import io.confluent.connect.elasticsearch.IndexableRecord;
+import io.confluent.connect.elasticsearch.Key;
+import io.confluent.connect.elasticsearch.Mapping;
+import io.confluent.connect.elasticsearch.bulk.BulkRequest;
+import io.searchbox.client.JestClient;
+import io.searchbox.client.JestResult;
+import io.searchbox.cluster.NodesInfo;
+import io.searchbox.core.BulkResult;
+import io.searchbox.core.Search;
+import io.searchbox.core.SearchResult;
+import io.searchbox.indices.CreateIndex;
+import io.searchbox.indices.IndicesExists;
+import io.searchbox.indices.mapping.GetMapping;
+import io.searchbox.indices.mapping.PutMapping;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentMatcher;
+import org.mockito.InOrder;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.equalTo;
+
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class JestElasticsearchClientTest {
+
+  private static final String INDEX = "index";
+  private static final String KEY = "key";
+  private static final String TYPE = "type";
+  private static final String QUERY = "query";
+
+  private JestClient jestClient;
+  private NodesInfo info;
+
+  @Before
+  public void setUp() throws Exception {
+    jestClient = mock(JestClient.class);
+    info = new NodesInfo.Builder().addCleanApiParameter("version").build();
+    JsonObject nodeRoot = new JsonObject();
+    nodeRoot.addProperty("version", "1.0");
+    JsonObject nodesRoot = new JsonObject();
+    nodesRoot.add("localhost", nodeRoot);
+    JsonObject nodesInfo = new JsonObject();
+    nodesInfo.add("nodes", nodesRoot);
+    JestResult result = new JestResult(new Gson());
+    result.setJsonObject(nodesInfo);
+    when(jestClient.execute(info)).thenReturn(result);
+  }
+
+  @Test
+  public void getsVersion() {
+    JestElasticsearchClient client = new JestElasticsearchClient(jestClient);
+    assertThat(client.getVersion(), is(equalTo(ElasticsearchClient.Version.ES_V1)));
+  }
+
+  @Test
+  public void createsIndices() throws Exception {
+    JestElasticsearchClient client = new JestElasticsearchClient(jestClient);
+    JestResult failure = new JestResult(new Gson());
+    failure.setSucceeded(false);
+    JestResult success = new JestResult(new Gson());
+    success.setSucceeded(true);
+    IndicesExists indicesExists = new IndicesExists.Builder(INDEX).build();
+    when(jestClient.execute(indicesExists)).thenReturn(failure);
+    when(jestClient.execute(argThat(isCreateIndexForTestIndex()))).thenReturn(success);
+
+    Set<String> indices = new HashSet<>();
+    indices.add(INDEX);
+    client.createIndices(indices);
+    InOrder inOrder = inOrder(jestClient);
+    inOrder.verify(jestClient).execute(info);
+    inOrder.verify(jestClient).execute(indicesExists);
+    inOrder.verify(jestClient).execute(argThat(isCreateIndexForTestIndex()));
+  }
+
+  private ArgumentMatcher<CreateIndex> isCreateIndexForTestIndex() {
+    return new ArgumentMatcher<CreateIndex>() {
+      @Override
+      public boolean matches(CreateIndex createIndex) {
+        // check the URI as the equals method on CreateIndex doesn't work
+        return createIndex.getURI().equals(INDEX);
+      }
+    };
+  }
+
+  @Test(expected = ConnectException.class)
+  public void createIndicesAndFails() throws Exception {
+    JestElasticsearchClient client = new JestElasticsearchClient(jestClient);
+    JestResult failure = new JestResult(new Gson());
+    failure.setSucceeded(false);
+    IndicesExists indicesExists = new IndicesExists.Builder(INDEX).build();
+    when(jestClient.execute(indicesExists)).thenReturn(failure);
+    when(jestClient.execute(argThat(isCreateIndexForTestIndex()))).thenReturn(failure);
+
+    Set<String> indices = new HashSet<>();
+    indices.add(INDEX);
+    client.createIndices(indices);
+  }
+
+  @Test
+  public void createsMapping() throws Exception {
+    JestElasticsearchClient client = new JestElasticsearchClient(jestClient);
+    JestResult success = new JestResult(new Gson());
+    success.setSucceeded(true);
+    ObjectNode obj = JsonNodeFactory.instance.objectNode();
+    obj.set(TYPE, Mapping.inferMapping(client, Schema.STRING_SCHEMA));
+    PutMapping putMapping = new PutMapping.Builder(INDEX, TYPE,obj.toString()).build();
+    when(jestClient.execute(putMapping)).thenReturn(success);
+
+    client.createMapping(INDEX, TYPE, Schema.STRING_SCHEMA);
+    verify(jestClient).execute(putMapping);
+  }
+
+  @Test(expected = ConnectException.class)
+  public void createsMappingAndFails() throws Exception {
+    JestElasticsearchClient client = new JestElasticsearchClient(jestClient);
+    JestResult failure = new JestResult(new Gson());
+    failure.setSucceeded(false);
+    ObjectNode obj = JsonNodeFactory.instance.objectNode();
+    obj.set(TYPE, Mapping.inferMapping(client, Schema.STRING_SCHEMA));
+    PutMapping putMapping = new PutMapping.Builder(INDEX, TYPE, obj.toString()).build();
+    when(jestClient.execute(putMapping)).thenReturn(failure);
+
+    client.createMapping(INDEX, TYPE, Schema.STRING_SCHEMA);
+  }
+
+  @Test
+  public void getsMapping() throws Exception {
+    JestElasticsearchClient client = new JestElasticsearchClient(jestClient);
+    JsonObject mapping = new JsonObject();
+    JsonObject mappings = new JsonObject();
+    mappings.add(TYPE, mapping);
+    JsonObject indexRoot = new JsonObject();
+    indexRoot.add("mappings", mappings);
+    JsonObject root = new JsonObject();
+    root.add(INDEX, indexRoot);
+    JestResult result = new JestResult(new Gson());
+    result.setJsonObject(root);
+    GetMapping getMapping = new GetMapping.Builder().addIndex(INDEX).addType(TYPE).build();
+    when(jestClient.execute(getMapping)).thenReturn(result);
+
+    assertThat(client.getMapping(INDEX, TYPE), is(equalTo(mapping)));
+  }
+
+  @Test
+  public void executesBulk() throws Exception {
+    JestElasticsearchClient client = new JestElasticsearchClient(jestClient);
+    IndexableRecord record = new IndexableRecord(new Key(INDEX, TYPE, KEY), "payload", 0L);
+    List<IndexableRecord> records = new ArrayList<>();
+    records.add(record);
+    BulkRequest request = client.createBulkRequest(records);
+    BulkResult success = new BulkResult(new Gson());
+    success.setSucceeded(true);
+    when(jestClient.execute(((JestBulkRequest) request).getBulk())).thenReturn(success);
+
+    assertThat(client.executeBulk(request).isSucceeded(), is(equalTo(true)));
+  }
+
+  @Test
+  public void executesBulkAndFails() throws Exception {
+    JestElasticsearchClient client = new JestElasticsearchClient(jestClient);
+    IndexableRecord record = new IndexableRecord(new Key(INDEX, TYPE, KEY), null, 0L);
+    List<IndexableRecord> records = new ArrayList<>();
+    records.add(record);
+    BulkRequest request = client.createBulkRequest(records);
+    BulkResult failure = new BulkResult(new Gson());
+    failure.setSucceeded(false);
+    when(jestClient.execute(((JestBulkRequest) request).getBulk())).thenReturn(failure);
+
+    assertThat(client.executeBulk(request).isSucceeded(), is(equalTo(false)));
+  }
+
+  @Test
+  public void executesBulkAndFailsWithParseError() throws Exception {
+    JestElasticsearchClient client = new JestElasticsearchClient(jestClient);
+    IndexableRecord record = new IndexableRecord(new Key(INDEX, TYPE, KEY), "payload", 0L);
+    List<IndexableRecord> records = new ArrayList<>();
+    records.add(record);
+    BulkRequest request = client.createBulkRequest(records);
+    BulkResult failure = createBulkResultFailure(JestElasticsearchClient.MAPPER_PARSE_EXCEPTION);
+    when(jestClient.execute(((JestBulkRequest) request).getBulk())).thenReturn(failure);
+
+    assertThat(client.executeBulk(request).isSucceeded(), is(equalTo(false)));
+  }
+
+  @Test
+  public void executesBulkAndFailsWithSomeOtherError() throws Exception {
+    JestElasticsearchClient client = new JestElasticsearchClient(jestClient);
+    IndexableRecord record = new IndexableRecord(new Key(INDEX, TYPE, KEY), "payload", 0L);
+    List<IndexableRecord> records = new ArrayList<>();
+    records.add(record);
+    BulkRequest request = client.createBulkRequest(records);
+    BulkResult failure = createBulkResultFailure("some_random_exception");
+    when(jestClient.execute(((JestBulkRequest) request).getBulk())).thenReturn(failure);
+
+    assertThat(client.executeBulk(request).isSucceeded(), is(equalTo(false)));
+  }
+
+  @Test
+  public void executesBulkAndSucceedsBecauseOnlyVersionConflicts() throws Exception {
+    JestElasticsearchClient client = new JestElasticsearchClient(jestClient);
+    IndexableRecord record = new IndexableRecord(new Key(INDEX, TYPE, KEY), "payload", 0L);
+    List<IndexableRecord> records = new ArrayList<>();
+    records.add(record);
+    BulkRequest request = client.createBulkRequest(records);
+    BulkResult failure = createBulkResultFailure(JestElasticsearchClient.VERSION_CONFLICT_ENGINE_EXCEPTION);
+    when(jestClient.execute(((JestBulkRequest) request).getBulk())).thenReturn(failure);
+
+    assertThat(client.executeBulk(request).isSucceeded(), is(equalTo(true)));
+  }
+
+  @Test
+  public void searches() throws Exception {
+    JestElasticsearchClient client = new JestElasticsearchClient(jestClient);
+    Search search = new Search.Builder(QUERY).addIndex(INDEX).addType(TYPE).build();
+    JsonObject queryResult = new JsonObject();
+    SearchResult result = new SearchResult(new Gson());
+    result.setJsonObject(queryResult);
+    when(jestClient.execute(search)).thenReturn(result);
+
+    assertThat(client.search(QUERY, INDEX, TYPE), is(equalTo(queryResult)));
+  }
+
+  @Test
+  public void closes() {
+    JestElasticsearchClient client = new JestElasticsearchClient(jestClient);
+    client.close();
+
+    verify(jestClient).shutdownClient();
+  }
+
+  private BulkResult createBulkResultFailure(String exception) {
+    BulkResult failure = new BulkResult(new Gson());
+    failure.setSucceeded(false);
+    JsonObject error = new JsonObject();
+    error.addProperty("type", exception);
+    JsonObject item = new JsonObject();
+    item.addProperty("_index", INDEX);
+    item.addProperty("_type", TYPE);
+    item.addProperty("status", 0);
+    item.add("error", error);
+    JsonObject index = new JsonObject();
+    index.add("index", item);
+    JsonArray items = new JsonArray();
+    items.add(index);
+    JsonObject root = new JsonObject();
+    root.add("items", items);
+    failure.setJsonObject(root);
+    return failure;
+  }
+}


### PR DESCRIPTION
The ES connector now queries for the version.  The version is stored in
an instance of ElasticsearchClient, which is passed around so that
it can be queried at the appropriate times (such as when inferring
schema mappings).

As part of this change, the old Jest client is now wrapped by a
higher-level client object.  Also, all the Jest dependencies have been
isolated to the io.confluent.connect.elasticsearch.jest package.  This
makes the third-party dependencies more clear and will facilitate moving
to a different ES client library in the future should we choose to do
so.

These changes have been tested with ES 2.x, 5.x, and 6.x.