### PR TITLE
Add indices to the internal cache if exist and not created by the connector

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
@@ -233,7 +233,11 @@ public class JestElasticsearchClient implements ElasticsearchClient {
     Action<?> action = new IndicesExists.Builder(index).build();
     try {
       JestResult result = client.execute(action);
-      return result.isSucceeded();
+      boolean isSucceded = result.isSucceeded();
+      if (isSucceded) {
+        indexCache.add(index);
+      }
+      return isSucceded;
     } catch (IOException e) {
       throw new ConnectException(e);
     }


### PR DESCRIPTION
If an index exist in Elasticsearch and is used by the connector, during the index creation verification we check with the server if the required index exist.

This call is protected with an internal cache, to not overflow the elasticsearch server.  However this case has not been covered in previous improvements.

This PR add the index to the cache in that case, covering the two cases, an index created by the connector or directly in elasticsearch.

Fix #332 