### PR TITLE
Add HTTPS support to Elasticsearch connector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,17 +66,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka-clients</artifactId>
-            <classifier>test</classifier>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>io.searchbox</groupId>
             <artifactId>jest</artifactId>
             <version>${jest.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,17 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <classifier>test</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk15on</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>io.searchbox</groupId>
             <artifactId>jest</artifactId>
             <version>${jest.version}</version>

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -150,9 +150,15 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
 
   public static final String CONNECTION_SSL_CONFIG = "elastic.https";
   private static final String CONNECTION_SSL_DOC = "Override to specify whether to use SSL "
-      + "connection despite URL protocol. By default, the connector will use SSL when at "
-      + "least one URL begins with 'https:'.";
+      + "connection in all cases. By default, the connector will use SSL when at "
+      + "least one URL begins with 'https:'. This config allows users to specify SSL even if "
+      + "host is specified without a protocol.";
   public static final String CONNECTION_SSL_DEFAULT = "false";
+
+  public static final String CLIENT_AUTH_REQ_CONF = "elastic.https.client.auth.required";
+  private static final String CLIENT_AUTH_REQ_DOC = "Specify whether the client (connector) will "
+      + "be required to authenticate itself for SSL communication.";
+  public static final String CLIENT_AUTH_REQ_DEFAULT = "false";
 
   protected static ConfigDef baseConfigDef() {
     final ConfigDef configDef = new ConfigDef();
@@ -299,6 +305,17 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
         ++order,
         Width.LONG,
         "Use Secure Connection"
+    )
+    .define(
+        CLIENT_AUTH_REQ_CONF,
+        Type.BOOLEAN,
+        CLIENT_AUTH_REQ_DEFAULT,
+        Importance.HIGH,
+        CLIENT_AUTH_REQ_DOC,
+        group,
+        ++order,
+        Width.SHORT,
+        "Client authentication Required"
     );
   }
 

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -34,7 +34,8 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   private static final String CONNECTION_URL_DOC =
       "List of Elasticsearch HTTP connection URLs e.g. ``http://eshost1:9200,"
       + "http://eshost2:9200``, or ``https://eshost3:9200``. If any of the URLs specifies "
-      + "``https:`` protocol, https will be used for all connections.";
+      + "``https:`` protocol, https will be used for all connections. A URL with no protocol will "
+      + "be treated as ``http``.";
   public static final String CONNECTION_USERNAME_CONFIG = "connection.username";
   private static final String CONNECTION_USERNAME_DOC =
       "The username used to authenticate with Elasticsearch. "

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -19,7 +19,6 @@ import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.ConfigDef.Width;
-import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
 
 import java.util.List;
 import java.util.Map;
@@ -34,8 +33,8 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   public static final String CONNECTION_URL_CONFIG = "connection.url";
   private static final String CONNECTION_URL_DOC =
       "The comma-separated list of one or more Elasticsearch URLs, such as ``http://eshost1:9200,"
-      + "http://eshost2:9200`` or ``https://eshost3:9200``. HTTPS will be used for all connections "
-      + "if any of the URLs starts with ``https:``. A URL without a protocol will be treated as "
+      + "http://eshost2:9200`` or ``https://eshost3:9200``. HTTPS is used for all connections "
+      + "if any of the URLs starts with ``https:``. A URL without a protocol is treated as "
       + "``http``.";
   public static final String CONNECTION_USERNAME_CONFIG = "connection.username";
   private static final String CONNECTION_USERNAME_DOC =
@@ -113,7 +112,7 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
       "Whether to ignore schemas during indexing. When this is set to ``true``, the record "
       + "schema will be ignored for the purpose of registering an Elasticsearch mapping. "
       + "Elasticsearch will infer the mapping from the data (dynamic mapping needs to be enabled "
-      + "by the user).\n Note that this is a global config that applies to all topics, use ``"
+      + "by the user).\n Note that this is a global config that applies to all topics. Use ``"
       + TOPIC_SCHEMA_IGNORE_CONFIG + "`` to override as ``true`` for specific topics.";
   private static final String TOPIC_SCHEMA_IGNORE_DOC =
       "List of topics for which ``" + SCHEMA_IGNORE_CONFIG + "`` should be ``true``.";
@@ -154,11 +153,6 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
       + "'ignore', 'warn', and 'fail'.";
 
   public static final String CONNECTION_SSL_CONFIG_PREFIX = "elastic.https.";
-
-  public static final String CLIENT_AUTH_CONF = CONNECTION_SSL_CONFIG_PREFIX
-      + BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG;
-  private static final String CLIENT_AUTH_DOC = BrokerSecurityConfigs.SSL_CLIENT_AUTH_DOC;
-  private static final String CLIENT_AUTH_DEFAULT = "requested";
 
   protected static ConfigDef baseConfigDef() {
     final ConfigDef configDef = new ConfigDef();
@@ -296,15 +290,6 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
         ++order, 
         Width.SHORT, 
         "Read Timeout"
-    ).define(CLIENT_AUTH_CONF,
-        Type.STRING,
-        CLIENT_AUTH_DEFAULT,
-        Importance.MEDIUM,
-        CLIENT_AUTH_DOC,
-        SSL_GROUP,
-        ++order,
-        Width.SHORT,
-        "Client Authentication Required"
     );
   }
 

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -34,7 +34,7 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   private static final String CONNECTION_URL_DOC =
       "List of Elasticsearch HTTP connection URLs e.g. ``http://eshost1:9200,"
       + "http://eshost2:9200``, or ``https://eshost3:9200``. If any of the URLs specifies "
-      + "\"https:\" protocol, https will be used for all connections.";
+      + "``https:`` protocol, https will be used for all connections.";
   public static final String CONNECTION_USERNAME_CONFIG = "connection.username";
   private static final String CONNECTION_USERNAME_DOC =
       "The username used to authenticate with Elasticsearch. "

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -33,10 +33,10 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
 
   public static final String CONNECTION_URL_CONFIG = "connection.url";
   private static final String CONNECTION_URL_DOC =
-      "List of Elasticsearch HTTP connection URLs e.g. ``http://eshost1:9200,"
-      + "http://eshost2:9200``, or ``https://eshost3:9200``. If any of the URLs specifies "
-      + "``https:`` protocol, https will be used for all connections. A URL with no protocol will "
-      + "be treated as ``http``.";
+      "The comma-separated list of one or more Elasticsearch URLs, such as ``http://eshost1:9200,"
+      + "http://eshost2:9200`` or ``https://eshost3:9200``. HTTPS will be used for all connections "
+      + "if any of the URLs starts with ``https:``. A URL without a protocol will be treated as "
+      + "``http``.";
   public static final String CONNECTION_USERNAME_CONFIG = "connection.username";
   private static final String CONNECTION_USERNAME_DOC =
       "The username used to authenticate with Elasticsearch. "
@@ -153,9 +153,9 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
       + " mapping conflict or a field name containing illegal characters. Valid options are "
       + "'ignore', 'warn', and 'fail'.";
 
-  public static final String CONNECTION_SSL_CONFIG = "elastic.https";
+  public static final String CONNECTION_SSL_CONFIG_PREFIX = "elastic.https.";
 
-  public static final String CLIENT_AUTH_CONF = CONNECTION_SSL_CONFIG + "."
+  public static final String CLIENT_AUTH_CONF = CONNECTION_SSL_CONFIG_PREFIX
       + BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG;
   private static final String CLIENT_AUTH_DOC = BrokerSecurityConfigs.SSL_CLIENT_AUTH_DOC;
   private static final String CLIENT_AUTH_DEFAULT = "requested";
@@ -167,8 +167,9 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
     ConfigDef sslConfigDef = new ConfigDef();
     addClientSslSupport(sslConfigDef);
     configDef.embed(
-        CONNECTION_SSL_CONFIG + ".", SSL_GROUP,
-        configDef.configKeys().size() + 1, sslConfigDef);
+        CONNECTION_SSL_CONFIG_PREFIX, SSL_GROUP,
+        configDef.configKeys().size() + 1, sslConfigDef
+    );
 
     return configDef;
   }
@@ -427,7 +428,7 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   public Map<String, Object> sslConfigs() {
     ConfigDef sslConfigDef = new ConfigDef();
     addClientSslSupport(sslConfigDef);
-    return sslConfigDef.parse(originalsWithPrefix(CONNECTION_SSL_CONFIG + "."));
+    return sslConfigDef.parse(originalsWithPrefix(CONNECTION_SSL_CONFIG_PREFIX));
   }
 
   public static void main(String[] args) {

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -19,6 +19,7 @@ import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.ConfigDef.Width;
+import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
 
 import java.util.Map;
 
@@ -155,10 +156,9 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
       + "host is specified without a protocol.";
   public static final String CONNECTION_SSL_DEFAULT = "false";
 
-  public static final String CLIENT_AUTH_REQ_CONF = "elastic.https.client.auth.required";
-  private static final String CLIENT_AUTH_REQ_DOC = "Specify whether the client (connector) will "
-      + "be required to authenticate itself for SSL communication.";
-  public static final String CLIENT_AUTH_REQ_DEFAULT = "false";
+  public static final String CLIENT_AUTH_CONF = BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG;
+  private static final String CLIENT_AUTH_DOC = BrokerSecurityConfigs.SSL_CLIENT_AUTH_DOC;
+  private static final String CLIENT_AUTH_DEFAULT = "requested";
 
   protected static ConfigDef baseConfigDef() {
     final ConfigDef configDef = new ConfigDef();
@@ -167,7 +167,7 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
     ConfigDef sslConfigDef = new ConfigDef();
     addClientSslSupport(sslConfigDef);
     configDef.embed(
-        CONNECTION_SSL_CONFIG + ".", "HTTPS",
+        CONNECTION_SSL_CONFIG + ".", "Security",
         configDef.configKeys().size() + 1, sslConfigDef);
 
     return configDef;
@@ -305,16 +305,15 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
         ++order,
         Width.LONG,
         "Use Secure Connection"
-    ).define(
-        CLIENT_AUTH_REQ_CONF,
-        Type.BOOLEAN,
-        CLIENT_AUTH_REQ_DEFAULT,
-        Importance.HIGH,
-        CLIENT_AUTH_REQ_DOC,
+    ).define(CLIENT_AUTH_CONF,
+        Type.STRING,
+        CLIENT_AUTH_DEFAULT,
+        Importance.MEDIUM,
+        CLIENT_AUTH_DOC,
         group,
         ++order,
         Width.SHORT,
-        "Client authentication Required"
+        "Client Authentication Required"
     );
   }
 

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -305,8 +305,7 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
         ++order,
         Width.LONG,
         "Use Secure Connection"
-    )
-    .define(
+    ).define(
         CLIENT_AUTH_REQ_CONF,
         Type.BOOLEAN,
         CLIENT_AUTH_REQ_DEFAULT,

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -29,6 +29,7 @@ import static io.confluent.connect.elasticsearch.bulk.BulkProcessor.BehaviorOnMa
 import static org.apache.kafka.common.config.SslConfigs.addClientSslSupport;
 
 public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
+  private static final String SSL_GROUP = "Security";
 
   public static final String CONNECTION_URL_CONFIG = "connection.url";
   private static final String CONNECTION_URL_DOC =
@@ -154,7 +155,8 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
 
   public static final String CONNECTION_SSL_CONFIG = "elastic.https";
 
-  public static final String CLIENT_AUTH_CONF = BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG;
+  public static final String CLIENT_AUTH_CONF = CONNECTION_SSL_CONFIG + "."
+      + BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG;
   private static final String CLIENT_AUTH_DOC = BrokerSecurityConfigs.SSL_CLIENT_AUTH_DOC;
   private static final String CLIENT_AUTH_DEFAULT = "requested";
 
@@ -165,7 +167,7 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
     ConfigDef sslConfigDef = new ConfigDef();
     addClientSslSupport(sslConfigDef);
     configDef.embed(
-        CONNECTION_SSL_CONFIG + ".", "Security",
+        CONNECTION_SSL_CONFIG + ".", SSL_GROUP,
         configDef.configKeys().size() + 1, sslConfigDef);
 
     return configDef;
@@ -298,7 +300,7 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
         CLIENT_AUTH_DEFAULT,
         Importance.MEDIUM,
         CLIENT_AUTH_DOC,
-        group,
+        SSL_GROUP,
         ++order,
         Width.SHORT,
         "Client Authentication Required"

--- a/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
@@ -134,8 +134,6 @@ public class JestElasticsearchClient implements ElasticsearchClient {
       List<String> address =
           config.getList(ElasticsearchSinkConnectorConfig.CONNECTION_URL_CONFIG);
 
-      final boolean secured = config.secured();
-
       HttpClientConfig.Builder builder = new HttpClientConfig.Builder(address)
           .connTimeout(connTimeout)
           .readTimeout(readTimeout)
@@ -146,7 +144,7 @@ public class JestElasticsearchClient implements ElasticsearchClient {
                 .map(addr -> HttpHost.create(addr)).collect(Collectors.toSet()));
       }
 
-      if (secured) {
+      if (config.secured()) {
         log.info("Using secured connection");
         String clientAuth = config.getString(ElasticsearchSinkConnectorConfig.CLIENT_AUTH_CONF);
         SslFactory kafkaSslFactory = new SslFactory(Mode.CLIENT, clientAuth, false);

--- a/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
@@ -146,8 +146,7 @@ public class JestElasticsearchClient implements ElasticsearchClient {
 
       if (config.secured()) {
         log.info("Using secured connection to {}", address);
-        String clientAuth = config.getString(ElasticsearchSinkConnectorConfig.CLIENT_AUTH_CONF);
-        SslFactory kafkaSslFactory = new SslFactory(Mode.CLIENT, clientAuth, false);
+        SslFactory kafkaSslFactory = new SslFactory(Mode.CLIENT, null, false);
         kafkaSslFactory.configure(config.sslConfigs());
         SSLContext sslContext = kafkaSslFactory.sslContext();
 

--- a/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
@@ -131,15 +131,11 @@ public class JestElasticsearchClient implements ElasticsearchClient {
           ElasticsearchSinkConnectorConfig.CONNECTION_USERNAME_CONFIG);
       final Password password = config.getPassword(
           ElasticsearchSinkConnectorConfig.CONNECTION_PASSWORD_CONFIG);
-      final Boolean alwaysSecured = config.getBoolean(
-          ElasticsearchSinkConnectorConfig.CONNECTION_SSL_CONFIG);
-
       List<String> address =
           config.getList(ElasticsearchSinkConnectorConfig.CONNECTION_URL_CONFIG);
 
+      final boolean secured = config.secured();
 
-      final boolean secured = alwaysSecured
-          || address.stream().anyMatch(a -> a.startsWith("https:"));
       HttpClientConfig.Builder builder = new HttpClientConfig.Builder(address)
           .connTimeout(connTimeout)
           .readTimeout(readTimeout)

--- a/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
@@ -119,7 +119,7 @@ public class JestElasticsearchClient implements ElasticsearchClient {
   }
 
   // visible for testing
-  public JestElasticsearchClient(Map<String, String> props, JestClientFactory factory) {
+  protected JestElasticsearchClient(Map<String, String> props, JestClientFactory factory) {
     try {
       ElasticsearchSinkConnectorConfig config = new ElasticsearchSinkConnectorConfig(props);
       final int connTimeout = config.getInt(

--- a/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
@@ -152,8 +152,7 @@ public class JestElasticsearchClient implements ElasticsearchClient {
 
       if (secured) {
         log.info("Using secured connection");
-        String clientAuth = config.getBoolean(ElasticsearchSinkConnectorConfig.CLIENT_AUTH_REQ_CONF)
-            ? "required" : "requested";
+        String clientAuth = config.getString(ElasticsearchSinkConnectorConfig.CLIENT_AUTH_CONF);
         SslFactory kafkaSslFactory = new SslFactory(Mode.CLIENT, clientAuth, false);
         kafkaSslFactory.configure(config.sslConfigs());
         SSLContext sslContext = kafkaSslFactory.sslContext();

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
@@ -1,5 +1,6 @@
 package io.confluent.connect.elasticsearch;
 
+import org.apache.kafka.common.config.types.Password;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -44,6 +45,22 @@ public class ElasticsearchSinkConnectorConfigTest {
     Assert.assertEquals(
         config.getInt(ElasticsearchSinkConnectorConfig.CONNECTION_TIMEOUT_MS_CONFIG),
         (Integer) 15000
+    );
+  }
+
+  @Test
+  public void testSslConfigs() {
+    props.put("elastic.ssl", "true");
+    props.put("elastic.https.ssl.keystore.location", "/path");
+    props.put("elastic.https.ssl.keystore.password", "pword");
+    props.put("elastic.https.ssl.truststore.location", "/path2");
+    props.put("elastic.https.ssl.truststore.password", "pword2");
+    ElasticsearchSinkConnectorConfig config = new ElasticsearchSinkConnectorConfig(props);
+    Map<String, Object> sslConfigs = config.sslConfigs();
+    Assert.assertTrue(sslConfigs.size() > 0);
+    Assert.assertEquals(
+        sslConfigs.get("ssl.keystore.password"),
+        new Password("pword")
     );
   }
 }

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
@@ -8,6 +8,9 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.Map;
 
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+
 public class ElasticsearchSinkConnectorConfigTest {
 
   private Map<String, String> props;
@@ -50,7 +53,6 @@ public class ElasticsearchSinkConnectorConfigTest {
 
   @Test
   public void testSslConfigs() {
-    props.put("elastic.ssl", "true");
     props.put("elastic.https.ssl.keystore.location", "/path");
     props.put("elastic.https.ssl.keystore.password", "opensesame");
     props.put("elastic.https.ssl.truststore.location", "/path2");
@@ -66,5 +68,21 @@ public class ElasticsearchSinkConnectorConfigTest {
         sslConfigs.get("ssl.truststore.password"));
     Assert.assertEquals("/path", sslConfigs.get("ssl.keystore.location"));
     Assert.assertEquals("/path2", sslConfigs.get("ssl.truststore.location"));
+  }
+
+  @Test
+  public void testSecured() {
+    props.put("connection.url", "http://host:9999");
+    assertFalse(new ElasticsearchSinkConnectorConfig(props).secured());
+
+    props.put("connection.url", "https://host:9999");
+    assertTrue(new ElasticsearchSinkConnectorConfig(props).secured());
+
+    props.put("connection.url", "http://host1:9992,https://host:9999");
+    assertTrue(new ElasticsearchSinkConnectorConfig(props).secured());
+
+    // Default behavior should be backwards compat
+    props.put("connection.url", "host1:9992");
+    assertFalse(new ElasticsearchSinkConnectorConfig(props).secured());
   }
 }

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
@@ -52,15 +52,15 @@ public class ElasticsearchSinkConnectorConfigTest {
   public void testSslConfigs() {
     props.put("elastic.ssl", "true");
     props.put("elastic.https.ssl.keystore.location", "/path");
-    props.put("elastic.https.ssl.keystore.password", "pword");
+    props.put("elastic.https.ssl.keystore.password", "opensesame");
     props.put("elastic.https.ssl.truststore.location", "/path2");
-    props.put("elastic.https.ssl.truststore.password", "pword2");
+    props.put("elastic.https.ssl.truststore.password", "opensesame2");
     ElasticsearchSinkConnectorConfig config = new ElasticsearchSinkConnectorConfig(props);
     Map<String, Object> sslConfigs = config.sslConfigs();
     Assert.assertTrue(sslConfigs.size() > 0);
     Assert.assertEquals(
         sslConfigs.get("ssl.keystore.password"),
-        new Password("pword")
+        new Password("opensesame")
     );
   }
 }

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
@@ -59,8 +59,8 @@ public class ElasticsearchSinkConnectorConfigTest {
     Map<String, Object> sslConfigs = config.sslConfigs();
     Assert.assertTrue(sslConfigs.size() > 0);
     Assert.assertEquals(
-        sslConfigs.get("ssl.keystore.password"),
-        new Password("opensesame")
+        new Password("opensesame"),
+        sslConfigs.get("ssl.keystore.password")
     );
   }
 }

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
@@ -62,10 +62,12 @@ public class ElasticsearchSinkConnectorConfigTest {
     Assert.assertTrue(sslConfigs.size() > 0);
     Assert.assertEquals(
         new Password("opensesame"),
-        sslConfigs.get("ssl.keystore.password"));
+        sslConfigs.get("ssl.keystore.password")
+    );
     Assert.assertEquals(
         new Password("opensesame2"),
-        sslConfigs.get("ssl.truststore.password"));
+        sslConfigs.get("ssl.truststore.password")
+    );
     Assert.assertEquals("/path", sslConfigs.get("ssl.keystore.location"));
     Assert.assertEquals("/path2", sslConfigs.get("ssl.truststore.location"));
   }

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
@@ -60,7 +60,11 @@ public class ElasticsearchSinkConnectorConfigTest {
     Assert.assertTrue(sslConfigs.size() > 0);
     Assert.assertEquals(
         new Password("opensesame"),
-        sslConfigs.get("ssl.keystore.password")
-    );
+        sslConfigs.get("ssl.keystore.password"));
+    Assert.assertEquals(
+        new Password("opensesame2"),
+        sslConfigs.get("ssl.truststore.password"));
+    Assert.assertEquals("/path", sslConfigs.get("ssl.keystore.location"));
+    Assert.assertEquals("/path2", sslConfigs.get("ssl.truststore.location"));
   }
 }


### PR DESCRIPTION
Builds on https://github.com/confluentinc/kafka-connect-elasticsearch/pull/270

Uses common Apache Kafka configs

Has a very basic unit test, but integration test framework here is for Elastic 2.x, which needs to be updated. The automated test here is taking a lot of time, and I'm trying to learn if integration test in this repo is better or system test external to this repo.

This has been manually tested. Automated integration or system tests will come, but Jest client does not integrate with elastic's provided integration test framework for elastic 6.x (required for xpack), so that would require an overhaul on the client. Could be done but is out of scope