### PR TITLE
CC-1625:  Fix NPE for null arrays with no default

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
@@ -324,6 +324,9 @@ public class DataConverter {
   }
 
   private Object preProcessArrayValue(Object value, Schema schema, Schema newSchema) {
+    if (value == null) {
+      return null;
+    }
     Collection collection = (Collection) value;
     List<Object> result = new ArrayList<>();
     for (Object element: collection) {
@@ -333,6 +336,9 @@ public class DataConverter {
   }
 
   private Object preProcessMapValue(Object value, Schema schema, Schema newSchema) {
+    if (value == null) {
+      return null;
+    }
     Schema keySchema = schema.keySchema();
     Schema valueSchema = schema.valueSchema();
     Schema newValueSchema = newSchema.valueSchema();
@@ -360,6 +366,9 @@ public class DataConverter {
   }
 
   private Object preProcessStructValue(Object value, Schema schema, Schema newSchema) {
+    if (value == null) {
+      return null;
+    }
     Struct struct = (Struct) value;
     Struct newStruct = new Struct(newSchema);
     for (Field field : schema.fields()) {

--- a/src/test/java/io/confluent/connect/elasticsearch/DataConverterTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/DataConverterTest.java
@@ -148,6 +148,18 @@ public class DataConverterTest {
   }
 
   @Test
+  public void nullArray() {
+    // Create optional schema with no default value
+    Schema origSchema = SchemaBuilder.array(Decimal.schema(2)).optional().schema();
+    Schema preProcessedSchema = converter.preProcessSchema(origSchema);
+
+    assertEquals(
+        null,
+        converter.preProcessValue(null, origSchema, preProcessedSchema)
+    );
+  }
+
+  @Test
   public void map() {
     Schema origSchema = SchemaBuilder.map(Schema.INT32_SCHEMA, Decimal.schema(2)).build();
     Schema preProcessedSchema = converter.preProcessSchema(origSchema);
@@ -186,6 +198,18 @@ public class DataConverterTest {
     assertEquals(
         SchemaBuilder.array(preProcessedSchema.valueSchema()).defaultValue(Collections.emptyList()).build(),
         converter.preProcessSchema(SchemaBuilder.map(Schema.INT32_SCHEMA, Decimal.schema(2)).defaultValue(Collections.emptyMap()).build())
+    );
+  }
+
+  @Test
+  public void nullMap() {
+    // Create optional schema with no default value
+    Schema origSchema = SchemaBuilder.map(Schema.INT32_SCHEMA, Decimal.schema(2)).optional().build();
+    Schema preProcessedSchema = converter.preProcessSchema(origSchema);
+
+    assertEquals(
+        null,
+        converter.preProcessValue(null, origSchema, preProcessedSchema)
     );
   }
 
@@ -260,6 +284,18 @@ public class DataConverterTest {
     assertEquals(
         SchemaBuilder.struct().name("struct").field("decimal", Schema.FLOAT64_SCHEMA).optional().build(),
         converter.preProcessSchema(SchemaBuilder.struct().name("struct").field("decimal", Decimal.schema(2)).optional().build())
+    );
+  }
+
+  @Test
+  public void nullStruct() {
+    // Create optional schema with no default value
+    Schema origSchema = SchemaBuilder.struct().name("struct").field("decimal", Decimal.schema(2)).optional().build();
+    Schema preProcessedSchema = converter.preProcessSchema(origSchema);
+
+    assertEquals(
+        null,
+        converter.preProcessValue(null, origSchema, preProcessedSchema)
     );
   }
 


### PR DESCRIPTION
This fixes a NullPointerException when a array, map, or struct is null
and the schema is optional with no default value.