### PR TITLE
If the index is not create by JestElasticsearchClient (or it just be …

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
@@ -270,7 +270,11 @@ public class JestElasticsearchClient implements ElasticsearchClient {
     Action<?> action = new IndicesExists.Builder(index).build();
     try {
       JestResult result = client.execute(action);
-      return result.isSucceeded();
+      boolean exists = result.isSucceeded();
+      if(exists) {
+        indexCache.add(index);
+      }
+      return exists;
     } catch (IOException e) {
       throw new ConnectException(e);
     }


### PR DESCRIPTION
If the index is not create by JestElasticsearchClient (or it just be already exist) , we will not to cache it , and call Jest client to check if it exists repeat and repeat.
It will dramatically decrease the performance , in my case it will be 3000 documents per second be wrote in the elasticsearch that not cache index , and 9000 documents per seconds if we cached the index.