### PR TITLE
fix: set connect-runtime to test scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,7 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-runtime</artifactId>
             <version>${kafka.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>


### PR DESCRIPTION
Changing `connect-runtime` to `test` scope to avoid conflicts with explicit dependencies.


Per @rhauch -
> It’s possible that the transitive dependencies of the Connect runtime may be added or conflict with other explicit dependencies, potentially bringing in the wrong versions and/or adding them unnecessarily to the generated archive.