### PR TITLE
MINOR: Tweak Kafka Connect Maven Plugin details

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
         <hamcrest.version>1.3</hamcrest.version>
         <mockito.version>2.13.0</mockito.version>
         <jest.version>2.4.0</jest.version>
+        <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
     </properties>
 
@@ -126,7 +127,7 @@
         <plugins>
             <plugin>
                 <groupId>io.confluent</groupId>
-                <version>0.10.0</version>
+                <version>${kafka.connect.maven.plugin.version}</version>
                 <artifactId>kafka-connect-maven-plugin</artifactId>
                 <executions>
                     <execution>
@@ -135,13 +136,13 @@
                         </goals>
                         <configuration>
                             <title>Kafka Connect Elasticsearch</title>
-                            <documentationUrl>https://docs.confluent.io/current/connect/connect-elasticsearch/docs/elasticsearch_connector.html</documentationUrl>
+                            <documentationUrl>https://docs.confluent.io/${project.version}/connect/connect-elasticsearch/docs/index.html</documentationUrl>
                             <description>
                                 The Elasticsearch connector allows moving data from Kafka to Elasticsearch. It writes data from a topic in Kafka to an index in Elasticsearch and all data for a topic have the same type.
 
                                 Elasticsearch is often used for text queries, analytics and as an key-value store (use cases). The connector covers both the analytics and key-value store use cases. For the analytics use case, each message is in Kafka is treated as an event and the connector uses topic+partition+offset as a unique identifier for events, which then converted to unique documents in Elasticsearch. For the key-value store use case, it supports using keys from Kafka messages as document ids in Elasticsearch and provides configurations ensuring that updates to a key are written to Elasticsearch in order. For both use cases, Elasticsearch’s idempotent write semantics guarantees exactly once delivery.
 
-                                Mapping is the process of defining how a document, and the fields it contains, are stored and indexed. Users can explicitly define mappings for types in indices. When mapping is not explicitly defined, Elasticsearch can determine field names and types from data, however, some types such as timestamp and decimal, may not be correctly inferred. To ensure that the types are correctly inferred, the connector provides a feature to infer mapping from the schemas of Kafka messages.
+                                Mapping is the process of defining how a document, and the fields it contains, are stored and indexed. Users can explicitly define mappings for types in indices. When a mapping is not explicitly defined, Elasticsearch can determine field names and types from data, however, some types such as timestamp and decimal, may not be correctly inferred. To ensure that the types are correctly inferred, the connector provides a feature to infer a mapping from the schemas of Kafka messages.
                             </description>
                             <logo>logos/elasticsearch.jpg</logo>
 
@@ -173,7 +174,7 @@
                             </tags>
 
                             <requirements>
-                                <requirement>Elasticsearch 2.x, 5.x, or 6.x</requirement>
+                                <requirement>Elasticsearch 2.x or 5.x</requirement>
                             </requirements>
 
                             <deliveryGuarantee>


### PR DESCRIPTION
This will align the configuration for the Kafka Connect Maven Plugin with the configuration proposed in https://github.com/confluentinc/kafka-connect-elasticsearch/pull/243; otherwise, future 4.0.x, 4.1.x, and 5.0.x releases wouldn't contain the changes included in there as well.