### PR TITLE
changed jest version and handled generics warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,8 @@ You can build kafka-connect-elasticsearch with Maven using the standard lifecycl
 
 This project is licensed under the [Confluent Community License](LICENSE).
 
+# Notes
+
+- While installing confluent-common, please make sure they had set the kafka version correctly in their pom.xml to the kafka version you are going to 'gradle installAll', if not, change it to what you just installed manually.
 
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fconfluentinc%2Fkafka-connect-elasticsearch.svg?type=large)](https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fconfluentinc%2Fkafka-connect-elasticsearch?ref=badge_large)

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <properties>
         <es.version>2.4.1</es.version>
         <lucene.version>5.5.2</lucene.version>
-        <jest.version>2.4.0</jest.version>
+        <jest.version>6.3.1</jest.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
         <version.docker.maven.plugin>0.28.0</version.docker.maven.plugin>

--- a/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
@@ -322,7 +322,7 @@ public class DataConverter {
   }
 
   private Object preProcessArrayValue(Object value, Schema schema, Schema newSchema) {
-    Collection collection = (Collection) value;
+    Collection<?> collection = (Collection) value;
     List<Object> result = new ArrayList<>();
     for (Object element: collection) {
       result.add(preProcessValue(element, schema.valueSchema(), newSchema.valueSchema()));

--- a/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
@@ -336,7 +336,7 @@ public class JestElasticsearchClient implements ElasticsearchClient {
   }
 
   // visible for testing
-  protected BulkableAction toBulkableAction(IndexableRecord record) {
+  protected BulkableAction<?> toBulkableAction(IndexableRecord record) {
     // If payload is null, the record was a tombstone and we should delete from the index.
     if (record.payload == null) {
       return toDeleteRequest(record);
@@ -431,7 +431,11 @@ public class JestElasticsearchClient implements ElasticsearchClient {
   }
 
   public void close() {
-    client.shutdownClient();
+    try {
+      client.close();
+    } catch (IOException e) {
+      log.error("Could not close client", e);
+    }
   }
 
   public enum WriteMethod {

--- a/src/test/java/io/confluent/connect/elasticsearch/DataConverterTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/DataConverterTest.java
@@ -234,7 +234,7 @@ public class DataConverterTest {
         SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.INT32_SCHEMA).build(),
         preProcessedSchema
     );
-    HashMap newValue = (HashMap) converter.preProcessValue(origValue, origSchema, preProcessedSchema);
+    HashMap<?,?> newValue = (HashMap) converter.preProcessValue(origValue, origSchema, preProcessedSchema);
     assertEquals(origValue, newValue);
   }
 

--- a/src/test/java/io/confluent/connect/elasticsearch/bulk/BulkProcessorTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/bulk/BulkProcessorTest.java
@@ -372,10 +372,9 @@ public class BulkProcessorTest {
     // Test both IGNORE and WARN options
     // There is no difference in logic between IGNORE and WARN, except for the logging.
     // Test to ensure they both work the same logically
-    final List<BehaviorOnMalformedDoc> behaviorsToTest = new ArrayList<BehaviorOnMalformedDoc>() {{
-      add(BehaviorOnMalformedDoc.WARN);
-      add(BehaviorOnMalformedDoc.IGNORE);
-    }};
+    final List<BehaviorOnMalformedDoc> behaviorsToTest = new ArrayList<BehaviorOnMalformedDoc>();
+    behaviorsToTest.add(BehaviorOnMalformedDoc.WARN);
+    behaviorsToTest.add(BehaviorOnMalformedDoc.IGNORE);
 
     for(BehaviorOnMalformedDoc behaviorOnMalformedDoc : behaviorsToTest)
     {

--- a/src/test/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClientTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClientTest.java
@@ -30,6 +30,7 @@ import io.searchbox.action.BulkableAction;
 import io.searchbox.client.JestClient;
 import io.searchbox.client.JestClientFactory;
 import io.searchbox.client.JestResult;
+import io.searchbox.client.config.ElasticsearchVersion;
 import io.searchbox.client.config.HttpClientConfig;
 import io.searchbox.cluster.NodesInfo;
 import io.searchbox.core.BulkResult;
@@ -55,6 +56,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatcher;
 import org.mockito.InOrder;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -174,7 +176,7 @@ public class JestElasticsearchClientTest {
       @Override
       public boolean matches(CreateIndex createIndex) {
         // check the URI as the equals method on CreateIndex doesn't work
-        return createIndex.getURI().equals(INDEX);
+        return createIndex.getURI(ElasticsearchVersion.UNKNOWN).equals(INDEX);
       }
     };
   }
@@ -318,18 +320,18 @@ public class JestElasticsearchClientTest {
   }
 
   @Test
-  public void closes() {
+  public void closes() throws IOException {
     JestElasticsearchClient client = new JestElasticsearchClient(jestClient);
     client.close();
 
-    verify(jestClient).shutdownClient();
+    verify(jestClient).close();
   }
 
   @Test
   public void toBulkableAction(){
     JestElasticsearchClient client = new JestElasticsearchClient(jestClient);
     IndexableRecord del = new IndexableRecord(new Key("idx", "tp", "xxx"), null, 1L);
-    BulkableAction ba = client.toBulkableAction(del);
+    BulkableAction<?> ba = client.toBulkableAction(del);
     assertNotNull(ba);
     assertSame(Delete.class, ba.getClass());
     assertEquals(del.key.index, ba.getIndex());


### PR DESCRIPTION
Handled generics warnings and changed jest version to 6.3.1(in pom.xml) in order to avoid field deprecation warnings on Elasticsearch version 6.1 on
Solves this issue: #295 