### PR TITLE
Add the possibility to use secure es with basic auth

### DIFF
--- a/docs/configuration_options.rst
+++ b/docs/configuration_options.rst
@@ -7,6 +7,18 @@ Connector
   * Type: list
   * Importance: high
 
+``connection.username``
+  Default username used to connect to a secure Elastic instance.
+
+  * Type: string
+  * Importance: medium
+
+``connection.password``
+  Default password used to connect to a secure Elastic instance.
+
+  * Type: string
+  * Importance: medium
+
 ``batch.size``
   The number of records to process as a batch when writing to Elasticsearch.
 

--- a/docs/elasticsearch_connector.rst
+++ b/docs/elasticsearch_connector.rst
@@ -338,4 +338,5 @@ connector jobs to achieve double writes:
       
 Security
 --------
-The Elasticsearch connector can read data from secure Kafka by following the instructions in the :ref:`Connect security documentation <connect_security>`. The functionality to write data to a secured Elasticsearch instance is not yet implemented.
+The Elasticsearch connector can read data from secure Kafka by following the instructions in the :ref:`Connect security documentation <connect_security>`.
+For now, the connector can write only to a secure Elasticsearch with basic authentication by setting ``connection.username`` & ``connection.password``.

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -33,6 +33,12 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   private static final String CONNECTION_URL_DOC =
       "List of Elasticsearch HTTP connection URLs e.g. ``http://eshost1:9200,"
       + "http://eshost2:9200``.";
+  public static final String CONNECTION_USERNAME_CONFIG = "connection.username";
+  private static final String CONNECTION_USERNAME_DOC =
+        "Default username used to connect to a secure Elastic instance";
+  public static final String CONNECTION_PASSWORD_CONFIG = "connection.password";
+  private static final String CONNECTION_PASSWORD_DOC =
+        "Default password used to connect to a secure Elastic instance";
   public static final String BATCH_SIZE_CONFIG = "batch.size";
   private static final String BATCH_SIZE_DOC =
       "The number of records to process as a batch when writing to Elasticsearch.";
@@ -92,7 +98,7 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
       + " When this is set to ``true``, document IDs will be generated as the record's "
       + "``topic+partition+offset``.\n Note that this is a global config that applies to all "
       + "topics, use ``" + TOPIC_KEY_IGNORE_CONFIG + "`` to override as ``true`` for specific "
-      + "topics." ;
+      + "topics.";
   private static final String TOPIC_KEY_IGNORE_DOC =
       "List of topics for which ``" + KEY_IGNORE_CONFIG + "`` should be ``true``.";
   private static final String SCHEMA_IGNORE_CONFIG_DOC =
@@ -158,6 +164,26 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
         ++order,
         Width.LONG,
         "Connection URLs"
+    ).define(
+        CONNECTION_USERNAME_CONFIG,
+        Type.STRING,
+        "",
+        Importance.MEDIUM,
+        CONNECTION_USERNAME_DOC,
+        group,
+        ++order,
+        Width.SHORT,
+        "Connection Username"
+    ).define(
+        CONNECTION_PASSWORD_CONFIG,
+        Type.STRING,
+        "",
+        Importance.MEDIUM,
+        CONNECTION_PASSWORD_DOC,
+        group,
+        ++order,
+        Width.SHORT,
+        "Connection Password"
     ).define(
         BATCH_SIZE_CONFIG,
         Type.INT,

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -116,7 +116,22 @@ public class ElasticsearchSinkTask extends SinkTask {
       if (client != null) {
         this.client = client;
       } else {
-        this.client = new JestElasticsearchClient(props);
+        List<String> address =
+            config.getList(ElasticsearchSinkConnectorConfig.CONNECTION_URL_CONFIG);
+
+        String username =
+                config.getString(ElasticsearchSinkConnectorConfig.CONNECTION_USERNAME_CONFIG);
+        String password =
+                config.getString(ElasticsearchSinkConnectorConfig.CONNECTION_PASSWORD_CONFIG);
+
+        JestClientFactory factory = new JestClientFactory();
+        factory.setHttpClientConfig(
+            new HttpClientConfig.Builder(address)
+                .multiThreaded(true)
+                .defaultCredentials(username, password)
+                .build()
+        );
+        this.client = factory.getObject();
       }
 
       ElasticsearchWriter.Builder builder = new ElasticsearchWriter.Builder(this.client)

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -116,22 +116,7 @@ public class ElasticsearchSinkTask extends SinkTask {
       if (client != null) {
         this.client = client;
       } else {
-        List<String> address =
-            config.getList(ElasticsearchSinkConnectorConfig.CONNECTION_URL_CONFIG);
-
-        String username =
-                config.getString(ElasticsearchSinkConnectorConfig.CONNECTION_USERNAME_CONFIG);
-        String password =
-                config.getString(ElasticsearchSinkConnectorConfig.CONNECTION_PASSWORD_CONFIG);
-
-        JestClientFactory factory = new JestClientFactory();
-        factory.setHttpClientConfig(
-            new HttpClientConfig.Builder(address)
-                .multiThreaded(true)
-                .defaultCredentials(username, password)
-                .build()
-        );
-        this.client = factory.getObject();
+        this.client = new JestElasticsearchClient(props);
       }
 
       ElasticsearchWriter.Builder builder = new ElasticsearchWriter.Builder(this.client)

--- a/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
@@ -115,12 +115,18 @@ public class JestElasticsearchClient implements ElasticsearchClient {
       final int readTimeout = config.getInt(
           ElasticsearchSinkConnectorConfig.READ_TIMEOUT_MS_CONFIG);
 
+      String username =
+              config.getString(ElasticsearchSinkConnectorConfig.CONNECTION_USERNAME_CONFIG);
+      String password =
+              config.getString(ElasticsearchSinkConnectorConfig.CONNECTION_PASSWORD_CONFIG);
+
       List<String> address =
           config.getList(ElasticsearchSinkConnectorConfig.CONNECTION_URL_CONFIG);
       JestClientFactory factory = new JestClientFactory();
       factory.setHttpClientConfig(new HttpClientConfig.Builder(address)
           .connTimeout(connTimeout)
           .readTimeout(readTimeout)
+          .defaultCredentials(username, password)
           .multiThreaded(true)
           .build()
       );


### PR DESCRIPTION
There is some use cases of secure ES (for example multitenancy), so the Jest client should authenticate.
This PR add the possibility to sink data to a secure ES with basic auth.

✅Code changed & tested
✅Doc changed

FYI : There are many tools used to secure Elasticsearch, for example

xPack https://www.elastic.co/guide/en/x-pack/current/security-getting-started.html
Searchguard https://docs.search-guard.com/latest/index