### PR TITLE
MINOR: Add 6.x to supported versions in Kafka Connect Maven Plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
                             </tags>
 
                             <requirements>
-                                <requirement>Elasticsearch 2.x or 5.x</requirement>
+                                <requirement>Elasticsearch 2.x, 5.x, or 6.x</requirement>
                             </requirements>
 
                             <deliveryGuarantee>


### PR DESCRIPTION
As mentioned in https://github.com/confluentinc/kafka-connect-elasticsearch/pull/243, we want to clarify that ES 6.x is supported by this connector as of version 4.1.0.