### PR TITLE
CC-3034: Disabled the ES JarHell utility since it considered `module-info` files as duplicates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,7 +220,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>@{argLine} -Djava.awt.headless=true -Dtests.security.manager=false</argLine>
+                    <argLine>@{argLine} -Djava.awt.headless=true -Dtests.security.manager=false -Dtests.jarhell.check=false</argLine>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
The `module-info` files will appear in multiple JARs, and they are not duplicates. The ES JarHell utility that the Elasticsearch project uses in their tests and base classes for tests (which we inherit and use in our tests) doesn’t take the `module-info` files into account.

Luckily there is a way to disable this check in the tests via the `tests.jarhell.check=false` system property, which this commit changes in the Surefire configuration.