### PR TITLE
MINOR: Give docker URI to deploy statements

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,7 +46,9 @@ def job = {
               // skip publishing results again to avoid double-counting
               options: [openTasksPublisher(disabled: true), junitPublisher(disabled: true), findbugsPublisher(disabled: true)]
       ) {
-        sh "mvn --batch-mode -Pjenkins -D${env.deployOptions} deploy -DskipTests"
+        withDockerServer([uri: dockerHost()]) {
+          sh "mvn --batch-mode -Pjenkins -D${env.deployOptions} deploy -DskipTests"
+        }
       }
     }
   }


### PR DESCRIPTION
This is causing failures in the deployment:
https://jenkins.confluent.io/job/confluentinc/job/kafka-connect-elasticsearch/job/5.2.x/60/console

These fixes will also be merged upstream to `jenkins-common`, but this is a testing-ground.