### PR TITLE
Bump kafka to 2.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,13 +150,13 @@
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.11</artifactId>
+            <artifactId>kafka_2.12</artifactId>
             <version>${kafka.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.11</artifactId>
+            <artifactId>kafka_2.12</artifactId>
             <type>test-jar</type>
             <classifier>test</classifier>
             <scope>test</scope>


### PR DESCRIPTION
muckrake 5.2.x system tests are building `kafka_2.12` but this package is requiring `kafka_2.11` so tests are failing

failing test example: https://jenkins.confluent.io/job/system-test-confluent-platform-branch-builder/1759/consoleFull

follow up: do we need a similar bump for master?