### PR TITLE
MINOR: Fix SecurityIT to work on different host IPs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <es.version>2.4.1</es.version>
         <lucene.version>5.5.2</lucene.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <mockito.version>2.13.0</mockito.version>
+        <mockito.version>2.28.2</mockito.version>
         <jest.version>6.3.1</jest.version>
         <test.containers.version>1.11.4</test.containers.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/SecurityIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/SecurityIT.java
@@ -111,11 +111,8 @@ public class SecurityIT {
    */
   @Test
   public void testSecureConnection() throws Throwable {
-    final String address = String.format(
-        "https://%s:%d",
-        container.getContainerIpAddress(),
-        container.getMappedPort(9200)
-    );
+    // Use 'localhost' here because that's the IP address the certificates allow
+    final String address = String.format("https://localhost:%d", container.getMappedPort(9200));
     log.info("Creating connector for {}", address);
 
     connect.kafka().createTopic(KAFKA_TOPIC, 1);
@@ -160,6 +157,9 @@ public class SecurityIT {
               .get("value").getAsInt();
           log.debug("Found {} documents", found);
           return found == NUM_MSG;
+        } catch (NullPointerException e) {
+          // no valid results yet, but kind of expected so no need to log
+          return false;
         } catch (Exception e) {
           log.error("Retrying after failing to read data from Elastic: {}", e.getMessage(), e);
           return false;


### PR DESCRIPTION
The build runs locally, but fails on Jenkins because the Elasticsearch TestContainer returns the IP address for the host on Jenkins but `locahost` on a dev machine. This is likely due to how Docker is configured on Jenkins vs locally. This change always makes the test use `localhost` for the ES address.