### PR TITLE
CC-4054: Remove the use of null_value (default values) for text and binary based fields

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/Mapping.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/Mapping.java
@@ -197,13 +197,12 @@ public class Mapping {
           break;
         case ElasticsearchSinkConnectorConstants.STRING_TYPE:
         case ElasticsearchSinkConnectorConstants.TEXT_TYPE:
-          // IGNORE default values for text types as this is not supported by ES side.
+        case ElasticsearchSinkConnectorConstants.BINARY_TYPE:
+          // IGNORE default values for text and binary types as this is not supported by ES side.
           // see https://www.elastic.co/guide/en/elasticsearch/reference/current/text.html
+          // https://www.elastic.co/guide/en/elasticsearch/reference/current/binary.html
           // for more details.
           //defaultValueNode = null;
-          break;
-        case ElasticsearchSinkConnectorConstants.BINARY_TYPE:
-          defaultValueNode = JsonNodeFactory.instance.binaryNode(bytes(defaultValue));
           break;
         case ElasticsearchSinkConnectorConstants.BOOLEAN_TYPE:
           defaultValueNode = JsonNodeFactory.instance.booleanNode((boolean) defaultValue);

--- a/src/main/java/io/confluent/connect/elasticsearch/Mapping.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/Mapping.java
@@ -197,7 +197,10 @@ public class Mapping {
           break;
         case ElasticsearchSinkConnectorConstants.STRING_TYPE:
         case ElasticsearchSinkConnectorConstants.TEXT_TYPE:
-          defaultValueNode = JsonNodeFactory.instance.textNode((String) defaultValue);
+          // IGNORE default values for text types as this is not supported by ES side.
+          // see https://www.elastic.co/guide/en/elasticsearch/reference/current/text.html
+          // for more details.
+          //defaultValueNode = null;
           break;
         case ElasticsearchSinkConnectorConstants.BINARY_TYPE:
           defaultValueNode = JsonNodeFactory.instance.binaryNode(bytes(defaultValue));


### PR DESCRIPTION
This PR remove the usage of null_values as part of the generated elasticsearch mappings for textual (searchable) fields. 

Before this PR, anyone willing to use text based fields need to create their mappings manually as the inferred one was wrong. As you can see from https://www.elastic.co/guide/en/elasticsearch/reference/current/text.html#text-params, this option is not accepted for text fields.

this PR cleans up as well the problem for binary fields

fixes  #285 #132 #271 #99