### PR TITLE
CC-8869: Fix kafka sslfactory changes causing ES connector to break

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
@@ -61,6 +61,7 @@ import org.apache.http.nio.conn.ssl.SSLIOSessionStrategy;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.common.network.Mode;
+import org.apache.kafka.common.security.ssl.DefaultSslEngineFactory;
 import org.apache.kafka.common.security.ssl.SslFactory;
 import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
@@ -269,7 +270,8 @@ public class JestElasticsearchClient implements ElasticsearchClient {
                                             ElasticsearchSinkConnectorConfig config) {
     SslFactory kafkaSslFactory = new SslFactory(Mode.CLIENT, null, false);
     kafkaSslFactory.configure(config.sslConfigs());
-    SSLContext sslContext = kafkaSslFactory.sslEngineBuilder().sslContext();
+    SSLContext sslContext = ((DefaultSslEngineFactory)kafkaSslFactory.sslEngineFactory())
+        .sslContext();
 
     // Sync calls
     SSLConnectionSocketFactory sslSocketFactory = new SSLConnectionSocketFactory(sslContext,


### PR DESCRIPTION
The `SslFactory` class in Apache Kafka was recently changed and no longer includes `sslEngineBuilder()`. The `SslEngineBuilder` class has also been removed from Apache Kafka and a new class, `SslEngineFactory` is being used instead. There wasn't a clean way to leverage the new API to provide an `SSLContext` to the ElasticSearch connector, so instead I copied the code from AK into the connector.

Signed-off-by: Aakash Shah <ashah@confluent.io>