### PR TITLE
Disable index creation at bootstrap time

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -141,7 +141,7 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
 
   public static final String AUTO_CREATE_INDICES_AT_START_CONFIG = "auto.create.indices.at.start";
   private static final String AUTO_CREATE_INDICES_AT_START_DOC = "Auto create the Elasticsearch"
-      + " indices at bootstrap time. This is useful when the indices are a direct mapping "
+      + " indices at startup. This is useful when the indices are a direct mapping "
       + " of the Kafka topics.";
 
   protected static ConfigDef baseConfigDef() {
@@ -262,7 +262,7 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
         group,
         ++order,
         Width.SHORT,
-        "Create indices at bootstrap time"
+        "Create indices at startup"
       );
   }
 

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -139,6 +139,11 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
       + " mapping conflict or a field name containing illegal characters. Valid options are "
       + "'ignore', 'warn', and 'fail'.";
 
+  public static final String CREATE_INDEX_AT_START_CONFIG = "create.index.at.start";
+  private static final String CREATE_INDEX_AT_START__DOC = "Create the Elasticsearch indexes at "
+      + " bootstrap time. This is useful when the indexes are a direct mapping "
+      + " of the Kafka topics.";
+
   protected static ConfigDef baseConfigDef() {
     final ConfigDef configDef = new ConfigDef();
     addConnectorConfigs(configDef);
@@ -244,10 +249,20 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
         3000, 
         Importance.LOW, 
         READ_TIMEOUT_MS_CONFIG_DOC,
-        group, 
-        ++order, 
-        Width.SHORT, 
-        "Read Timeout");
+        group,
+        ++order,
+        Width.SHORT,
+        "Read Timeout"
+    ).define(
+        CREATE_INDEX_AT_START_CONFIG,
+        Type.BOOLEAN,
+        true,
+        Importance.LOW,
+        CREATE_INDEX_AT_START__DOC,
+        group,
+        ++order,
+        Width.SHORT,
+        "Create indexes at bootstrap time");
   }
 
   private static void addConversionConfigs(ConfigDef configDef) {

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -139,9 +139,9 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
       + " mapping conflict or a field name containing illegal characters. Valid options are "
       + "'ignore', 'warn', and 'fail'.";
 
-  public static final String CREATE_INDEX_AT_START_CONFIG = "create.index.at.start";
-  private static final String CREATE_INDEX_AT_START__DOC = "Create the Elasticsearch indexes at "
-      + " bootstrap time. This is useful when the indexes are a direct mapping "
+  public static final String AUTO_CREATE_INDICES_AT_START_CONFIG = "auto.create.indices.at.start";
+  private static final String AUTO_CREATE_INDICES_AT_START_DOC = "Auto create the Elasticsearch"
+      + " indices at bootstrap time. This is useful when the indices are a direct mapping "
       + " of the Kafka topics.";
 
   protected static ConfigDef baseConfigDef() {
@@ -254,15 +254,16 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
         Width.SHORT,
         "Read Timeout"
     ).define(
-        CREATE_INDEX_AT_START_CONFIG,
+        AUTO_CREATE_INDICES_AT_START_CONFIG,
         Type.BOOLEAN,
         true,
         Importance.LOW,
-        CREATE_INDEX_AT_START__DOC,
+        AUTO_CREATE_INDICES_AT_START_DOC,
         group,
         ++order,
         Width.SHORT,
-        "Create indexes at bootstrap time");
+        "Create indices at bootstrap time"
+      );
   }
 
   private static void addConversionConfigs(ConfigDef configDef) {

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -40,6 +40,7 @@ public class ElasticsearchSinkTask extends SinkTask {
   private static final Logger log = LoggerFactory.getLogger(ElasticsearchSinkTask.class);
   private ElasticsearchWriter writer;
   private ElasticsearchClient client;
+  private Boolean createIndexAtStartTime;
 
   @Override
   public String version() {
@@ -90,6 +91,8 @@ public class ElasticsearchSinkTask extends SinkTask {
           config.getInt(ElasticsearchSinkConnectorConfig.MAX_RETRIES_CONFIG);
       boolean dropInvalidMessage =
           config.getBoolean(ElasticsearchSinkConnectorConfig.DROP_INVALID_MESSAGE_CONFIG);
+      boolean createIndexAtStartTime =
+          config.getBoolean(ElasticsearchSinkConnectorConfig.CREATE_INDEX_AT_START_CONFIG);
 
       DataConverter.BehaviorOnNullValues behaviorOnNullValues =
           DataConverter.BehaviorOnNullValues.forValue(
@@ -136,6 +139,8 @@ public class ElasticsearchSinkTask extends SinkTask {
           .setBehaviorOnNullValues(behaviorOnNullValues)
           .setBehaviorOnMalformedDoc(behaviorOnMalformedDoc);
 
+      this.createIndexAtStartTime = createIndexAtStartTime;
+
       writer = builder.build();
       writer.start();
     } catch (ConfigException e) {
@@ -149,11 +154,13 @@ public class ElasticsearchSinkTask extends SinkTask {
   @Override
   public void open(Collection<TopicPartition> partitions) {
     log.debug("Opening the task for topic partitions: {}", partitions);
-    Set<String> topics = new HashSet<>();
-    for (TopicPartition tp : partitions) {
-      topics.add(tp.topic());
+    if (createIndexAtStartTime) {
+      Set<String> topics = new HashSet<>();
+      for (TopicPartition tp : partitions) {
+        topics.add(tp.topic());
+      }
+      writer.createIndicesForTopics(topics);
     }
-    writer.createIndicesForTopics(topics);
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -40,7 +40,7 @@ public class ElasticsearchSinkTask extends SinkTask {
   private static final Logger log = LoggerFactory.getLogger(ElasticsearchSinkTask.class);
   private ElasticsearchWriter writer;
   private ElasticsearchClient client;
-  private Boolean createIndexAtStartTime;
+  private Boolean createIndicesAtStartTime;
 
   @Override
   public String version() {
@@ -91,8 +91,8 @@ public class ElasticsearchSinkTask extends SinkTask {
           config.getInt(ElasticsearchSinkConnectorConfig.MAX_RETRIES_CONFIG);
       boolean dropInvalidMessage =
           config.getBoolean(ElasticsearchSinkConnectorConfig.DROP_INVALID_MESSAGE_CONFIG);
-      boolean createIndexAtStartTime =
-          config.getBoolean(ElasticsearchSinkConnectorConfig.CREATE_INDEX_AT_START_CONFIG);
+      boolean createIndicesAtStartTime =
+          config.getBoolean(ElasticsearchSinkConnectorConfig.AUTO_CREATE_INDICES_AT_START_CONFIG);
 
       DataConverter.BehaviorOnNullValues behaviorOnNullValues =
           DataConverter.BehaviorOnNullValues.forValue(
@@ -139,7 +139,7 @@ public class ElasticsearchSinkTask extends SinkTask {
           .setBehaviorOnNullValues(behaviorOnNullValues)
           .setBehaviorOnMalformedDoc(behaviorOnMalformedDoc);
 
-      this.createIndexAtStartTime = createIndexAtStartTime;
+      this.createIndicesAtStartTime = createIndicesAtStartTime;
 
       writer = builder.build();
       writer.start();
@@ -154,7 +154,7 @@ public class ElasticsearchSinkTask extends SinkTask {
   @Override
   public void open(Collection<TopicPartition> partitions) {
     log.debug("Opening the task for topic partitions: {}", partitions);
-    if (createIndexAtStartTime) {
+    if (createIndicesAtStartTime) {
       Set<String> topics = new HashSet<>();
       for (TopicPartition tp : partitions) {
         topics.add(tp.topic());

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
@@ -253,6 +253,8 @@ public class ElasticsearchWriter {
       final boolean ignoreSchema =
           ignoreSchemaTopics.contains(sinkRecord.topic()) || this.ignoreSchema;
 
+      client.createIndices(Collections.singleton(index));
+
       if (!ignoreSchema && !existingMappings.contains(index)) {
         try {
           if (Mapping.getMapping(client, index, type) == null) {


### PR DESCRIPTION
This PR include changes enhance the experience creating indexes in Elasticsearch based on the preferred index names and not only on the topic name.

Before this PR the connector create all indexes at start time, using the topic names as a basis for that. However there are situations when the users need to change the expected index name using an SMT. This PR include as well a backwards compatibility flag, so the users can decide if they aim to keep the initial bootstrap index creation time or disable it and rely only in the record write time operation.

Proposed flow:

1. By default: create always an initial topic to index during start time. This could be deactivated if necessary.
2. Make sure that if a SMT is applied, the index is created anyway. (this does not happen in the current way of operation).


This is a backport PR from https://github.com/confluentinc/kafka-connect-elasticsearch/pull/274 as per discussion with @wicknicks 