### PR TITLE
MINOR: Fix tests

### DIFF
--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchWriterTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchWriterTest.java
@@ -55,9 +55,6 @@ public class ElasticsearchWriterTest extends ElasticsearchSinkTestBase {
   private final Schema otherSchema = createOtherSchema();
   private final Struct otherRecord = createOtherRecord(otherSchema);
 
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
-
   private boolean ignoreKey;
   private boolean ignoreSchema;
 
@@ -428,9 +425,10 @@ public class ElasticsearchWriterTest extends ElasticsearchSinkTestBase {
 
     final ElasticsearchWriter strictWriter = initWriter(client);
 
-    thrown.expect(ConnectException.class);
-    thrown.expectMessage("Key is used as document id and can not be null");
-    strictWriter.write(records);
+    Exception e = assertThrows(ConnectException.class, () -> {
+      strictWriter.write(records);
+    });
+    assertEquals("Key is used as document id and can not be null.", e.getMessage());
   }
 
   @Test


### PR DESCRIPTION
Tests were failing due to use of deprecated `ExpectedException.none()`. We picked up the new version of JUnit that deprecated this in: 
https://github.com/confluentinc/common/commit/10fef4a03b21fc6c4aaad6948bcc1386fcdcc26d

Just switch over to use assertThrows as suggested in JUnit release notes - https://github.com/junit-team/junit4/blob/master/doc/ReleaseNotes4.13.md#pull-request-1633-deprecate-expectedexceptionnone