### PR TITLE
ST-1492: Use predefined kafka.scala.version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,13 +150,13 @@
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.11</artifactId>
+            <artifactId>kafka_${kafka.scala.version}</artifactId>
             <version>${kafka.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.11</artifactId>
+            <artifactId>kafka_${kafka.scala.version}</artifactId>
             <type>test-jar</type>
             <classifier>test</classifier>
             <scope>test</scope>


### PR DESCRIPTION
A predefined default version is provided in the common pom so we default to using the most recent Scala version where possible and so we don't have to build all versions in some other cases (such as system tests).