### PR TITLE
#396 new configuration option write.method "create"

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -154,7 +154,8 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
       + "'ignore', 'warn', and 'fail'.";
   public static final String WRITE_METHOD_CONFIG = "write.method";
   private static final String WRITE_METHOD_DOC = "Method used for writing data to Elasticsearch,"
-          + " and one of " + WriteMethod.INSERT.toString() + " or " + WriteMethod.UPSERT.toString()
+          + " and one of " + WriteMethod.INSERT.toString() + ", " + WriteMethod.UPSERT.toString() 
+          + " or " + WriteMethod.CREATE.toString()
           + ". The default method is " + WriteMethod.INSERT.toString() + ", in which the "
           + "connector constructs a document from the record value and inserts that document "
           + "into Elasticsearch, completely replacing any existing document with the same ID; "
@@ -164,7 +165,10 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
           + "only those fields present in the record value. The " + WriteMethod.UPSERT.toString()
           + " method may require additional time and resources of Elasticsearch, so consider "
           + "increasing the " + FLUSH_TIMEOUT_MS_CONFIG + ", " + READ_TIMEOUT_MS_CONFIG
-          + ", and decrease " + BATCH_SIZE_CONFIG + " configuration properties.";
+          + ", and decrease " + BATCH_SIZE_CONFIG + " configuration properties. The " 
+          + WriteMethod.CREATE.toString() + " will create a new document if one with the "
+          + "specified id does not yet exist, and does nothing if a document with the same id "
+          + "already exists.";
 
   public static final String CONNECTION_SSL_CONFIG_PREFIX = "elastic.https.";
 

--- a/src/test/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClientTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClientTest.java
@@ -43,6 +43,8 @@ import io.searchbox.indices.CreateIndex;
 import io.searchbox.indices.IndicesExists;
 import io.searchbox.indices.mapping.GetMapping;
 import io.searchbox.indices.mapping.PutMapping;
+import io.searchbox.params.Parameters;
+
 import java.io.IOException;
 import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
@@ -50,7 +52,6 @@ import org.apache.http.auth.Credentials;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.errors.ConnectException;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -373,6 +374,15 @@ public class JestElasticsearchClientTest {
     assertEquals(idx.key.id, ba.getId());
     assertEquals(idx.key.type, ba.getType());
     assertEquals("{\"doc\":" + idx.payload + ", \"doc_as_upsert\":true}", ba.getData(null));
+    // create
+    client.setWriteMethod(JestElasticsearchClient.WriteMethod.CREATE);
+    ba = client.toBulkableAction(idx);
+    assertNotNull(ba);
+    assertSame(Index.class, ba.getClass());
+    assertEquals(idx.key.index, ba.getIndex());
+    assertEquals(idx.key.id, ba.getId());
+    assertEquals(idx.key.type, ba.getType());
+    assertThat(Collections.singleton("create"), is(ba.getParameter(Parameters.OP_TYPE)));
   }
 
   private BulkResult createBulkResultFailure(String exception) {


### PR DESCRIPTION
Add the possibility to set `write.method` configuration option to  `"create"`.

If `write.method` is set to `create`, a new document is created if the id does not already exist. If a document already exist with this id, it is NOT updated. The implementation uses `op_type=create` elasticsearch parameter.