### PR TITLE
Fix bug when topic names are not in all lowercase

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
@@ -249,7 +249,7 @@ public class ElasticsearchWriter {
       }
 
       final String indexOverride = topicToIndexMap.get(sinkRecord.topic());
-      final String index = indexOverride != null ? indexOverride : sinkRecord.topic();
+      final String index = indexOverride != null ? indexOverride : sinkRecord.topic().toLowerCase();
       final boolean ignoreKey = ignoreKeyTopics.contains(sinkRecord.topic()) || this.ignoreKey;
       final boolean ignoreSchema =
           ignoreSchemaTopics.contains(sinkRecord.topic()) || this.ignoreSchema;
@@ -337,7 +337,9 @@ public class ElasticsearchWriter {
       if (index != null) {
         indices.add(index);
       } else {
-        indices.add(topic);
+        String topicAsIndex = topic.toLowerCase();
+        log.debug("Topic " + topic + " was created as index name " + topicAsIndex);
+        indices.add(topicAsIndex);
       }
     }
     return indices;


### PR DESCRIPTION
As described in (https://github.com/confluentinc/kafka-connect-elasticsearch/issues/246#issuecomment-431794980), Elasticsearch can only create indexes in lowercase letters, this PR fix this by making sure that all indexes are created that way.

Please forgive me If I miss a necessary check before pushing the PR, is the first time I contribute a change. 

Fix partially #246 
