### PR TITLE
Disable index creation at bootstrap time

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -147,6 +147,11 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
       + " mapping conflict or a field name containing illegal characters. Valid options are "
       + "'ignore', 'warn', and 'fail'.";
 
+  public static final String CREATE_INDEX_AT_START_CONFIG = "create.index.at.start";
+  private static final String CREATE_INDEX_AT_START__DOC = "Create the Elasticsearch indexes at "
+      + " bootstrap time. This is useful when the indexes are a direct mapping "
+      + " of the Kafka topics.";
+
   protected static ConfigDef baseConfigDef() {
     final ConfigDef configDef = new ConfigDef();
     addConnectorConfigs(configDef);
@@ -272,10 +277,20 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
         3000, 
         Importance.LOW, 
         READ_TIMEOUT_MS_CONFIG_DOC,
-        group, 
-        ++order, 
-        Width.SHORT, 
-        "Read Timeout");
+        group,
+        ++order,
+        Width.SHORT,
+        "Read Timeout"
+    ).define(
+        CREATE_INDEX_AT_START_CONFIG,
+        Type.BOOLEAN,
+        true,
+        Importance.LOW,
+        CREATE_INDEX_AT_START__DOC,
+        group,
+        ++order,
+        Width.SHORT,
+        "Create indexes at bootstrap time");
   }
 
   private static void addConversionConfigs(ConfigDef configDef) {

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -147,9 +147,9 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
       + " mapping conflict or a field name containing illegal characters. Valid options are "
       + "'ignore', 'warn', and 'fail'.";
 
-  public static final String CREATE_INDEX_AT_START_CONFIG = "create.index.at.start";
-  private static final String CREATE_INDEX_AT_START__DOC = "Create the Elasticsearch indexes at "
-      + " bootstrap time. This is useful when the indexes are a direct mapping "
+  public static final String AUTO_CREATE_INDEX_AT_START_CONFIG = "auto.create.index.at.start";
+  private static final String AUTO_CREATE_INDEX_AT_START_DOC = "Auto create the Elasticsearch"
+      + " indexes at bootstrap time. This is useful when the indexes are a direct mapping "
       + " of the Kafka topics.";
 
   protected static ConfigDef baseConfigDef() {
@@ -282,11 +282,11 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
         Width.SHORT,
         "Read Timeout"
     ).define(
-        CREATE_INDEX_AT_START_CONFIG,
+        AUTO_CREATE_INDEX_AT_START_CONFIG,
         Type.BOOLEAN,
         true,
         Importance.LOW,
-        CREATE_INDEX_AT_START__DOC,
+        AUTO_CREATE_INDEX_AT_START_DOC,
         group,
         ++order,
         Width.SHORT,

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -91,7 +91,7 @@ public class ElasticsearchSinkTask extends SinkTask {
       boolean dropInvalidMessage =
           config.getBoolean(ElasticsearchSinkConnectorConfig.DROP_INVALID_MESSAGE_CONFIG);
       boolean createIndexAtStartTime =
-          config.getBoolean(ElasticsearchSinkConnectorConfig.CREATE_INDEX_AT_START_CONFIG);
+          config.getBoolean(ElasticsearchSinkConnectorConfig.AUTO_CREATE_INDEX_AT_START_CONFIG);
 
       DataConverter.BehaviorOnNullValues behaviorOnNullValues =
           DataConverter.BehaviorOnNullValues.forValue(

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
@@ -251,6 +251,8 @@ public class ElasticsearchWriter {
       final boolean ignoreSchema =
           ignoreSchemaTopics.contains(sinkRecord.topic()) || this.ignoreSchema;
 
+      client.createIndices(Collections.singleton(index));
+
       if (!ignoreSchema && !existingMappings.contains(index)) {
         try {
           if (Mapping.getMapping(client, index, type) == null) {

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
@@ -40,6 +40,11 @@ public class ElasticsearchSinkTaskTest extends ElasticsearchSinkTestBase {
   private static final int PARTITION_113 = 113;
   private static final TopicPartition TOPIC_IN_CAPS_PARTITION = new TopicPartition(TOPIC_IN_CAPS, PARTITION_113);
 
+  private static final String UNSEEN_TOPIC = "UnseenTopic";
+  private static final int PARTITION_114 = 114;
+  private static final TopicPartition UNSEEN_TOPIC_PARTITION = new TopicPartition(UNSEEN_TOPIC, PARTITION_114);
+
+
   private Map<String, String> createProps() {
     Map<String, String> props = new HashMap<>();
     props.put(ElasticsearchSinkConnectorConfig.TYPE_NAME_CONFIG, TYPE);
@@ -92,7 +97,38 @@ public class ElasticsearchSinkTaskTest extends ElasticsearchSinkTestBase {
     Struct record = createRecord(schema);
 
     SinkRecord sinkRecord = new SinkRecord(TOPIC_IN_CAPS,
-            PARTITION_113,
+        PARTITION_113,
+        Schema.STRING_SCHEMA,
+        key,
+        schema,
+        record,
+        0 );
+
+    try {
+      task.start(props, client);
+      task.open(new HashSet<>(Collections.singletonList(TOPIC_IN_CAPS_PARTITION)));
+      task.put(Collections.singleton(sinkRecord));
+    } catch (Exception ex) {
+      fail("A topic name not in lowercase can not be used as index name in Elasticsearch");
+    } finally {
+      task.stop();
+    }
+  }
+
+  @Test
+  public void testCreateAndWriteToIndexNotCreatedAtStartTime() {
+    InternalTestCluster cluster = ESIntegTestCase.internalCluster();
+    cluster.ensureAtLeastNumDataNodes(3);
+    Map<String, String> props = createProps();
+
+    ElasticsearchSinkTask task = new ElasticsearchSinkTask();
+
+    String key = "key";
+    Schema schema = createSchema();
+    Struct record = createRecord(schema);
+
+    SinkRecord sinkRecord = new SinkRecord(UNSEEN_TOPIC,
+            PARTITION_114,
             Schema.STRING_SCHEMA,
             key,
             schema,
@@ -104,7 +140,7 @@ public class ElasticsearchSinkTaskTest extends ElasticsearchSinkTestBase {
       task.open(new HashSet<>(Collections.singletonList(TOPIC_IN_CAPS_PARTITION)));
       task.put(Collections.singleton(sinkRecord));
     } catch (Exception ex) {
-      fail("A topic name not in lowercase can not be used as index name in Elasticsearch");
+      fail("Record could not be written to elasticsearch due to non existing index");
     } finally {
       task.stop();
     }


### PR DESCRIPTION
This PR include changes enhance the experience creating indexes in Elasticsearch based on the preferred index names and not only on the topic name.

Before this PR the connector create all indexes at start time, using the topic names as a basis for that. However there are situations when the users need to change the expected index name using an SMT. This PR include as well a backwards compatibility flag, so the users can decide if they aim to keep the initial bootstrap index creation time or disable it and rely only in the record write time operation.