### PR TITLE
CC-1802 Handle null values in optional struct fields with no defaults

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
@@ -16,7 +16,6 @@
 
 package io.confluent.connect.elasticsearch;
 
-import com.sun.istack.internal.NotNull;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.data.ConnectSchema;
 import org.apache.kafka.connect.data.Date;
@@ -271,7 +270,7 @@ public class DataConverter {
     if (schema == null) {
       return value;
     }
-    
+
     if (value == null) {
       return preProcessNullValue(schema);
     }

--- a/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
@@ -16,6 +16,7 @@
 
 package io.confluent.connect.elasticsearch;
 
+import com.sun.istack.internal.NotNull;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.data.ConnectSchema;
 import org.apache.kafka.connect.data.Date;
@@ -235,7 +236,8 @@ public class DataConverter {
     Schema preprocessedKeySchema = preProcessSchema(keySchema);
     Schema preprocessedValueSchema = preProcessSchema(valueSchema);
     if (useCompactMapEntries && keySchema.type() == Schema.Type.STRING) {
-      return SchemaBuilder.map(preprocessedKeySchema, preprocessedValueSchema).build();
+      SchemaBuilder result = SchemaBuilder.map(preprocessedKeySchema, preprocessedValueSchema);
+      return copySchemaBasics(schema, result).build();
     }
     Schema elementSchema = SchemaBuilder.struct().name(keyName + "-" + valueName)
         .field(MAP_KEY, preprocessedKeySchema)
@@ -269,11 +271,9 @@ public class DataConverter {
     if (schema == null) {
       return value;
     }
+    
     if (value == null) {
-      Object result = preProcessNullValue(schema);
-      if (result != null) {
-        return result;
-      }
+      return preProcessNullValue(schema);
     }
 
     // Handle logical types

--- a/src/test/java/io/confluent/connect/elasticsearch/DataConverterTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/DataConverterTest.java
@@ -282,7 +282,7 @@ public class DataConverterTest {
   ) {
     Schema origSchema = SchemaBuilder.struct().name("struct").field(
         "optionalField", optionalFieldSchema.optional().build()
-    );
+    ).build();
     Schema preProcessedSchema = converter.preProcessSchema(origSchema);
 
     Object preProcessedValue = converter.preProcessValue(


### PR DESCRIPTION
If a `Struct` schema contains an optional field of type `Decimal`, `Array`, `Map`, or `Struct`, an NPE is thrown when converting values for this schema when the corresponding field is `null`. This PR provides a fix for that bug, including several unit tests to ensure it won't pop up again.

Additionally, in the process of fixing this NPE, we ran across another error that the NPE masked wherein passing a struct containing a `null` value for a field with an optional `Map` schema to the `DataConverter.preProcessValue(...)` method would cause a `DataException`. This is also addressed, specifically by adding a call to `copySchemaBasics(...)` to the `preProcessMapSchema(...)` method. This bug would _not_ have affected top-level optional maps, which helps explain why it has not yet been reported as an issue. It is addressed here in order to facilitate newly-introduced tests that ensure that the NPE bug will not resurface (if it were not addressed, testing against optional maps would require a workaround to avoid the `DataException` that would otherwise occur).