### PR TITLE
Add configuration for Max connection idle time to prevent read timeout

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -24,4 +24,8 @@
             files="(ElasticsearchWriter).java"
     />
 
+    <suppress
+            checks="MethodLengthCheck"
+            files="ElasticsearchSinkConnectorConfig.java"/>
+
 </suppressions>

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -192,7 +192,6 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   protected static ConfigDef baseConfigDef() {
     final ConfigDef configDef = new ConfigDef();
     addConnectorConfigs(configDef);
-    addConnectorTimeoutConfigs(configDef);
     addConversionConfigs(configDef);
     addSecurityConfigs(configDef);
     return configDef;
@@ -219,82 +218,6 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
     );
   }
 
-  private static void addConnectorTimeoutConfigs(ConfigDef configDef) {
-    final String group = "Connector";
-    int order = 0;
-    configDef.define(
-        LINGER_MS_CONFIG,
-        Type.LONG,
-        1L,
-        Importance.LOW,
-        LINGER_MS_DOC,
-        group,
-        ++order,
-        Width.SHORT,
-        "Linger (ms)"
-    ).define(
-        FLUSH_TIMEOUT_MS_CONFIG,
-        Type.LONG,
-        10000L,
-        Importance.LOW,
-        FLUSH_TIMEOUT_MS_DOC,
-        group,
-        ++order,
-        Width.SHORT,
-        "Flush Timeout (ms)"
-    ).define(
-        MAX_RETRIES_CONFIG,
-        Type.INT,
-        5,
-        Importance.LOW,
-        MAX_RETRIES_DOC,
-        group,
-        ++order,
-        Width.SHORT,
-        "Max Retries"
-    ).define(
-        RETRY_BACKOFF_MS_CONFIG,
-        Type.LONG,
-        100L,
-        Importance.LOW,
-        RETRY_BACKOFF_MS_DOC,
-        group,
-        ++order,
-        Width.SHORT,
-        "Retry Backoff (ms)"
-      ).define(
-        MAX_CONNECTION_IDLE_TIME_MS_CONFIG,
-        Type.INT,
-        60000,
-        Importance.LOW,
-        MAX_CONNECTION_IDLE_TIME_MS_CONFIG_DOC,
-        group,
-        ++order,
-        Width.SHORT,
-        "Max Connection Idle Time"
-    ).define(
-        CONNECTION_TIMEOUT_MS_CONFIG, 
-        Type.INT, 
-        1000, 
-        Importance.LOW, 
-        CONNECTION_TIMEOUT_MS_CONFIG_DOC,
-        group, 
-        ++order, 
-        Width.SHORT, 
-        "Connection Timeout"
-    ).define(
-        READ_TIMEOUT_MS_CONFIG, 
-        Type.INT, 
-        3000, 
-        Importance.LOW, 
-        READ_TIMEOUT_MS_CONFIG_DOC,
-        group,
-        ++order, 
-        Width.SHORT, 
-        "Read Timeout"
-    );
-  }
-  
   private static void addConnectorConfigs(ConfigDef configDef) {
     final String group = "Connector";
     int order = 0;
@@ -358,6 +281,46 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
         Width.SHORT,
         "Max Buffered Records"
     ).define(
+        LINGER_MS_CONFIG,
+        Type.LONG,
+        1L,
+        Importance.LOW,
+        LINGER_MS_DOC,
+        group,
+        ++order,
+        Width.SHORT,
+        "Linger (ms)"
+    ).define(
+        FLUSH_TIMEOUT_MS_CONFIG,
+        Type.LONG,
+        10000L,
+        Importance.LOW,
+        FLUSH_TIMEOUT_MS_DOC,
+        group,
+        ++order,
+        Width.SHORT,
+        "Flush Timeout (ms)"
+    ).define(
+        MAX_RETRIES_CONFIG,
+        Type.INT,
+        5,
+        Importance.LOW,
+        MAX_RETRIES_DOC,
+        group,
+        ++order,
+        Width.SHORT,
+        "Max Retries"
+    ).define(
+        RETRY_BACKOFF_MS_CONFIG,
+        Type.LONG,
+        100L,
+        Importance.LOW,
+        RETRY_BACKOFF_MS_DOC,
+        group,
+        ++order,
+        Width.SHORT,
+        "Retry Backoff (ms)"
+      ).define(
         CONNECTION_COMPRESSION_CONFIG,
         Type.BOOLEAN,
         false,
@@ -368,6 +331,36 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
         Width.SHORT,
         "Compression"
       ).define(
+        MAX_CONNECTION_IDLE_TIME_MS_CONFIG,
+        Type.INT,
+        "60000",
+        Importance.LOW,
+        MAX_CONNECTION_IDLE_TIME_MS_CONFIG_DOC,
+        group,
+        ++order,
+        Width.SHORT,
+        "Max Connection Idle Time"
+    ).define(
+        CONNECTION_TIMEOUT_MS_CONFIG, 
+        Type.INT, 
+        1000, 
+        Importance.LOW, 
+        CONNECTION_TIMEOUT_MS_CONFIG_DOC,
+        group, 
+        ++order, 
+        Width.SHORT, 
+        "Connection Timeout"
+        ).define(
+        READ_TIMEOUT_MS_CONFIG, 
+        Type.INT, 
+        3000, 
+        Importance.LOW, 
+        READ_TIMEOUT_MS_CONFIG_DOC,
+        group,
+        ++order, 
+        Width.SHORT, 
+        "Read Timeout"
+    ).define(
         AUTO_CREATE_INDICES_AT_START_CONFIG,
         Type.BOOLEAN,
         true,
@@ -379,6 +372,7 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
         "Create indices at startup"
     );
   }
+
 
   public boolean secured() {
     SecurityProtocol securityProtocol = securityProtocol();

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -192,6 +192,7 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   protected static ConfigDef baseConfigDef() {
     final ConfigDef configDef = new ConfigDef();
     addConnectorConfigs(configDef);
+    addConnectorTimeoutConfigs(configDef);
     addConversionConfigs(configDef);
     addSecurityConfigs(configDef);
     return configDef;
@@ -218,6 +219,82 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
     );
   }
 
+  private static void addConnectorTimeoutConfigs(ConfigDef configDef) {
+    final String group = "Connector";
+    int order = 0;
+    configDef.define(
+        LINGER_MS_CONFIG,
+        Type.LONG,
+        1L,
+        Importance.LOW,
+        LINGER_MS_DOC,
+        group,
+        ++order,
+        Width.SHORT,
+        "Linger (ms)"
+    ).define(
+        FLUSH_TIMEOUT_MS_CONFIG,
+        Type.LONG,
+        10000L,
+        Importance.LOW,
+        FLUSH_TIMEOUT_MS_DOC,
+        group,
+        ++order,
+        Width.SHORT,
+        "Flush Timeout (ms)"
+    ).define(
+        MAX_RETRIES_CONFIG,
+        Type.INT,
+        5,
+        Importance.LOW,
+        MAX_RETRIES_DOC,
+        group,
+        ++order,
+        Width.SHORT,
+        "Max Retries"
+    ).define(
+        RETRY_BACKOFF_MS_CONFIG,
+        Type.LONG,
+        100L,
+        Importance.LOW,
+        RETRY_BACKOFF_MS_DOC,
+        group,
+        ++order,
+        Width.SHORT,
+        "Retry Backoff (ms)"
+      ).define(
+        MAX_CONNECTION_IDLE_TIME_MS_CONFIG,
+        Type.INT,
+        60000,
+        Importance.LOW,
+        MAX_CONNECTION_IDLE_TIME_MS_CONFIG_DOC,
+        group,
+        ++order,
+        Width.SHORT,
+        "Max Connection Idle Time"
+    ).define(
+        CONNECTION_TIMEOUT_MS_CONFIG, 
+        Type.INT, 
+        1000, 
+        Importance.LOW, 
+        CONNECTION_TIMEOUT_MS_CONFIG_DOC,
+        group, 
+        ++order, 
+        Width.SHORT, 
+        "Connection Timeout"
+    ).define(
+        READ_TIMEOUT_MS_CONFIG, 
+        Type.INT, 
+        3000, 
+        Importance.LOW, 
+        READ_TIMEOUT_MS_CONFIG_DOC,
+        group,
+        ++order, 
+        Width.SHORT, 
+        "Read Timeout"
+    );
+  }
+  
   private static void addConnectorConfigs(ConfigDef configDef) {
     final String group = "Connector";
     int order = 0;
@@ -281,46 +358,6 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
         Width.SHORT,
         "Max Buffered Records"
     ).define(
-        LINGER_MS_CONFIG,
-        Type.LONG,
-        1L,
-        Importance.LOW,
-        LINGER_MS_DOC,
-        group,
-        ++order,
-        Width.SHORT,
-        "Linger (ms)"
-    ).define(
-        FLUSH_TIMEOUT_MS_CONFIG,
-        Type.LONG,
-        10000L,
-        Importance.LOW,
-        FLUSH_TIMEOUT_MS_DOC,
-        group,
-        ++order,
-        Width.SHORT,
-        "Flush Timeout (ms)"
-    ).define(
-        MAX_RETRIES_CONFIG,
-        Type.INT,
-        5,
-        Importance.LOW,
-        MAX_RETRIES_DOC,
-        group,
-        ++order,
-        Width.SHORT,
-        "Max Retries"
-    ).define(
-        RETRY_BACKOFF_MS_CONFIG,
-        Type.LONG,
-        100L,
-        Importance.LOW,
-        RETRY_BACKOFF_MS_DOC,
-        group,
-        ++order,
-        Width.SHORT,
-        "Retry Backoff (ms)"
-      ).define(
         CONNECTION_COMPRESSION_CONFIG,
         Type.BOOLEAN,
         false,
@@ -331,36 +368,6 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
         Width.SHORT,
         "Compression"
       ).define(
-        MAX_CONNECTION_IDLE_TIME_MS_CONFIG,
-        Type.INT,
-        "60000",
-        Importance.LOW,
-        MAX_CONNECTION_IDLE_TIME_MS_CONFIG_DOC,
-        group,
-        ++order,
-        Width.SHORT,
-        "Max Connection Idle Time"
-    ).define(
-        CONNECTION_TIMEOUT_MS_CONFIG, 
-        Type.INT, 
-        1000, 
-        Importance.LOW, 
-        CONNECTION_TIMEOUT_MS_CONFIG_DOC,
-        group, 
-        ++order, 
-        Width.SHORT, 
-        "Connection Timeout"
-        ).define(
-        READ_TIMEOUT_MS_CONFIG, 
-        Type.INT, 
-        3000, 
-        Importance.LOW, 
-        READ_TIMEOUT_MS_CONFIG_DOC,
-        group,
-        ++order, 
-        Width.SHORT, 
-        "Read Timeout"
-    ).define(
         AUTO_CREATE_INDICES_AT_START_CONFIG,
         Type.BOOLEAN,
         true,

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -132,7 +132,7 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
       + "so set this to ``false`` to use that older behavior.";
   public static final String MAX_CONNECTION_IDLE_TIME_MS_CONFIG = "max.connection.idle.time.ms";
   private static final String MAX_CONNECTION_IDLE_TIME_MS_CONFIG_DOC = "How long to wait "
-        + "in milliseconds after an idle connection is dropped to prevent "
+        + "in milliseconds before dropping an idle connection to prevent "
         + "a read timeout.";
   public static final String CONNECTION_TIMEOUT_MS_CONFIG = "connection.timeout.ms";
   public static final String READ_TIMEOUT_MS_CONFIG = "read.timeout.ms";

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -130,7 +130,10 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
       + "All map entries with non-string keys are always written as nested documents. "
       + "Prior to 3.3.0, this connector always wrote map entries as nested documents, "
       + "so set this to ``false`` to use that older behavior.";
-
+  public static final String MAX_CONNECTION_IDLE_TIME_MS_CONFIG = "max.connection.idle.time.ms";
+  private static final String MAX_CONNECTION_IDLE_TIME_MS_CONFIG_DOC = "How long to wait "
+        + "in milliseconds after an idle connection is dropped to prevent "
+        + "a read timeout.";
   public static final String CONNECTION_TIMEOUT_MS_CONFIG = "connection.timeout.ms";
   public static final String READ_TIMEOUT_MS_CONFIG = "read.timeout.ms";
   private static final String CONNECTION_TIMEOUT_MS_CONFIG_DOC = "How long to wait "
@@ -328,6 +331,16 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
         Width.SHORT,
         "Compression"
       ).define(
+        MAX_CONNECTION_IDLE_TIME_MS_CONFIG,
+        Type.INT,
+        "60000",
+        Importance.LOW,
+        MAX_CONNECTION_IDLE_TIME_MS_CONFIG_DOC,
+        group,
+        ++order,
+        Width.SHORT,
+        "Max Connection Idle Time"
+    ).define(
         CONNECTION_TIMEOUT_MS_CONFIG, 
         Type.INT, 
         1000, 

--- a/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
@@ -72,6 +72,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.net.ssl.SSLContext;
 
@@ -154,6 +155,7 @@ public class JestElasticsearchClient implements ElasticsearchClient {
               config.getLong(ElasticsearchSinkConnectorConfig.RETRY_BACKOFF_MS_CONFIG);
       this.maxRetries = config.getInt(ElasticsearchSinkConnectorConfig.MAX_RETRIES_CONFIG);
       this.timeout = config.getInt(ElasticsearchSinkConnectorConfig.READ_TIMEOUT_MS_CONFIG);
+      
     } catch (IOException e) {
       throw new ConnectException(
           "Couldn't start ElasticsearchSinkTask due to connection error:",
@@ -173,7 +175,8 @@ public class JestElasticsearchClient implements ElasticsearchClient {
         ElasticsearchSinkConnectorConfig.CONNECTION_TIMEOUT_MS_CONFIG);
     final int readTimeout = config.getInt(
         ElasticsearchSinkConnectorConfig.READ_TIMEOUT_MS_CONFIG);
-
+    final int maxIdleTime = config.getInt(
+        ElasticsearchSinkConnectorConfig.MAX_CONNECTION_IDLE_TIME_MS_CONFIG);
     final String username = config.getString(
         ElasticsearchSinkConnectorConfig.CONNECTION_USERNAME_CONFIG);
     final Password password = config.getPassword(
@@ -193,6 +196,7 @@ public class JestElasticsearchClient implements ElasticsearchClient {
             .readTimeout(readTimeout)
             .requestCompressionEnabled(compressionEnabled)
             .defaultMaxTotalConnectionPerRoute(maxInFlightRequests)
+            .maxConnectionIdleTime(maxIdleTime, TimeUnit.MILLISECONDS)
             .multiThreaded(true);
     if (username != null && password != null) {
       builder.defaultCredentials(username, password.value())


### PR DESCRIPTION
Changes:

1. Add config max.connection.idle.time.ms for taking value from connector config, default value 60s. 
1. Since check style didn't allow method more than 150 lines, I separated the method into "addConnectorConfigs" and "addConnectorTimeoutConfigs". Not sure if this is good practice, need review for that.
1. put the maxConnectionIdleTime parameter to config builder
