### PR TITLE
CC-7367: Add a lot more logging

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -9,7 +9,7 @@
     <!-- switch statements on types exceed maximum complexity -->
     <suppress
             checks="(CyclomaticComplexity)"
-            files="(JestElasticsearchClient|Mapping|DataConverter).java"
+            files="(JestElasticsearchClient|Mapping|DataConverter|ElasticsearchWriter).java"
     />
 
     <!-- TODO: Undecided if this is too much -->

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -9,7 +9,7 @@
     <!-- switch statements on types exceed maximum complexity -->
     <suppress
             checks="(CyclomaticComplexity)"
-            files="(JestElasticsearchClient|Mapping|DataConverter|ElasticsearchWriter).java"
+            files="(JestElasticsearchClient|Mapping).java"
     />
 
     <!-- TODO: Undecided if this is too much -->

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -9,7 +9,7 @@
     <!-- switch statements on types exceed maximum complexity -->
     <suppress
             checks="(CyclomaticComplexity)"
-            files="(JestElasticsearchClient|Mapping).java"
+            files="(JestElasticsearchClient|Mapping|DataConverter).java"
     />
 
     <!-- TODO: Undecided if this is too much -->

--- a/pom.xml
+++ b/pom.xml
@@ -250,7 +250,7 @@
                 <inherited>true</inherited>
                 <configuration>
                     <compilerArgs>
-                        <arg>-Xlint:all</arg>
+                        <arg>-Xlint:all,-try</arg>
                         <arg>-Werror</arg>
                     </compilerArgs>
                 </configuration>

--- a/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
@@ -30,6 +30,8 @@ import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.storage.Converter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
@@ -47,6 +49,7 @@ import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConst
 
 public class DataConverter {
 
+  private static final Logger log = LoggerFactory.getLogger(DataConverter.class);
   private static final Converter JSON_CONVERTER;
 
   static {
@@ -115,6 +118,14 @@ public class DataConverter {
     if (record.value() == null) {
       switch (behaviorOnNullValues) {
         case IGNORE:
+          if (log.isTraceEnabled()) {
+            log.trace(
+                "Ignoring record with null value at topic '{}', partition {}, offset {}",
+                record.topic(),
+                record.kafkaPartition(),
+                record.kafkaOffset()
+            );
+          }
           return null;
         case DELETE:
           if (record.key() == null) {
@@ -125,9 +136,26 @@ public class DataConverter {
             // offset information for the SinkRecord. Since that information is guaranteed to be
             // unique per message, we can be confident that there wouldn't be any corresponding
             // index present in ES to delete anyways.
+            if (log.isTraceEnabled()) {
+              log.trace(
+                  "Ignoring record with null key at topic '{}', partition {}, offset {}, since "
+                  + "the record key is used as the ID of the index",
+                  record.topic(),
+                  record.kafkaPartition(),
+                  record.kafkaOffset()
+              );
+            }
             return null;
           }
           // Will proceed as normal, ultimately creating an IndexableRecord with a null payload
+          if (log.isTraceEnabled()) {
+            log.trace(
+                "Deleting from Elasticsearch record at topic '{}', partition {}, offset {}",
+                record.topic(),
+                record.kafkaPartition(),
+                record.kafkaOffset()
+            );
+          }
           break;
         case FAIL:
           throw new DataException(String.format(

--- a/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
@@ -118,14 +118,12 @@ public class DataConverter {
     if (record.value() == null) {
       switch (behaviorOnNullValues) {
         case IGNORE:
-          if (log.isTraceEnabled()) {
-            log.trace(
-                "Ignoring record with null value at topic '{}', partition {}, offset {}",
-                record.topic(),
-                record.kafkaPartition(),
-                record.kafkaOffset()
-            );
-          }
+          log.trace(
+              "Ignoring record with null value at topic '{}', partition {}, offset {}",
+              record.topic(),
+              record.kafkaPartition(),
+              record.kafkaOffset()
+          );
           return null;
         case DELETE:
           if (record.key() == null) {
@@ -136,26 +134,22 @@ public class DataConverter {
             // offset information for the SinkRecord. Since that information is guaranteed to be
             // unique per message, we can be confident that there wouldn't be any corresponding
             // index present in ES to delete anyways.
-            if (log.isTraceEnabled()) {
-              log.trace(
-                  "Ignoring record with null key at topic '{}', partition {}, offset {}, since "
-                  + "the record key is used as the ID of the index",
-                  record.topic(),
-                  record.kafkaPartition(),
-                  record.kafkaOffset()
-              );
-            }
-            return null;
-          }
-          // Will proceed as normal, ultimately creating an IndexableRecord with a null payload
-          if (log.isTraceEnabled()) {
             log.trace(
-                "Deleting from Elasticsearch record at topic '{}', partition {}, offset {}",
+                "Ignoring record with null key at topic '{}', partition {}, offset {}, since "
+                + "the record key is used as the ID of the index",
                 record.topic(),
                 record.kafkaPartition(),
                 record.kafkaOffset()
             );
+            return null;
           }
+          // Will proceed as normal, ultimately creating an IndexableRecord with a null payload
+          log.trace(
+              "Deleting from Elasticsearch record at topic '{}', partition {}, offset {}",
+              record.topic(),
+              record.kafkaPartition(),
+              record.kafkaOffset()
+          );
           break;
         case FAIL:
           throw new DataException(String.format(

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -144,8 +144,9 @@ public class ElasticsearchSinkTask extends SinkTask {
       writer = builder.build();
       writer.start();
       log.info(
-          "Started ElasticsearchSinkTask, will {} records with null values",
-          behaviorOnNullValues
+          "Started ElasticsearchSinkTask, will {} records with null values ('{}')",
+          behaviorOnNullValues,
+          ElasticsearchSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG
       );
     } catch (ConfigException e) {
       throw new ConnectException(

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -186,7 +186,7 @@ public class ElasticsearchSinkTask extends SinkTask {
 
   @Override
   public void stop() throws ConnectException {
-    log.info("Stopping ElasticsearchSinkTask.");
+    log.info("Stopping ElasticsearchSinkTask");
     if (writer != null) {
       writer.stop();
     }

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -55,7 +55,7 @@ public class ElasticsearchSinkTask extends SinkTask {
   // public for testing
   public void start(Map<String, String> props, ElasticsearchClient client) {
     try {
-      log.info("Starting ElasticsearchSinkTask.");
+      log.info("Starting ElasticsearchSinkTask");
 
       ElasticsearchSinkConnectorConfig config = new ElasticsearchSinkConnectorConfig(props);
       String type = config.getString(ElasticsearchSinkConnectorConfig.TYPE_NAME_CONFIG);
@@ -143,7 +143,10 @@ public class ElasticsearchSinkTask extends SinkTask {
 
       writer = builder.build();
       writer.start();
-      log.info("Elasticsearch sink task will {} records with null values", behaviorOnNullValues);
+      log.info(
+          "Started ElasticsearchSinkTask, will {} records with null values",
+          behaviorOnNullValues
+      );
     } catch (ConfigException e) {
       throw new ConnectException(
           "Couldn't start ElasticsearchSinkTask due to configuration error:",

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -143,6 +143,7 @@ public class ElasticsearchSinkTask extends SinkTask {
 
       writer = builder.build();
       writer.start();
+      log.info("Elasticsearch sink task will {} records with null values", behaviorOnNullValues);
     } catch (ConfigException e) {
       throw new ConnectException(
           "Couldn't start ElasticsearchSinkTask due to configuration error:",
@@ -165,13 +166,13 @@ public class ElasticsearchSinkTask extends SinkTask {
 
   @Override
   public void put(Collection<SinkRecord> records) throws ConnectException {
-    log.trace("Putting {} to Elasticsearch.", records);
+    log.debug("Putting {} records to Elasticsearch", records.size());
     writer.write(records);
   }
 
   @Override
   public void flush(Map<TopicPartition, OffsetAndMetadata> offsets) {
-    log.trace("Flushing data to Elasticsearch with the following offsets: {}", offsets);
+    log.debug("Flushing data to Elasticsearch with the following offsets: {}", offsets);
     writer.flush();
   }
 

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
@@ -238,9 +238,9 @@ public class ElasticsearchWriter {
     log.debug("Writing {} records to Elasticsearch", records.size());
     for (SinkRecord sinkRecord : records) {
       log.trace("Writing record to Elasticsearch: topic/partition/offset {}/{}/{}",
-        sinkRecord.topic(),
-        sinkRecord.kafkaPartition(),
-        sinkRecord.kafkaOffset());
+          sinkRecord.topic(),
+          sinkRecord.kafkaPartition(),
+          sinkRecord.kafkaOffset());
       // Preemptively skip records with null values if they're going to be ignored anyways
       if (ignoreRecord(sinkRecord)) {
         log.trace(

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
@@ -302,7 +302,7 @@ public class ElasticsearchWriter {
       if (record != null) {
         if (log.isTraceEnabled()) {
           log.trace(
-              "Adding record from topic '{}', partition {}, offset {} to bulk processor",
+              "Adding record from topic/partition/offset {}/{}/{} to bulk processor",
               sinkRecord.topic(),
               sinkRecord.kafkaPartition(),
               sinkRecord.kafkaOffset()
@@ -313,7 +313,7 @@ public class ElasticsearchWriter {
     } catch (ConnectException convertException) {
       if (dropInvalidMessage) {
         log.error(
-            "Can't convert record from topic {} with partition {} and offset {}. "
+            "Can't convert record from topic/partition/offset {}/{}/{}. "
                 + "Error message: {}",
             sinkRecord.topic(),
             sinkRecord.kafkaPartition(),

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
@@ -235,7 +235,6 @@ public class ElasticsearchWriter {
   }
 
   public void write(Collection<SinkRecord> records) {
-    log.debug("Writing {} records to Elasticsearch", records.size());
     for (SinkRecord sinkRecord : records) {
       // Preemptively skip records with null values if they're going to be ignored anyways
       if (ignoreRecord(sinkRecord)) {

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
@@ -238,23 +238,19 @@ public class ElasticsearchWriter {
     for (SinkRecord sinkRecord : records) {
       // Preemptively skip records with null values if they're going to be ignored anyways
       if (ignoreRecord(sinkRecord)) {
-        if (log.isTraceEnabled()) {
-          log.trace(
-              "Ignoring sink record with null value for topic/partition/offset {}/{}/{}",
-              sinkRecord.topic(),
-              sinkRecord.kafkaPartition(),
-              sinkRecord.kafkaOffset()
-          );
-        }
-        continue;
-      }
-      if (log.isTraceEnabled()) {
-        log.trace("Writing record to Elasticsearch: topic/partition/offset {}/{}/{}",
+        log.trace(
+            "Ignoring sink record with null value for topic/partition/offset {}/{}/{}",
             sinkRecord.topic(),
             sinkRecord.kafkaPartition(),
             sinkRecord.kafkaOffset()
         );
+        continue;
       }
+      log.trace("Writing record to Elasticsearch: topic/partition/offset {}/{}/{}",
+          sinkRecord.topic(),
+          sinkRecord.kafkaPartition(),
+          sinkRecord.kafkaOffset()
+      );
 
       final String index = convertTopicToIndexName(sinkRecord.topic());
       final boolean ignoreKey = ignoreKeyTopics.contains(sinkRecord.topic()) || this.ignoreKey;
@@ -299,14 +295,12 @@ public class ElasticsearchWriter {
           ignoreKey,
           ignoreSchema);
       if (record != null) {
-        if (log.isTraceEnabled()) {
-          log.trace(
-              "Adding record from topic/partition/offset {}/{}/{} to bulk processor",
-              sinkRecord.topic(),
-              sinkRecord.kafkaPartition(),
-              sinkRecord.kafkaOffset()
-          );
-        }
+        log.trace(
+            "Adding record from topic/partition/offset {}/{}/{} to bulk processor",
+            sinkRecord.topic(),
+            sinkRecord.kafkaPartition(),
+            sinkRecord.kafkaOffset()
+        );
         bulkProcessor.add(record, flushTimeoutMs);
       }
     } catch (ConnectException convertException) {

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
@@ -240,7 +240,7 @@ public class ElasticsearchWriter {
       log.trace("Writing record to Elasticsearch: {}", sinkRecord);
       // Preemptively skip records with null values if they're going to be ignored anyways
       if (ignoreRecord(sinkRecord)) {
-        log.debug(
+        log.trace(
             "Ignoring sink record with key {} and null value for topic/partition/offset {}/{}/{}",
             sinkRecord.key(),
             sinkRecord.topic(),
@@ -326,7 +326,7 @@ public class ElasticsearchWriter {
   private String convertTopicToIndexName(String topic) {
     final String indexOverride = topicToIndexMap.get(topic);
     String index = indexOverride != null ? indexOverride : topic.toLowerCase();
-    log.debug("Topic '{}' was translated as index '{}'", topic, index);
+    log.trace("Topic '{}' was translated as index '{}'", topic, index);
     return index;
   }
 

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
@@ -237,12 +237,14 @@ public class ElasticsearchWriter {
   public void write(Collection<SinkRecord> records) {
     log.debug("Writing {} records to Elasticsearch", records.size());
     for (SinkRecord sinkRecord : records) {
-      log.trace("Writing record to Elasticsearch: {}", sinkRecord);
+      log.trace("Writing record to Elasticsearch: topic/partition/offset {}/{}/{}",
+        sinkRecord.topic(),
+        sinkRecord.kafkaPartition(),
+        sinkRecord.kafkaOffset());
       // Preemptively skip records with null values if they're going to be ignored anyways
       if (ignoreRecord(sinkRecord)) {
         log.trace(
-            "Ignoring sink record with key {} and null value for topic/partition/offset {}/{}/{}",
-            sinkRecord.key(),
+            "Ignoring sink record with null value for topic/partition/offset {}/{}/{}",
             sinkRecord.topic(),
             sinkRecord.kafkaPartition(),
             sinkRecord.kafkaOffset());

--- a/src/main/java/io/confluent/connect/elasticsearch/LogContext.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/LogContext.java
@@ -46,7 +46,11 @@ public class LogContext implements AutoCloseable {
   @Override
   public void close() {
     if (currentContext != null) {
-      MDC.put(CONNECTOR_CONTEXT, previousContext);
+      if (previousContext != null) {
+        MDC.put(CONNECTOR_CONTEXT, previousContext);
+      } else {
+        MDC.remove(CONNECTOR_CONTEXT);
+      }
     }
   }
 }

--- a/src/main/java/io/confluent/connect/elasticsearch/LogContext.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/LogContext.java
@@ -23,13 +23,8 @@ public class LogContext implements AutoCloseable {
   private final String currentContext;
 
   public LogContext() {
-    this(null);
+    this(MDC.get(CONNECTOR_CONTEXT), null);
   }
-
-  public LogContext(String suffix) {
-    this(MDC.get(CONNECTOR_CONTEXT), suffix);
-  }
-
 
   protected LogContext(String currentContext, String suffix) {
     this.previousContext = currentContext;

--- a/src/main/java/io/confluent/connect/elasticsearch/LogContext.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/LogContext.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright [2018 - 2018] Confluent Inc.
+ */
+
+package io.confluent.connect.elasticsearch;
+
+import org.slf4j.MDC;
+
+public class LogContext implements AutoCloseable {
+
+  private static final String CONNECTOR_CONTEXT = "connector.context";
+
+  private final String previousContext;
+  private final String currentContext;
+
+  public LogContext() {
+    this(null);
+  }
+
+  public LogContext(String suffix) {
+    previousContext = MDC.get(CONNECTOR_CONTEXT);
+    if (previousContext != null && suffix != null && !suffix.trim().isEmpty()) {
+      currentContext = previousContext + " " + suffix + " ";
+      MDC.put(CONNECTOR_CONTEXT, currentContext);
+    } else {
+      currentContext = null;
+    }
+  }
+
+  public LogContext create(String suffix) {
+    return new LogContext(suffix);
+  }
+
+  @Override
+  public void close() {
+    if (currentContext != null) {
+      MDC.put(CONNECTOR_CONTEXT, previousContext);
+    }
+  }
+}

--- a/src/main/java/io/confluent/connect/elasticsearch/bulk/BulkProcessor.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/bulk/BulkProcessor.java
@@ -366,6 +366,7 @@ public class BulkProcessor<R, B> {
 
     @Override
     public BulkResponse call() throws Exception {
+      long startTime = System.currentTimeMillis();
       final BulkResponse rsp;
       try {
         rsp = execute();
@@ -373,7 +374,8 @@ public class BulkProcessor<R, B> {
         failAndStop(e);
         throw e;
       }
-      log.debug("Successfully executed batch {} of {} records", batchId, batch.size());
+      log.debug("Successfully executed batch {} of {} records in {} ms",
+          batchId, batch.size(), System.currentTimeMillis() - startTime);
       onBatchCompletion(batch.size());
       return rsp;
     }

--- a/src/main/java/io/confluent/connect/elasticsearch/bulk/BulkProcessor.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/bulk/BulkProcessor.java
@@ -211,7 +211,7 @@ public class BulkProcessor<R, B> {
    * <p>This should only be called after a previous {@link #stop()} invocation.
    */
   public void awaitStop(long timeoutMs) {
-    log.trace("awaitStop {}", timeoutMs);
+    log.debug("awaitStop {}", timeoutMs);
     assert stopRequested;
     try {
       if (!executor.awaitTermination(timeoutMs, TimeUnit.MILLISECONDS)) {
@@ -283,7 +283,7 @@ public class BulkProcessor<R, B> {
 
     int numBufferedRecords = bufferedRecords();
     if (numBufferedRecords >= maxBufferedRecords) {
-      log.trace(
+      log.debug(
           "Number of buffered records ({}) exceeds {}; waiting up to {} ms",
           numBufferedRecords,
           maxBufferedRecords,
@@ -395,7 +395,7 @@ public class BulkProcessor<R, B> {
       for (int attempts = 1, retryAttempts = 0; true; ++attempts, ++retryAttempts) {
         boolean retriable = true;
         try {
-          log.trace("Executing batch {} of {} records with attempt {}/{}",
+          log.debug("Executing batch {} of {} records with attempt {}/{}",
                   batchId, batch.size(), attempts, maxAttempts);
           final BulkResponse bulkRsp = bulkClient.execute(bulkReq);
           if (bulkRsp.isSucceeded()) {

--- a/src/main/java/io/confluent/connect/elasticsearch/bulk/BulkProcessor.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/bulk/BulkProcessor.java
@@ -286,10 +286,9 @@ public class BulkProcessor<R, B> {
 
     int numBufferedRecords = bufferedRecords();
     if (numBufferedRecords >= maxBufferedRecords) {
-      log.debug(
-          "Number of buffered records ({}) exceeds {}; waiting up to {} ms",
+      log.trace(
+          "Buffer full at {} records, so waiting up to {} ms before adding",
           numBufferedRecords,
-          maxBufferedRecords,
           timeoutMs
       );
       final long addStartTimeMs = time.milliseconds();
@@ -306,14 +305,12 @@ public class BulkProcessor<R, B> {
       if (bufferedRecords() >= maxBufferedRecords) {
         throw new ConnectException("Add timeout expired before buffer availability");
       }
-      if (log.isTraceEnabled()) {
-        log.trace(
-            "Adding record to queue after blocking {} ms",
-            time.milliseconds() - addStartTimeMs
-        );
-      }
+      log.debug(
+          "Adding record to queue after waiting {} ms",
+          time.milliseconds() - addStartTimeMs
+      );
     } else {
-      log.trace("Adding record to unsent queue");
+      log.trace("Adding record to queue");
     }
 
     unsentRecords.addLast(record);
@@ -416,7 +413,7 @@ public class BulkProcessor<R, B> {
       for (int attempts = 1, retryAttempts = 0; true; ++attempts, ++retryAttempts) {
         boolean retriable = true;
         try {
-          log.debug("Executing batch {} of {} records with attempt {}/{}",
+          log.trace("Executing batch {} of {} records with attempt {}/{}",
                   batchId, batch.size(), attempts, maxAttempts);
           final BulkResponse bulkRsp = bulkClient.execute(bulkReq);
           if (bulkRsp.isSucceeded()) {

--- a/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
@@ -212,7 +212,7 @@ public class JestElasticsearchClient implements ElasticsearchClient {
     NodesInfo info = new NodesInfo.Builder().addCleanApiParameter("version").build();
     JsonObject result = client.execute(info).getJsonObject();
     if (result == null) {
-      LOG.warn("Couldn't get Elasticsearch version, result is null");
+      LOG.warn("Couldn't get Elasticsearch version (result is null); assuming {}", defaultVersion);
       return defaultVersion;
     }
 
@@ -220,32 +220,50 @@ public class JestElasticsearchClient implements ElasticsearchClient {
 
     JsonObject nodesRoot = result.get("nodes").getAsJsonObject();
     if (nodesRoot == null || nodesRoot.entrySet().size() == 0) {
-      LOG.warn("Couldn't get Elasticsearch version, nodesRoot is null or empty");
+      LOG.warn(
+          "Couldn't get Elasticsearch version (response nodesRoot is null or empty); assuming {}",
+          defaultVersion
+      );
       return defaultVersion;
     }
 
     JsonObject nodeRoot = nodesRoot.entrySet().iterator().next().getValue().getAsJsonObject();
     if (nodeRoot == null) {
-      LOG.warn("Couldn't get Elasticsearch version, nodeRoot is null");
+      LOG.warn(
+          "Couldn't get Elasticsearch version (response nodeRoot is null); assuming {}",
+          defaultVersion
+      );
       return defaultVersion;
     }
 
     String esVersion = nodeRoot.get("version").getAsString();
+    Version version;
     if (esVersion == null) {
-      LOG.warn("Couldn't get Elasticsearch version, version is null");
-      return defaultVersion;
+      version = defaultVersion;
+      LOG.warn(
+          "Couldn't get Elasticsearch version (response version is null); assuming {}",
+          version
+      );
     } else if (esVersion.startsWith("1.")) {
-      return Version.ES_V1;
+      version = Version.ES_V1;
+      log.info("Detected Elasticsearch version is {}", version);
     } else if (esVersion.startsWith("2.")) {
-      return Version.ES_V2;
+      version = Version.ES_V2;
+      log.info("Detected Elasticsearch version is {}", version);
     } else if (esVersion.startsWith("5.")) {
-      return Version.ES_V5;
+      version = Version.ES_V5;
+      log.info("Detected Elasticsearch version is {}", version);
     } else if (esVersion.startsWith("6.")) {
-      return Version.ES_V6;
+      version = Version.ES_V6;
+      log.info("Detected Elasticsearch version is {}", version);
     } else if (esVersion.startsWith("7.")) {
-      return Version.ES_V7;
+      version = Version.ES_V7;
+      log.info("Detected Elasticsearch version is {}", version);
+    } else {
+      version = defaultVersion;
+      log.info("Detected unexpected Elasticsearch version {}, using {}", esVersion, version);
     }
-    return defaultVersion;
+    return version;
   }
 
   private void checkForError(JsonObject result) {
@@ -268,10 +286,15 @@ public class JestElasticsearchClient implements ElasticsearchClient {
     }
     Action<?> action = new IndicesExists.Builder(index).build();
     try {
+      log.info("Index '{}' not found in local cache; checking for existence", index);
       JestResult result = client.execute(action);
+      log.debug("Received response for checking existence of index '{}'", index);
       boolean exists = result.isSucceeded();
       if (exists) {
         indexCache.add(index);
+        log.info("Index '{}' exists in Elasticsearch; adding to local cache", index);
+      } else {
+        log.info("Index '{}' not found in Elasticsearch", index);
       }
       return exists;
     } catch (IOException e) {
@@ -280,17 +303,23 @@ public class JestElasticsearchClient implements ElasticsearchClient {
   }
 
   public void createIndices(Set<String> indices) {
+    log.trace("Attempting to discover or create indexes in Elasticsearch: {}", indices);
     for (String index : indices) {
       if (!indexExists(index)) {
         CreateIndex createIndex = new PortableJestCreateIndexBuilder(index, version).build();
         try {
+          log.info("Requesting Elasticsearch create index '{}'", index);
           JestResult result = client.execute(createIndex);
+          log.debug("Received response for request to create index '{}'", index);
           if (!result.isSucceeded()) {
             // Check if index was created by another client
             if (!indexExists(index)) {
               String msg = result.getErrorMessage() != null ? ": " + result.getErrorMessage() : "";
               throw new ConnectException("Could not create index '" + index + "'" + msg);
             }
+            log.info("Index '{}' exists in Elasticsearch; adding to local cache", index);
+          } else {
+            log.info("Index '{}' created in Elasticsearch; adding to local cache", index);
           }
           indexCache.add(index);
         } catch (IOException e) {
@@ -305,24 +334,28 @@ public class JestElasticsearchClient implements ElasticsearchClient {
     obj.set(type, Mapping.inferMapping(this, schema));
     PutMapping putMapping = new PortableJestPutMappingBuilder(index, type, obj.toString(), version)
         .build();
+    log.info("Creating mapping (type={}) for index '{}' and schema {}", type, index, schema);
     JestResult result = client.execute(putMapping);
     if (!result.isSucceeded()) {
       throw new ConnectException(
           "Cannot create mapping " + obj + " -- " + result.getErrorMessage()
       );
     }
+    log.info("Created mapping (type={}) for index '{}' and schema {}", type, index, schema);
   }
 
   /**
    * Get the JSON mapping for given index and type. Returns {@code null} if it does not exist.
    */
   public JsonObject getMapping(String index, String type) throws IOException {
+    log.info("Get mapping (type={}) for index '{}'", type, index);
     final JestResult result = client.execute(
         new PortableJestGetMappingBuilder(version)
             .addIndex(index)
             .addType(type)
             .build()
     );
+    log.debug("Received mapping (type={}) for index '{}'", type, index);
     final JsonObject indexRoot = result.getJsonObject().getAsJsonObject(index);
     if (indexRoot == null) {
       return null;
@@ -337,19 +370,35 @@ public class JestElasticsearchClient implements ElasticsearchClient {
   /**
    * Delete all indexes in Elasticsearch (useful for test)
    */
+  // For testing purposes
   public void deleteAll() throws IOException {
-    client.execute(new DeleteIndex
+    log.info("Request deletion of all indexes");
+    final JestResult result = client.execute(new DeleteIndex
         .Builder(ALL_FIELD_PARAM)
         .build());
+    if (result.isSucceeded()) {
+      log.info("Deletion of all indexes succeeded");
+    } else {
+      String msg = result.getErrorMessage() != null ? ": " + result.getErrorMessage() : "";
+      log.warn("Could not delete all indexes: {}", msg);
+    }
   }
 
   /**
-   * Refresh all data in elasticsearch, making it available for search
+   * Refresh all data in elasticsearch, making it available for search (useful for testing)
    */
+  // For testing purposes
   public void refresh() throws IOException {
-    client.execute(
+    log.info("Request refresh");
+    final JestResult result = client.execute(
         new Refresh.Builder().build()
     );
+    if (result.isSucceeded()) {
+      log.info("Refresh completed");
+    } else {
+      String msg = result.getErrorMessage() != null ? ": " + result.getErrorMessage() : "";
+      log.warn("Could not refresh: {}", msg);
+    }
   }
 
   public BulkRequest createBulkRequest(List<IndexableRecord> batch) {
@@ -387,11 +436,14 @@ public class JestElasticsearchClient implements ElasticsearchClient {
   }
 
   public BulkResponse executeBulk(BulkRequest bulk) throws IOException {
+    log.trace("Executing bulk request");
     final BulkResult result = client.execute(((JestBulkRequest) bulk).getBulk());
 
     if (result.isSucceeded()) {
+      log.trace("Bulk request succeeded");
       return BulkResponse.success();
     }
+    log.trace("Bulk request failed; collecting error(s)");
 
     boolean retriable = true;
 
@@ -426,6 +478,7 @@ public class JestElasticsearchClient implements ElasticsearchClient {
     return BulkResponse.failure(retriable, errorInfo);
   }
 
+  // For testing purposes
   public JsonObject search(String query, String index, String type) throws IOException {
     final Search.Builder search = new Search.Builder(query);
     if (index != null) {
@@ -435,13 +488,24 @@ public class JestElasticsearchClient implements ElasticsearchClient {
       search.addType(type);
     }
 
+    log.info("Executing search on index '{}' (type={}): {}", index, type, query);
     final SearchResult result = client.execute(search.build());
-
+    if (result.isSucceeded()) {
+      log.info(
+          "Executing search succeeded with {} total results and {} max score",
+          result.getTotal(),
+          result.getMaxScore()
+      );
+    } else {
+      String msg = result.getErrorMessage() != null ? ": " + result.getErrorMessage() : "";
+      log.warn("Failed to execute search: {}", msg);
+    }
     return result.getJsonObject();
   }
 
   public void close() {
     try {
+      log.debug("Closing Elasticsearch client");
       client.close();
     } catch (IOException e) {
       LOG.error("Exception while closing the JEST client", e);

--- a/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
@@ -438,11 +438,9 @@ public class JestElasticsearchClient implements ElasticsearchClient {
   }
 
   public BulkResponse executeBulk(BulkRequest bulk) throws IOException {
-    log.debug("Executing bulk request");
     final BulkResult result = client.execute(((JestBulkRequest) bulk).getBulk());
 
     if (result.isSucceeded()) {
-      log.debug("Bulk request succeeded");
       return BulkResponse.success();
     }
     log.debug("Bulk request failed; collecting error(s)");

--- a/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
@@ -436,14 +436,14 @@ public class JestElasticsearchClient implements ElasticsearchClient {
   }
 
   public BulkResponse executeBulk(BulkRequest bulk) throws IOException {
-    log.trace("Executing bulk request");
+    log.debug("Executing bulk request");
     final BulkResult result = client.execute(((JestBulkRequest) bulk).getBulk());
 
     if (result.isSucceeded()) {
-      log.trace("Bulk request succeeded");
+      log.debug("Bulk request succeeded");
       return BulkResponse.success();
     }
-    log.trace("Bulk request failed; collecting error(s)");
+    log.debug("Bulk request failed; collecting error(s)");
 
     boolean retriable = true;
 

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchSinkTaskIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchSinkTaskIT.java
@@ -31,6 +31,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.slf4j.MDC;
 
 @Category(IntegrationTest.class)
 public class ElasticsearchSinkTaskIT extends ElasticsearchIntegrationTestBase {
@@ -39,6 +40,7 @@ public class ElasticsearchSinkTaskIT extends ElasticsearchIntegrationTestBase {
 
   @Before
   public void beforeEach() {
+    MDC.put("connector.context", "[MyConnector|task1] ");
     Map<String, String> props = createProps();
     task.start(props, client);
   }
@@ -48,6 +50,7 @@ public class ElasticsearchSinkTaskIT extends ElasticsearchIntegrationTestBase {
     if (task != null) {
       task.stop();
     }
+    MDC.remove("connector.context");
   }
 
   private Map<String, String> createProps() {

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchSinkTaskIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchSinkTaskIT.java
@@ -27,11 +27,28 @@ import java.util.Map;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 @Category(IntegrationTest.class)
 public class ElasticsearchSinkTaskIT extends ElasticsearchIntegrationTestBase {
+
+  private ElasticsearchSinkTask task = new ElasticsearchSinkTask();
+
+  @Before
+  public void beforeEach() {
+    Map<String, String> props = createProps();
+    task.start(props, client);
+  }
+
+  @After
+  public void afterEach() {
+    if (task != null) {
+      task.stop();
+    }
+  }
 
   private Map<String, String> createProps() {
     Map<String, String> props = new HashMap<>();
@@ -43,10 +60,7 @@ public class ElasticsearchSinkTaskIT extends ElasticsearchIntegrationTestBase {
 
   @Test
   public void testPutAndFlush() throws Exception {
-    Map<String, String> props = createProps();
 
-    ElasticsearchSinkTask task = new ElasticsearchSinkTask();
-    task.start(props, client);
     task.open(new HashSet<>(Arrays.asList(TOPIC_PARTITION, TOPIC_PARTITION2, TOPIC_PARTITION3)));
 
     String key = "key";

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchSinkTaskIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchSinkTaskIT.java
@@ -40,7 +40,7 @@ public class ElasticsearchSinkTaskIT extends ElasticsearchIntegrationTestBase {
 
   @Before
   public void beforeEach() {
-    MDC.put("connector.context", "[MyConnector|task1] ");
+    //MDC.put("connector.context", "[MyConnector|task1] ");
     Map<String, String> props = createProps();
     task.start(props, client);
   }

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchSinkTaskIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchSinkTaskIT.java
@@ -40,7 +40,7 @@ public class ElasticsearchSinkTaskIT extends ElasticsearchIntegrationTestBase {
 
   @Before
   public void beforeEach() {
-    //MDC.put("connector.context", "[MyConnector|task1] ");
+    MDC.put("connector.context", "[MyConnector|task1] ");
     Map<String, String> props = createProps();
     task.start(props, client);
   }

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -17,7 +17,7 @@ log4j.rootLogger=INFO, stdout
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
+log4j.appender.stdout.layout.ConversionPattern=[%d] %p %X{connector.context}%m (%c:%L)%n
 
 log4j.logger.org.apache.kafka=ERROR
 log4j.logger.org.apache.zookeeper=ERROR
@@ -25,3 +25,5 @@ log4j.logger.org.I0Itec.zkclient=ERROR
 log4j.logger.org.reflections=ERROR
 log4j.logger.org.eclipse.jetty=ERROR
 log4j.logger.org.glassfish.jersey.internal=ERROR
+
+log4j.logger.io.confluent.connect.elasticsearch=DEBUG

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -17,6 +17,7 @@ log4j.rootLogger=INFO, stdout
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+#log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
 log4j.appender.stdout.layout.ConversionPattern=[%d] %p %X{connector.context}%m (%c:%L)%n
 
 log4j.logger.org.apache.kafka=ERROR


### PR DESCRIPTION
Some logging was added at INFO level when it would not occur under nominal operation, more at DEBUG level to identify what the connector is doing and when while still not writing individual record details, and a few more at TRACE that output which messages are being processed.

I tried to be a bit conservative in terms of the log level, so as to not overwhelm the log during normal or even debug operation.