### PR TITLE
CC-4788: Added elastic.security.protocol.

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -163,7 +163,8 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   private static final String ELASTICSEARCH_SECURITY_PROTOCOL_CONFIG = "elastic.security.protocol";
   private static final String ELASTICSEARCH_SECURITY_PROTOCOL_DOC =
       "The security protocol to use when connecting to Elasticsearch. "
-          + "Values can be `PLAINTEXT` or `SSL`.";
+          + "Values can be `PLAINTEXT` or `SSL`. If `PLAINTEXT` is passed, "
+          + "all configs prefixed by " + CONNECTION_SSL_CONFIG_PREFIX + " will be ignored.";
 
   protected static ConfigDef baseConfigDef() {
     final ConfigDef configDef = new ConfigDef();
@@ -330,7 +331,6 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   }
 
   public boolean secured() {
-    getString(ElasticsearchSinkConnectorConfig.ELASTICSEARCH_SECURITY_PROTOCOL_CONFIG);
     SecurityProtocol securityProtocol = securityProtocol();
     return SecurityProtocol.SSL.equals(securityProtocol);
   }

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -25,7 +25,6 @@ import java.util.Map;
 
 import static io.confluent.connect.elasticsearch.DataConverter.BehaviorOnNullValues;
 import static io.confluent.connect.elasticsearch.bulk.BulkProcessor.BehaviorOnMalformedDoc;
-import static io.confluent.connect.elasticsearch.jest.JestElasticsearchClient.WriteMethod;
 import static org.apache.kafka.common.config.SslConfigs.addClientSslSupport;
 
 public class ElasticsearchSinkConnectorConfig extends AbstractConfig {

--- a/src/main/java/io/confluent/connect/elasticsearch/SecurityProtocol.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/SecurityProtocol.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.elasticsearch;
+
+public enum SecurityProtocol {
+
+  /**
+   * Un-authenticated, non-encrypted channel
+   */
+  PLAINTEXT(0, "PLAINTEXT"),
+  /**
+   * SSL channel
+   */
+  SSL(1, "SSL");
+
+  private final int id;
+  private final String name;
+
+  SecurityProtocol(int id, String name) {
+    this.id = id;
+    this.name = name;
+  }
+}

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
@@ -78,13 +78,20 @@ public class ElasticsearchSinkConnectorConfigTest {
     assertFalse(new ElasticsearchSinkConnectorConfig(props).secured());
 
     props.put("connection.url", "https://host:9999");
-    assertTrue(new ElasticsearchSinkConnectorConfig(props).secured());
+    assertFalse(new ElasticsearchSinkConnectorConfig(props).secured());
 
     props.put("connection.url", "http://host1:9992,https://host:9999");
-    assertTrue(new ElasticsearchSinkConnectorConfig(props).secured());
+    assertFalse(new ElasticsearchSinkConnectorConfig(props).secured());
 
     // Default behavior should be backwards compat
     props.put("connection.url", "host1:9992");
+    assertFalse(new ElasticsearchSinkConnectorConfig(props).secured());
+
+    props.put("elastic.security.protocol", SecurityProtocol.SSL.name());
+    assertTrue(new ElasticsearchSinkConnectorConfig(props).secured());
+
+    props.put("elastic.security.protocol", SecurityProtocol.PLAINTEXT.name());
+    props.put("connection.url", "https://host:9999");
     assertFalse(new ElasticsearchSinkConnectorConfig(props).secured());
   }
 }

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/SecurityIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/SecurityIT.java
@@ -82,6 +82,7 @@ public class SecurityIT {
     // Start connector
     Map<String, String> props = getProps();
     props.put("connection.url", address);
+    props.put("elastic.security.protocol", "SSL");
     props.put("elastic.https.ssl.keystore.location", "./src/test/resources/certs/keystore.jks");
     props.put("elastic.https.ssl.keystore.password", "asdfasdf");
     props.put("elastic.https.ssl.key.password", "asdfasdf");


### PR DESCRIPTION
Relying on `connection.url` is not sufficient in some case, e.g. when users have configured Worker to talk to ES, which is behind proxy, and proxy terminates SSL and uses plaintext.
This PR adds an additional configuration parameter, `elastic.security.protocol`, with two possible values: `PLAINTEXT`(default) and `SSL` which should be already known to users.