### PR TITLE
CC-7146 : Introduce an option to control HTTP-level compression

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -142,6 +142,13 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
       + "if any read operation times out, and will need to be restarted to resume "
       + "further operations.";
 
+  public static final String CONNECTION_COMPRESSION_CONFIG = "connection.compression";
+  private static final String CONNECTION_COMPRESSION_DOC = "Whether to use GZip compression on "
+          + "HTTP connection to ElasticSearch. Valid options are ``true`` and ``false``. "
+          + "Default is ``false``. To make this setting to work "
+          + "the ``http.compression`` setting also needs to be enabled at the Elasticsearch nodes "
+          + "or the load-balancer before using it.";
+
   public static final String BEHAVIOR_ON_NULL_VALUES_CONFIG = "behavior.on.null.values";
   private static final String BEHAVIOR_ON_NULL_VALUES_DOC = "How to handle records with a "
       + "non-null key and a null value (i.e. Kafka tombstone records). Valid options are "
@@ -310,6 +317,16 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
         ++order,
         Width.SHORT,
         "Retry Backoff (ms)"
+      ).define(
+        CONNECTION_COMPRESSION_CONFIG,
+        Type.BOOLEAN,
+        false,
+        Importance.LOW,
+        CONNECTION_COMPRESSION_DOC,
+        group,
+        ++order,
+        Width.SHORT,
+        "Compression"
       ).define(
         CONNECTION_TIMEOUT_MS_CONFIG, 
         Type.INT, 

--- a/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
@@ -169,10 +169,14 @@ public class JestElasticsearchClient implements ElasticsearchClient {
     List<String> address = config.getList(
         ElasticsearchSinkConnectorConfig.CONNECTION_URL_CONFIG);
 
+    final boolean compressionEnabled = config.getBoolean(
+            ElasticsearchSinkConnectorConfig.CONNECTION_COMPRESSION_CONFIG);
+
     HttpClientConfig.Builder builder =
         new HttpClientConfig.Builder(address)
             .connTimeout(connTimeout)
             .readTimeout(readTimeout)
+            .requestCompressionEnabled(compressionEnabled)
             .multiThreaded(true);
     if (username != null && password != null) {
       builder.defaultCredentials(username, password.value())

--- a/src/test/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClientTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClientTest.java
@@ -72,6 +72,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -125,6 +126,22 @@ public class JestElasticsearchClientTest {
     assertEquals("elastic", credentials.getUserPrincipal().getName());
     assertEquals("elasticpw", credentials.getPassword());
     assertEquals(HttpHost.create("http://localhost:9200"), preemptiveAuthTargetHosts.iterator().next());
+  }
+
+  @Test
+  public void compressedConnectsSecurely() {
+    Map<String, String> props = new HashMap<>();
+    props.put(ElasticsearchSinkConnectorConfig.CONNECTION_URL_CONFIG, "http://localhost:9200");
+    props.put(ElasticsearchSinkConnectorConfig.CONNECTION_USERNAME_CONFIG, "elastic");
+    props.put(ElasticsearchSinkConnectorConfig.CONNECTION_PASSWORD_CONFIG, "elasticpw");
+    props.put(ElasticsearchSinkConnectorConfig.TYPE_NAME_CONFIG, "kafka-connect");
+    props.put(ElasticsearchSinkConnectorConfig.CONNECTION_COMPRESSION_CONFIG, "true");
+    JestElasticsearchClient client = new JestElasticsearchClient(props, jestClientFactory);
+
+    ArgumentCaptor<HttpClientConfig> captor = ArgumentCaptor.forClass(HttpClientConfig.class);
+    verify(jestClientFactory).setHttpClientConfig(captor.capture());
+    HttpClientConfig httpClientConfig = captor.getValue();
+    assertTrue(httpClientConfig.isRequestCompressionEnabled());
   }
 
   @Test


### PR DESCRIPTION
This code uses jest-http client that's supported Gzip compression over HTTP and this commit introduced an option to control this compression.

By default compression is disabled and this doesn't change any behaviour until it is enabled by hand.