### PR TITLE
CC-6187: Cache already existing index in JestElasticsearchClient

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
@@ -195,7 +195,11 @@ public class JestElasticsearchClient implements ElasticsearchClient {
     Action action = new IndicesExists.Builder(index).build();
     try {
       JestResult result = client.execute(action);
-      return result.isSucceeded();
+      boolean exists = result.isSucceeded();
+      if(exists) {
+        indexCache.add(index);
+      }
+      return exists;
     } catch (IOException e) {
       throw new ConnectException(e);
     }

--- a/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
@@ -196,7 +196,7 @@ public class JestElasticsearchClient implements ElasticsearchClient {
     try {
       JestResult result = client.execute(action);
       boolean exists = result.isSucceeded();
-      if(exists) {
+      if (exists) {
         indexCache.add(index);
       }
       return exists;


### PR DESCRIPTION
If an already existing index is not cached in JestElasticsearchClient, performance will decrease.  For instance, the difference could be 3000 documents per second written in the elasticsearch when the preexisting index is not cached, versus 9000 documents per seconds if the index is cached.

Commit imported from the original [PR](https://github.com/confluentinc/kafka-connect-elasticsearch/pull/309)

had to rebase to point at the 4.1.x branch instead of master