### PR TITLE
Make "behavior.on.malformed.documents" also cover "action_request_validation_exception" (#325)

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -150,8 +150,8 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   public static final String BEHAVIOR_ON_MALFORMED_DOCS_CONFIG = "behavior.on.malformed.documents";
   private static final String BEHAVIOR_ON_MALFORMED_DOCS_DOC = "How to handle records that "
       + "Elasticsearch rejects due to some malformation of the document itself, such as an index"
-      + " mapping conflict, a field name containing illegal characters, or a record with a missing id."
-      + " Valid options are ignore', 'warn', and 'fail'.";
+      + " mapping conflict, a field name containing illegal characters, or a record with a missing"
+      + " id. Valid options are ignore', 'warn', and 'fail'.";
   public static final String WRITE_METHOD_CONFIG = "write.method";
   private static final String WRITE_METHOD_DOC = "Method used for writing data to Elasticsearch,"
           + " and one of " + WriteMethod.INSERT.toString() + " or " + WriteMethod.UPSERT.toString()

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -150,8 +150,8 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   public static final String BEHAVIOR_ON_MALFORMED_DOCS_CONFIG = "behavior.on.malformed.documents";
   private static final String BEHAVIOR_ON_MALFORMED_DOCS_DOC = "How to handle records that "
       + "Elasticsearch rejects due to some malformation of the document itself, such as an index"
-      + " mapping conflict or a field name containing illegal characters. Valid options are "
-      + "'ignore', 'warn', and 'fail'.";
+      + " mapping conflict, a field name containing illegal characters, or a record with a missing id."
+      + " Valid options are ignore', 'warn', and 'fail'.";
   public static final String WRITE_METHOD_CONFIG = "write.method";
   private static final String WRITE_METHOD_DOC = "Method used for writing data to Elasticsearch,"
           + " and one of " + WriteMethod.INSERT.toString() + " or " + WriteMethod.UPSERT.toString()

--- a/src/main/java/io/confluent/connect/elasticsearch/bulk/BulkProcessor.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/bulk/BulkProcessor.java
@@ -489,7 +489,8 @@ public class BulkProcessor<R, B> {
 
   private boolean responseContainsMalformedDocError(BulkResponse bulkRsp) {
     return bulkRsp.getErrorInfo().contains("mapper_parsing_exception")
-        || bulkRsp.getErrorInfo().contains("illegal_argument_exception");
+        || bulkRsp.getErrorInfo().contains("illegal_argument_exception")
+        || bulkRsp.getErrorInfo().contains("action_request_validation_exception");
   }
 
   private synchronized void onBatchCompletion(int batchSize) {


### PR DESCRIPTION
Background: I have "key.ignore=false" and have old messages in my topic that don't have keys or have empty keys. Connector tasks fail because Elasticsearch is returning a validation error:

{"root_cause":[{"type":"action_request_validation_exception","reason":"Validation Failed: 1: an id must be provided if version type or value are set;"}],"type":"action_request_validation_exception","reason":"Validation Failed: 1: an id must be provided if version type or value are set;"}

Ignore errors like this so tasks don't stop running. Addig "action_request_validation_exception" to the list covered by "behavior.on.malformed.documents".