### PR TITLE
CC-1491: Remove note about unsupported ES6 from ES quick start

### DIFF
--- a/docs/elasticsearch_connector.rst
+++ b/docs/elasticsearch_connector.rst
@@ -36,8 +36,6 @@ producer to Elasticsearch.
 - :ref:`Confluent Platform <installation>` is installed and services are running by using the Confluent CLI. This quick start assumes that you are using the Confluent CLI, but standalone installations are also supported. By default ZooKeeper, Kafka, Schema Registry, Kafka Connect REST API, and Kafka Connect are started with the ``confluent start`` command. For more information, see :ref:`installation_archive`.
 - Elasticsearch 5.x is installed and running.
 
-  .. important:: Elasticsearch 6.x is not supported at this time due to a known issue.
-
 ----------------------------
 Add a Record to the Consumer
 ----------------------------

--- a/docs/elasticsearch_connector.rst
+++ b/docs/elasticsearch_connector.rst
@@ -34,7 +34,7 @@ producer to Elasticsearch.
 **Prerequisites:**
 
 - :ref:`Confluent Platform <installation>` is installed and services are running by using the Confluent CLI. This quick start assumes that you are using the Confluent CLI, but standalone installations are also supported. By default ZooKeeper, Kafka, Schema Registry, Kafka Connect REST API, and Kafka Connect are started with the ``confluent start`` command. For more information, see :ref:`installation_archive`.
-- Elasticsearch 5.x is installed and running.
+- Elasticsearch 5.x or 6.x is installed and running.
 
 ----------------------------
 Add a Record to the Consumer


### PR DESCRIPTION
Remove the note since we now support ES6.