### PR TITLE
CC-1550: Clarify ES 6 compatibility

### DIFF
--- a/docs/elasticsearch_connector.rst
+++ b/docs/elasticsearch_connector.rst
@@ -36,7 +36,7 @@ producer to Elasticsearch.
 - :ref:`Confluent Platform <installation>` is installed and services are running by using the Confluent CLI. This quick start assumes that you are using the Confluent CLI, but standalone installations are also supported. By default ZooKeeper, Kafka, Schema Registry, Kafka Connect REST API, and Kafka Connect are started with the ``confluent start`` command. For more information, see :ref:`installation_archive`.
 - Elasticsearch 5.x is installed and running.
 
-  .. important:: Elasticsearch 6.x is not supported at this time due to a known issue.
+  .. important:: Elasticsearch 6.0 removes the ``string`` type used in the connector, but you can set ``schema.ignore=true`` in the connector configuration to skip creating the mappings based upon the ``string`` type. Elasticsearch will then detect the type using the field mapping rules specified `here <https://www.elastic.co/guide/en/elasticsearch/reference/current/dynamic-field-mapping.html>`_.
 
 ----------------------------
 Add a Record to the Consumer


### PR DESCRIPTION
Add note to state that `schema.ignore=true` can be added for ES6