### PR TITLE
Document external version with custom modes supported

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
@@ -16,6 +16,7 @@
 package io.confluent.connect.elasticsearch;
 
 import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.record.Record;
 import org.apache.kafka.connect.data.ConnectSchema;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
@@ -56,6 +57,7 @@ public class DataConverter {
 
   private final boolean useCompactMapEntries;
   private final BehaviorOnNullValues behaviorOnNullValues;
+  private final DocumentVersionType documentVersionType;
 
   /**
    * Create a DataConverter, specifying how map entries with string keys within record
@@ -63,15 +65,16 @@ public class DataConverter {
    * <code>"entryKey": "entryValue"</code>, while the non-compact form are written as a nested
    * document such as <code>{"key": "entryKey", "value": "entryValue"}</code>. All map entries
    * with non-string keys are always written as nested documents.
-   *
-   * @param useCompactMapEntries true for compact map entries with string keys, or false for
+   *  @param useCompactMapEntries true for compact map entries with string keys, or false for
    *                             the nested document form.
    * @param behaviorOnNullValues behavior for handling records with null values; may not be null
+   * @param documentVersionType document version generated with method
    */
-  public DataConverter(boolean useCompactMapEntries, BehaviorOnNullValues behaviorOnNullValues) {
+  public DataConverter(boolean useCompactMapEntries, BehaviorOnNullValues behaviorOnNullValues, DocumentVersionType documentVersionType) {
     this.useCompactMapEntries = useCompactMapEntries;
     this.behaviorOnNullValues =
         Objects.requireNonNull(behaviorOnNullValues, "behaviorOnNullValues cannot be null.");
+    this.documentVersionType = documentVersionType;
   }
 
   private String convertKey(Schema keySchema, Object key) {
@@ -161,8 +164,33 @@ public class DataConverter {
     }
 
     final String payload = getPayload(record, ignoreSchema);
-    final Long version = ignoreKey ? null : record.kafkaOffset();
+    final Long version = getIndexableRecordVersion(record, ignoreKey);
     return new IndexableRecord(new Key(index, type, id), payload, version);
+  }
+
+  private Long getIndexableRecordVersion(SinkRecord record, boolean ignoreKey){
+    Long version;
+    switch (documentVersionType){
+      case LEGACY:
+        version = ignoreKey ? null : record.kafkaOffset();
+        break;
+      case MESSAGE_TIMESTAMP:
+        version = record.timestamp();
+        break;
+      case UNUSED:
+        version = null;
+        break;
+      case MESSAGE_OFFSET:
+        version = record.kafkaOffset();
+        break;
+      default:
+        throw new RuntimeException(String.format(
+                "Unknown value for %s enum: %s",
+                DocumentVersionType.class.getSimpleName(),
+                documentVersionType
+        ));
+    }
+    return version;
   }
 
   private String getPayload(SinkRecord record, boolean ignoreSchema) {
@@ -366,6 +394,54 @@ public class DataConverter {
       newStruct.put(field.name(), converted);
     }
     return newStruct;
+  }
+
+  public enum DocumentVersionType {
+    LEGACY,
+    UNUSED,
+    MESSAGE_OFFSET,
+    MESSAGE_TIMESTAMP;
+
+    public static final DocumentVersionType DEFAULT = LEGACY;
+
+    public static final ConfigDef.Validator VALIDATOR = new ConfigDef.Validator() {
+      private final ConfigDef.ValidString validator = ConfigDef.ValidString.in(names());
+
+      @Override
+      public void ensureValid(String name, Object value) {
+        if (value instanceof String) {
+          value = ((String) value).toLowerCase(Locale.ROOT);
+        }
+        validator.ensureValid(name, value);
+      }
+
+      // Overridden here so that ConfigDef.toEnrichedRst shows possible values correctly
+      @Override
+      public String toString() {
+        return validator.toString();
+      }
+
+    };
+
+    public static String[] names() {
+      DocumentVersionType[] documentVersionTypes = values();
+      String[] result = new String[documentVersionTypes.length];
+
+      for (int i = 0; i < documentVersionTypes.length; i++) {
+        result[i] = documentVersionTypes[i].toString();
+      }
+
+      return result;
+    }
+
+    public static DocumentVersionType forValue(String value) {
+      return valueOf(value.toUpperCase(Locale.ROOT));
+    }
+
+    @Override
+    public String toString() {
+      return name().toLowerCase(Locale.ROOT);
+    }
   }
 
   public enum BehaviorOnNullValues {

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -27,6 +27,7 @@ import static io.confluent.connect.elasticsearch.jest.JestElasticsearchClient.Wr
 import static io.confluent.connect.elasticsearch.DataConverter.BehaviorOnNullValues;
 import static io.confluent.connect.elasticsearch.bulk.BulkProcessor.BehaviorOnMalformedDoc;
 import static org.apache.kafka.common.config.SslConfigs.addClientSslSupport;
+import static io.confluent.connect.elasticsearch.DataConverter.DocumentVersionType;
 
 public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   private static final String SSL_GROUP = "Security";
@@ -178,6 +179,15 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
       "The security protocol to use when connecting to Elasticsearch. "
           + "Values can be `PLAINTEXT` or `SSL`. If `PLAINTEXT` is passed, "
           + "all configs prefixed by " + CONNECTION_SSL_CONFIG_PREFIX + " will be ignored.";
+
+
+  public static final String ELASTICSEARCH_DOCUMENT_VERSION_TYPE_CONFIG = "elastic.document.version.type";
+  private static final String ELASTICSEARCH_DOCUMENT_VERSION_TYPE_DOC =
+          "The version type being used by connector. "
+                  + "Values can be " + DocumentVersionType.LEGACY + ", "
+                  + DocumentVersionType.UNUSED + ", "
+                  + DocumentVersionType.MESSAGE_OFFSET + ", "
+                  + DocumentVersionType.MESSAGE_TIMESTAMP + ".";
 
   protected static ConfigDef baseConfigDef() {
     final ConfigDef configDef = new ConfigDef();
@@ -466,7 +476,18 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
         group,
         ++order,
         Width.SHORT,
-        "Write method");
+        "Write method"
+    ).define(
+            ELASTICSEARCH_DOCUMENT_VERSION_TYPE_CONFIG,
+            Type.STRING,
+            "legacy",
+            Importance.LOW,
+            ELASTICSEARCH_DOCUMENT_VERSION_TYPE_DOC,
+            group,
+            ++order,
+            Width.SHORT,
+            "Document version"
+    );
   }
 
   public static final ConfigDef CONFIG = baseConfigDef();

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -103,7 +103,10 @@ public class ElasticsearchSinkTask extends SinkTask {
           BulkProcessor.BehaviorOnMalformedDoc.forValue(
               config.getString(ElasticsearchSinkConnectorConfig.BEHAVIOR_ON_MALFORMED_DOCS_CONFIG)
           );
-
+    DataConverter.DocumentVersionType documentVersionType =
+            DataConverter.DocumentVersionType.forValue(
+                    config.getString(ElasticsearchSinkConnectorConfig.ELASTICSEARCH_DOCUMENT_VERSION_TYPE_CONFIG)
+            );
       // Calculate the maximum possible backoff time ...
       long maxRetryBackoffMs =
           RetryUtil.computeRetryWaitTimeInMillis(maxRetry, retryBackoffMs);
@@ -137,7 +140,8 @@ public class ElasticsearchSinkTask extends SinkTask {
           .setMaxRetry(maxRetry)
           .setDropInvalidMessage(dropInvalidMessage)
           .setBehaviorOnNullValues(behaviorOnNullValues)
-          .setBehaviorOnMalformedDoc(behaviorOnMalformedDoc);
+          .setBehaviorOnMalformedDoc(behaviorOnMalformedDoc)
+          .setDocumentVersionType(documentVersionType);
 
       this.createIndicesAtStartTime = createIndicesAtStartTime;
 

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
@@ -72,7 +72,8 @@ public class ElasticsearchWriter {
       long retryBackoffMs,
       boolean dropInvalidMessage,
       BehaviorOnNullValues behaviorOnNullValues,
-      BehaviorOnMalformedDoc behaviorOnMalformedDoc
+      BehaviorOnMalformedDoc behaviorOnMalformedDoc,
+      DataConverter.DocumentVersionType documentVersionType
   ) {
     this.client = client;
     this.type = type;
@@ -84,7 +85,7 @@ public class ElasticsearchWriter {
     this.flushTimeoutMs = flushTimeoutMs;
     this.dropInvalidMessage = dropInvalidMessage;
     this.behaviorOnNullValues = behaviorOnNullValues;
-    this.converter = new DataConverter(useCompactMapEntries, behaviorOnNullValues);
+    this.converter = new DataConverter(useCompactMapEntries, behaviorOnNullValues, documentVersionType);
     this.behaviorOnMalformedDoc = behaviorOnMalformedDoc;
 
     bulkProcessor = new BulkProcessor<>(
@@ -121,6 +122,8 @@ public class ElasticsearchWriter {
     private boolean dropInvalidMessage;
     private BehaviorOnNullValues behaviorOnNullValues = BehaviorOnNullValues.DEFAULT;
     private BehaviorOnMalformedDoc behaviorOnMalformedDoc;
+
+    private DataConverter.DocumentVersionType documentVersionType;
 
     public Builder(ElasticsearchClient client) {
       this.client = client;
@@ -210,6 +213,11 @@ public class ElasticsearchWriter {
       return this;
     }
 
+    public Builder setDocumentVersionType(DataConverter.DocumentVersionType documentVersionType) {
+      this.documentVersionType = documentVersionType;
+      return this;
+    }
+
     public ElasticsearchWriter build() {
       return new ElasticsearchWriter(
           client,
@@ -229,7 +237,8 @@ public class ElasticsearchWriter {
           retryBackoffMs,
           dropInvalidMessage,
           behaviorOnNullValues,
-          behaviorOnMalformedDoc
+          behaviorOnMalformedDoc,
+          documentVersionType
       );
     }
   }

--- a/src/test/java/io/confluent/connect/elasticsearch/DataConverterTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/DataConverterTest.java
@@ -48,7 +48,7 @@ public class DataConverterTest {
 
   @Before
   public void setUp() {
-    converter = new DataConverter(true, BehaviorOnNullValues.DEFAULT);
+    converter = new DataConverter(true, BehaviorOnNullValues.DEFAULT, DataConverter.DocumentVersionType.LEGACY);
     key = "key";
     topic = "topic";
     partition = 0;
@@ -194,7 +194,7 @@ public class DataConverterTest {
     origValue.put("field2", 2);
 
     // Use the older non-compact format for map entries with string keys
-    converter = new DataConverter(false, BehaviorOnNullValues.DEFAULT);
+    converter = new DataConverter(false, BehaviorOnNullValues.DEFAULT, DataConverter.DocumentVersionType.LEGACY);
 
     Schema preProcessedSchema = converter.preProcessSchema(origSchema);
     assertEquals(
@@ -228,7 +228,7 @@ public class DataConverterTest {
     origValue.put("field2", 2);
 
     // Use the newer compact format for map entries with string keys
-    converter = new DataConverter(true, BehaviorOnNullValues.DEFAULT);
+    converter = new DataConverter(true, BehaviorOnNullValues.DEFAULT, DataConverter.DocumentVersionType.LEGACY);
     Schema preProcessedSchema = converter.preProcessSchema(origSchema);
     assertEquals(
         SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.INT32_SCHEMA).build(),
@@ -272,7 +272,7 @@ public class DataConverterTest {
     testOptionalFieldWithoutDefault(SchemaBuilder.struct().field("innerField", Schema.BOOLEAN_SCHEMA));
     testOptionalFieldWithoutDefault(SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.BOOLEAN_SCHEMA));
     // Have to test maps with useCompactMapEntries set to true and set to false
-    converter = new DataConverter(false, BehaviorOnNullValues.DEFAULT);
+    converter = new DataConverter(false, BehaviorOnNullValues.DEFAULT, DataConverter.DocumentVersionType.LEGACY);
     testOptionalFieldWithoutDefault(SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.BOOLEAN_SCHEMA));
   }
 
@@ -293,7 +293,7 @@ public class DataConverterTest {
 
   @Test
   public void ignoreOnNullValue() {
-    converter = new DataConverter(true, BehaviorOnNullValues.IGNORE);
+    converter = new DataConverter(true, BehaviorOnNullValues.IGNORE, DataConverter.DocumentVersionType.LEGACY);
 
     SinkRecord sinkRecord = createSinkRecordWithValue(null);
     assertNull(converter.convertRecord(sinkRecord, index, type, false, false));
@@ -301,7 +301,7 @@ public class DataConverterTest {
 
   @Test
   public void deleteOnNullValue() {
-    converter = new DataConverter(true, BehaviorOnNullValues.DELETE);
+    converter = new DataConverter(true, BehaviorOnNullValues.DELETE, DataConverter.DocumentVersionType.LEGACY);
 
     SinkRecord sinkRecord = createSinkRecordWithValue(null);
     IndexableRecord expectedRecord = createIndexableRecordWithPayload(null);
@@ -312,7 +312,7 @@ public class DataConverterTest {
 
   @Test
   public void ignoreDeleteOnNullValueWithNullKey() {
-    converter = new DataConverter(true, BehaviorOnNullValues.DELETE);
+    converter = new DataConverter(true, BehaviorOnNullValues.DELETE, DataConverter.DocumentVersionType.LEGACY);
     key = null;
 
     SinkRecord sinkRecord = createSinkRecordWithValue(null);
@@ -321,7 +321,7 @@ public class DataConverterTest {
 
   @Test
   public void failOnNullValue() {
-    converter = new DataConverter(true, BehaviorOnNullValues.FAIL);
+    converter = new DataConverter(true, BehaviorOnNullValues.FAIL, DataConverter.DocumentVersionType.LEGACY);
 
     SinkRecord sinkRecord = createSinkRecordWithValue(null);
     try {

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTestBase.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTestBase.java
@@ -57,7 +57,7 @@ public class ElasticsearchSinkTestBase extends ESIntegTestCase {
   public void setUp() throws Exception {
     super.setUp();
     client = new JestElasticsearchClient("http://localhost:" + getPort());
-    converter = new DataConverter(true, BehaviorOnNullValues.IGNORE);
+    converter = new DataConverter(true, BehaviorOnNullValues.IGNORE, DataConverter.DocumentVersionType.LEGACY);
   }
 
   @After

--- a/src/test/java/io/confluent/connect/elasticsearch/MappingTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/MappingTest.java
@@ -163,7 +163,7 @@ public class MappingTest extends ElasticsearchSinkTestBase {
       }
     }
 
-    DataConverter converter = new DataConverter(true, BehaviorOnNullValues.IGNORE);
+    DataConverter converter = new DataConverter(true, BehaviorOnNullValues.IGNORE, DataConverter.DocumentVersionType.LEGACY);
     Schema.Type schemaType = schema.type();
     switch (schemaType) {
       case ARRAY:

--- a/src/test/java/io/confluent/connect/elasticsearch/TestUtils.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/TestUtils.java
@@ -75,7 +75,7 @@ public class TestUtils {
       }
     }
 
-    DataConverter converter = new DataConverter(true, BehaviorOnNullValues.IGNORE);
+    DataConverter converter = new DataConverter(true, BehaviorOnNullValues.IGNORE, DataConverter.DocumentVersionType.LEGACY);
     Schema.Type schemaType = schema.type();
     switch (schemaType) {
       case ARRAY:

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchIntegrationTestBase.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchIntegrationTestBase.java
@@ -74,7 +74,7 @@ public class ElasticsearchIntegrationTestBase {
   public void setUp() {
     log.info("Attempting to connect to {}", container.getConnectionUrl());
     client = new JestElasticsearchClient(container.getConnectionUrl());
-    converter = new DataConverter(true, BehaviorOnNullValues.IGNORE);
+    converter = new DataConverter(true, BehaviorOnNullValues.IGNORE, DataConverter.DocumentVersionType.LEGACY);
   }
 
   @After


### PR DESCRIPTION
Here are issues with fixed ES document version:
https://github.com/confluentinc/kafka-connect-elasticsearch/issues/142
https://github.com/confluentinc/kafka-connect-elasticsearch/issues/308

I implemented the feature for user need customize the ES external version by kafka message offset, kafka message timestamp, or default with legacy operation. 