### PR TITLE
CC-5605: Log version conflicts as warnings.

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
@@ -379,7 +379,7 @@ public class JestElasticsearchClient implements ElasticsearchClient {
     }
 
     if (!versionConflicts.isEmpty()) {
-      LOG.debug("Ignoring version conflicts for items: {}", versionConflicts);
+      LOG.warn("Ignoring version conflicts for items: {}", versionConflicts);
       if (errors.isEmpty()) {
         // The only errors were version conflicts
         return BulkResponse.success();


### PR DESCRIPTION
This PR handles version conflicts for upsert use-case when a topic has multiple partitions and there is no guarantee that messages with the same ids will be written to the same partition.

We are assuming that when we use a user-provided key(`ignoreKey=false`), all messages with the same id are produced to the same partition, thus we use message's offset as version when writing a document to ES.

Example:
User has a topic `moon` with 10 partitions, and produces a message `{"entityId": "42": "color": "red"}`, it gets written to partition 1, with offset 50.
💚 ES Connector sends a document to ES: `Key:42, Version:50, Payload:{"color": "red"}`.
Then, the next message with the same id is produced `{"entityId": "42": "color": "red"}`, it gets written to partition 2, with offset 30.
🔴 ES Connector sends a document to ES: `Key:42, Version:30, Payload:{"color": "red"}`, it gets rejected with DEBUG `Ignoring version conflicts for items`.

Solution:
Use `timestamp` from a message, if it's present, failback to offset.

