### PR TITLE
Add maxConnectionIdleTime parameter in JestElasticsearchClient

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -179,6 +179,11 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
           + "Values can be `PLAINTEXT` or `SSL`. If `PLAINTEXT` is passed, "
           + "all configs prefixed by " + CONNECTION_SSL_CONFIG_PREFIX + " will be ignored.";
 
+  public static final String MAX_CONNECTION_IDLE_TIME_MS_CONFIG = "max.connection.idle.time.ms";
+  private static final String MAX_CONNECTION_IDLE_TIME_MS_CONFIG_DOC = "Time "
+        + "in milliseconds after which an unused connection is dropped to prevent "
+        + "a timeout.";
+
   protected static ConfigDef baseConfigDef() {
     final ConfigDef configDef = new ConfigDef();
     addConnectorConfigs(configDef);
@@ -340,6 +345,16 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
         ++order,
         Width.SHORT,
         "Create indices at startup"
+    ).define(
+        MAX_CONNECTION_IDLE_TIME_MS_CONFIG,
+        Type.INT,
+        "60000",
+        Importance.LOW,
+        MAX_CONNECTION_IDLE_TIME_MS_CONFIG_DOC,
+        group,
+        ++order,
+        Width.SHORT,
+        "Max Connection Idle"
     );
   }
 

--- a/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
@@ -69,6 +69,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.net.ssl.SSLContext;
 
@@ -161,6 +162,8 @@ public class JestElasticsearchClient implements ElasticsearchClient {
         ElasticsearchSinkConnectorConfig.CONNECTION_TIMEOUT_MS_CONFIG);
     final int readTimeout = config.getInt(
         ElasticsearchSinkConnectorConfig.READ_TIMEOUT_MS_CONFIG);
+    final int maxIdleTime = config.getInt(
+        ElasticsearchSinkConnectorConfig.MAX_CONNECTION_IDLE_TIME_MS_CONFIG);
 
     final String username = config.getString(
         ElasticsearchSinkConnectorConfig.CONNECTION_USERNAME_CONFIG);
@@ -173,6 +176,7 @@ public class JestElasticsearchClient implements ElasticsearchClient {
         new HttpClientConfig.Builder(address)
             .connTimeout(connTimeout)
             .readTimeout(readTimeout)
+            .maxConnectionIdleTime(maxIdleTime, TimeUnit.MILLISECONDS)
             .multiThreaded(true);
     if (username != null && password != null) {
       builder.defaultCredentials(username, password.value())


### PR DESCRIPTION
closes #189 

If a connection isn't used for a while, a `java.net.SocketTimeoutException: Read timed out` could occurs.

The following parameter has been added in Connector configuration to set the **maxConnectionIdleTime** in **JestElasticsearchClient** :
`max.connection.idle.time.ms`