### PR TITLE
ESCALATION-2214 : Add retries for create index

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
@@ -92,6 +92,7 @@ public class JestElasticsearchClient implements ElasticsearchClient {
 
   private final JestClient client;
   private final Version version;
+  private long timeout;
   private WriteMethod writeMethod = WriteMethod.DEFAULT;
 
   private final Set<String> indexCache = new HashSet<>();
@@ -152,6 +153,7 @@ public class JestElasticsearchClient implements ElasticsearchClient {
       this.retryBackoffMs =
               config.getLong(ElasticsearchSinkConnectorConfig.RETRY_BACKOFF_MS_CONFIG);
       this.maxRetries = config.getInt(ElasticsearchSinkConnectorConfig.MAX_RETRIES_CONFIG);
+      this.timeout = config.getLong(ElasticsearchSinkConnectorConfig.READ_TIMEOUT_MS_CONFIG);
     } catch (IOException e) {
       throw new ConnectException(
           "Couldn't start ElasticsearchSinkTask due to connection error:",
@@ -332,7 +334,7 @@ public class JestElasticsearchClient implements ElasticsearchClient {
       if (!indexExists(index)) {
         final int maxAttempts = maxRetries + 1;
         final int attempts = 1;
-        CreateIndex createIndex = new PortableJestCreateIndexBuilder(index, version).build();
+        CreateIndex createIndex = new PortableJestCreateIndexBuilder(index, version, timeout).build();
         boolean indexed = false;
         while (!indexed) {
           try {

--- a/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
@@ -353,7 +353,7 @@ public class JestElasticsearchClient implements ElasticsearchClient {
             indexed = true;
           } catch (IOException e) {
             if (attempts < maxAttempts) {
-              long sleepTimeMs = RetryUtil.computeRandomRetryWaitTimeInMillis(attempts-1,
+              long sleepTimeMs = RetryUtil.computeRandomRetryWaitTimeInMillis(attempts - 1,
                   retryBackoffMs);
               log.warn("Failed to create index {} with attempt {}/{}, "
                       + "will attempt retry after {} ms. Failure reason: {}",

--- a/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
@@ -333,7 +333,7 @@ public class JestElasticsearchClient implements ElasticsearchClient {
     for (String index : indices) {
       if (!indexExists(index)) {
         final int maxAttempts = maxRetries + 1;
-        final int attempts = 1;
+        int attempts = 1;
         CreateIndex createIndex = new PortableJestCreateIndexBuilder(index, version, timeout).build();
         boolean indexed = false;
         while (!indexed) {
@@ -351,6 +351,7 @@ public class JestElasticsearchClient implements ElasticsearchClient {
             } else {
               throw new ConnectException(e);
             }
+            attempts++;
           }
         }
       }

--- a/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
@@ -334,7 +334,8 @@ public class JestElasticsearchClient implements ElasticsearchClient {
       if (!indexExists(index)) {
         final int maxAttempts = maxRetries + 1;
         int attempts = 1;
-        CreateIndex createIndex = new PortableJestCreateIndexBuilder(index, version, timeout).build();
+        CreateIndex createIndex =
+            new PortableJestCreateIndexBuilder(index, version, timeout).build();
         boolean indexed = false;
         while (!indexed) {
           try {

--- a/src/main/java/io/confluent/connect/elasticsearch/jest/actions/PortableJestCreateIndexBuilder.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/actions/PortableJestCreateIndexBuilder.java
@@ -44,7 +44,9 @@ public class PortableJestCreateIndexBuilder extends CreateIndex.Builder {
     if (version.equals(Version.ES_V7)) {
       setParameter(INCLUDE_TYPE_NAME_PARAM, true);
     }
-    setParameter(TIMEOUT_PARAM, timeout);
+    if (timeout > 0) {
+      setParameter(TIMEOUT_PARAM, timeout);
+    }
 
     return super.build();
   }

--- a/src/main/java/io/confluent/connect/elasticsearch/jest/actions/PortableJestCreateIndexBuilder.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/actions/PortableJestCreateIndexBuilder.java
@@ -17,7 +17,6 @@ package io.confluent.connect.elasticsearch.jest.actions;
 
 import io.confluent.connect.elasticsearch.ElasticsearchClient.Version;
 import io.searchbox.indices.CreateIndex;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Portable Jest action builder, across ES versions, to create indexes.

--- a/src/main/java/io/confluent/connect/elasticsearch/jest/actions/PortableJestCreateIndexBuilder.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/actions/PortableJestCreateIndexBuilder.java
@@ -17,6 +17,7 @@ package io.confluent.connect.elasticsearch.jest.actions;
 
 import io.confluent.connect.elasticsearch.ElasticsearchClient.Version;
 import io.searchbox.indices.CreateIndex;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Portable Jest action builder, across ES versions, to create indexes.
@@ -27,12 +28,15 @@ import io.searchbox.indices.CreateIndex;
 public class PortableJestCreateIndexBuilder extends CreateIndex.Builder {
 
   public static final String INCLUDE_TYPE_NAME_PARAM = "include_type_name";
+  public static final String TIMEOUT_PARAM = "timeout";
 
   private final Version version;
+  private final long timeout;
 
-  public PortableJestCreateIndexBuilder(String index, Version version) {
+  public PortableJestCreateIndexBuilder(String index, Version version, long timeout) {
     super(index);
     this.version = version;
+    this.timeout = TimeUnit.MILLISECONDS.toSeconds(timeout);
   }
 
   @Override
@@ -40,6 +44,8 @@ public class PortableJestCreateIndexBuilder extends CreateIndex.Builder {
     if (version.equals(Version.ES_V7)) {
       setParameter(INCLUDE_TYPE_NAME_PARAM, true);
     }
+    setParameter(TIMEOUT_PARAM, timeout);
+
     return super.build();
   }
 }

--- a/src/main/java/io/confluent/connect/elasticsearch/jest/actions/PortableJestCreateIndexBuilder.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/actions/PortableJestCreateIndexBuilder.java
@@ -36,7 +36,7 @@ public class PortableJestCreateIndexBuilder extends CreateIndex.Builder {
   public PortableJestCreateIndexBuilder(String index, Version version, long timeout) {
     super(index);
     this.version = version;
-    this.timeout = TimeUnit.MILLISECONDS.toSeconds(timeout);
+    this.timeout = timeout;
   }
 
   @Override
@@ -45,7 +45,7 @@ public class PortableJestCreateIndexBuilder extends CreateIndex.Builder {
       setParameter(INCLUDE_TYPE_NAME_PARAM, true);
     }
     if (timeout > 0) {
-      setParameter(TIMEOUT_PARAM, timeout);
+      setParameter(TIMEOUT_PARAM, timeout + "ms");
     }
 
     return super.build();

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
@@ -57,6 +57,7 @@ public class ElasticsearchSinkTaskTest extends ElasticsearchSinkTestBase {
     props.put(ElasticsearchSinkConnectorConfig.TYPE_NAME_CONFIG, TYPE);
     props.put(ElasticsearchSinkConnectorConfig.CONNECTION_URL_CONFIG, "localhost");
     props.put(ElasticsearchSinkConnectorConfig.KEY_IGNORE_CONFIG, "true");
+    props.put(ElasticsearchSinkConnectorConfig.READ_TIMEOUT_MS_CONFIG, "3000");
     return props;
   }
 


### PR DESCRIPTION
Currently, the connector has retry mechanism for the actual writes and doesn't do retries for create index.
https://confluentinc.atlassian.net/browse/ESCALATION-2214. 
In cases where elastic has a temporary glitch this leads to connector failing. Adding a retry mechanism using the same configs that are already exposed.

- Retry on IO Exception ( potentially happening because of client timeout)
- Retry on a failure response ( this is an area to be improved). ES could also timeout on server side  and we would want to retry in those situations
- pass timeout on the create index API call