### PR TITLE
[Backport ready] Fix bug when topic names are not in all lowercase

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
@@ -189,7 +189,6 @@ public class ElasticsearchWriter {
   }
 
   public void write(Collection<SinkRecord> records) {
-
     for (SinkRecord sinkRecord : records) {
       final String index = convertTopicToIndexName(sinkRecord.topic());
       final boolean ignoreKey = ignoreKeyTopics.contains(sinkRecord.topic()) || this.ignoreKey;
@@ -211,9 +210,7 @@ public class ElasticsearchWriter {
 
       bulkProcessor.add(indexableRecord, flushTimeoutMs);
     }
-
   }
-
 
   /**
    * Return the expected index name for a given topic, using the configured mapping or the topic name. Elasticsearch

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
@@ -214,18 +214,15 @@ public class ElasticsearchWriter {
 
   }
 
+
   /**
-   * Return the expected index name for a given topic. It makes sure to lowercase the topic name
-   * as elasticsearch require all index names to be lowercase.
-   * See https://github.com/confluentinc/kafka-connect-elasticsearch/issues/246 for connector details.
-   * See https://github.com/elastic/elasticsearch/issues/29420 for elasticsearch details.
-   * @param topic The topic name being proceed.
-   * @return String A valid elasticsearch index name
+   * Return the expected index name for a given topic, using the configured mapping or the topic name. Elasticsearch
+   * <a href="https://github.com/elastic/elasticsearch/issues/29420">accepts only lowercase index names</a>.
    */
   private String convertTopicToIndexName(String topic) {
     final String indexOverride = topicToIndexMap.get(topic);
     String index = indexOverride != null ? indexOverride : topic.toLowerCase();
-    log.debug("Topic " + topic + " was translated as index name " + index);
+    log.debug("Topic '{}' was translated as index '{}'", topic, index);
     return index;
   }
 

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
@@ -80,7 +80,7 @@ public class ElasticsearchSinkTaskTest extends ElasticsearchSinkTestBase {
   }
 
   @Test
-  public void testPutWithTopicInCaps() {
+  public void testCreateAndWriteToIndexForTopicWithUppercaseCharacters() {
     // We should as well test that writing a record with a previously un seen record will create
     // an index following the required elasticsearch requirements of lowercasing.
     InternalTestCluster cluster = ESIntegTestCase.internalCluster();
@@ -105,7 +105,6 @@ public class ElasticsearchSinkTaskTest extends ElasticsearchSinkTestBase {
       task.start(props, client);
       task.open(new HashSet<>(Collections.singletonList(TOPIC_IN_CAPS_PARTITION)));
       task.put(Collections.singleton(sinkRecord));
-      assertTrue("A topic name not in lowercase was created in Elasticsearch", true);
     } catch (Exception ex) {
       fail("A topic name not in lowercase can not be used as index name in Elasticsearch");
     } finally {

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
@@ -110,7 +110,5 @@ public class ElasticsearchSinkTaskTest extends ElasticsearchSinkTestBase {
     } finally {
       task.stop();
     }
-
   }
-
 }

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
@@ -18,6 +18,7 @@ package io.confluent.connect.elasticsearch;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.sink.SinkRecord;
@@ -25,15 +26,21 @@ import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.InternalTestCluster;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Collection;
+import java.util.ArrayList;
+import java.util.Collections;
+
 
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class ElasticsearchSinkTaskTest extends ElasticsearchSinkTestBase {
+
+  private static final String TOPIC_IN_CAPS = "AnotherTopicInCaps";
+  private static final int PARTITION_113 = 113;
+  private static final TopicPartition TOPIC_IN_CAPS_PARTITION = new TopicPartition(TOPIC_IN_CAPS, PARTITION_113);
 
   private Map<String, String> createProps() {
     Map<String, String> props = new HashMap<>();
@@ -70,6 +77,41 @@ public class ElasticsearchSinkTaskTest extends ElasticsearchSinkTestBase {
     refresh();
 
     verifySearchResults(records, true, false);
+  }
+
+  @Test
+  public void testPutWithTopicInCaps() {
+    // We should as well test that writing a record with a previously un seen record will create
+    // an index following the required elasticsearch requirements of lowercasing.
+    InternalTestCluster cluster = ESIntegTestCase.internalCluster();
+    cluster.ensureAtLeastNumDataNodes(3);
+    Map<String, String> props = createProps();
+
+    ElasticsearchSinkTask task = new ElasticsearchSinkTask();
+
+    String key = "key";
+    Schema schema = createSchema();
+    Struct record = createRecord(schema);
+
+    SinkRecord sinkRecord = new SinkRecord(TOPIC_IN_CAPS,
+            PARTITION_113,
+            Schema.STRING_SCHEMA,
+            key,
+            schema,
+            record,
+            0 );
+
+    try {
+      task.start(props, client);
+      task.open(new HashSet<>(Collections.singletonList(TOPIC_IN_CAPS_PARTITION)));
+      task.put(Collections.singleton(sinkRecord));
+      assertTrue("A topic name not in lowercase was created in Elasticsearch", true);
+    } catch (Exception ex) {
+      fail("A topic name not in lowercase can not be used as index name in Elasticsearch");
+    } finally {
+      task.stop();
+    }
+
   }
 
 }


### PR DESCRIPTION
As described in (https://github.com/confluentinc/kafka-connect-elasticsearch/issues/246#issuecomment-431794980), Elasticsearch can only create indexes in lowercase letters, this PR fix this by making sure that all indexes are created that way.

Please forgive me If I miss a necessary check before pushing the PR, is the first time I contribute a change. 

Fix partially #246 

Backport of #250 as requested in https://github.com/confluentinc/kafka-connect-elasticsearch/pull/250#pullrequestreview-167503044
