### PR TITLE
Create indices before writing records

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
@@ -46,6 +46,15 @@ public interface ElasticsearchClient extends AutoCloseable {
   void createIndices(Set<String> indices);
 
   /**
+   * Gets the Elasticsearch version.
+   *
+   * @param index the index check exists
+   * @return whether the index exists
+   * @throws IOException if the client cannot execute the request
+   */
+  boolean indexExists(String index);
+
+  /**
    * Creates an explicit mapping.
    *
    * @param index the index to write

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
@@ -46,15 +46,6 @@ public interface ElasticsearchClient extends AutoCloseable {
   void createIndices(Set<String> indices);
 
   /**
-   * Gets the Elasticsearch version.
-   *
-   * @param index the index check exists
-   * @return whether the index exists
-   * @throws IOException if the client cannot execute the request
-   */
-  boolean indexExists(String index);
-
-  /**
    * Creates an explicit mapping.
    *
    * @param index the index to write

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
@@ -24,12 +24,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.HashSet;
-import java.util.Map;
+import java.util.HashMap;
 import java.util.Objects;
+import java.util.Map;
 import java.util.Set;
 
 import static io.confluent.connect.elasticsearch.DataConverter.BehaviorOnNullValues;
@@ -255,11 +256,7 @@ public class ElasticsearchWriter {
 
       if (!ignoreSchema && !existingMappings.contains(index)) {
         try {
-          if (client.indexExists(index) == false) {
-            Set<String> indicies = new HashSet<String>();
-            indicies.add(index);
-            client.createIndices(indicies);
-          }
+          client.createIndices(new HashSet<>(Arrays.asList(index)));
           if (Mapping.getMapping(client, index, type) == null) {
             Mapping.createMapping(client, index, type, sinkRecord.valueSchema());
           }

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
@@ -255,6 +255,11 @@ public class ElasticsearchWriter {
 
       if (!ignoreSchema && !existingMappings.contains(index)) {
         try {
+          if (client.indexExists(index) == false) {
+            Set<String> indicies = new HashSet<String>();
+            indicies.add(index);
+            client.createIndices(indicies);
+          }
           if (Mapping.getMapping(client, index, type) == null) {
             Mapping.createMapping(client, index, type, sinkRecord.valueSchema());
           }

--- a/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
@@ -215,7 +215,7 @@ public class JestElasticsearchClient implements ElasticsearchClient {
     return version;
   }
 
-  private boolean indexExists(String index) {
+  public boolean indexExists(String index) {
     Action<JestResult> action = new IndicesExists.Builder(index).build();
     try {
       JestResult result = client.execute(action);

--- a/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
@@ -54,6 +54,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -70,6 +71,7 @@ public class JestElasticsearchClient implements ElasticsearchClient {
   private static final Logger LOG = LoggerFactory.getLogger(JestElasticsearchClient.class);
 
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private final HashSet<String> createdIndices = new HashSet<>();
 
   private final JestClient client;
   private final Version version;
@@ -215,7 +217,7 @@ public class JestElasticsearchClient implements ElasticsearchClient {
     return version;
   }
 
-  public boolean indexExists(String index) {
+  private boolean indexExists(String index) {
     Action<JestResult> action = new IndicesExists.Builder(index).build();
     try {
       JestResult result = client.execute(action);
@@ -227,7 +229,7 @@ public class JestElasticsearchClient implements ElasticsearchClient {
 
   public void createIndices(Set<String> indices) {
     for (String index : indices) {
-      if (!indexExists(index)) {
+      if (!this.createdIndices.contains(index) && !indexExists(index)) {
         CreateIndex createIndex = new CreateIndex.Builder(index).build();
         try {
           JestResult result = client.execute(createIndex);
@@ -241,6 +243,7 @@ public class JestElasticsearchClient implements ElasticsearchClient {
         } catch (IOException e) {
           throw new ConnectException(e);
         }
+        this.createdIndices.add(index);
       }
     }
   }


### PR DESCRIPTION
Currently, indices are only created when the connector is opened. If the
destination index is changed by a Single Message Transform, the index
may not exist when the record is being written, and as such will fail
to create a mapping, as the index does not exist.

This patch creates the index, after the message has been transformed.

Fixes #99.