### PR TITLE
CC-9314: Allow disabling hostname verification

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,9 +179,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>3.0.0-M3</version>
-                <configuration>
-                    <skipITs>true</skipITs>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>io.confluent</groupId>
@@ -332,7 +329,15 @@
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <version>3.0.0-M3</version>
                         <configuration>
-                            <skipITs>false</skipITs>
+                            <excludes>
+                                <!--
+                                The jenkins container is only accessible through its DOCKER_HOST IP
+                                address. This makes it hard to test both hostname verification
+                                enabled and disabled cases with the same cert. So, disable this IT
+                                in jenkins and only test the enabled case in SecurityIT.
+                                -->
+                                <exclude>**/HostnameVerificationDisabledIT.java</exclude>
+                            </excludes>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -25,7 +25,6 @@ import java.util.Map;
 
 import static io.confluent.connect.elasticsearch.DataConverter.BehaviorOnNullValues;
 import static io.confluent.connect.elasticsearch.bulk.BulkProcessor.BehaviorOnMalformedDoc;
-import static org.apache.http.util.TextUtils.isBlank;
 import static org.apache.kafka.common.config.SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG;
 import static org.apache.kafka.common.config.SslConfigs.addClientSslSupport;
 
@@ -461,7 +460,8 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   public boolean shouldDisableHostnameVerification() {
     String sslEndpointIdentificationAlgorithm = getString(
             CONNECTION_SSL_CONFIG_PREFIX + SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG);
-    return isBlank(sslEndpointIdentificationAlgorithm);
+    return sslEndpointIdentificationAlgorithm != null
+            && !sslEndpointIdentificationAlgorithm.isEmpty();
   }
 
   public static void main(String[] args) {

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -461,7 +461,7 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
     String sslEndpointIdentificationAlgorithm = getString(
             CONNECTION_SSL_CONFIG_PREFIX + SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG);
     return sslEndpointIdentificationAlgorithm != null
-            && !sslEndpointIdentificationAlgorithm.isEmpty();
+            && sslEndpointIdentificationAlgorithm.isEmpty();
   }
 
   public static void main(String[] args) {

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -25,6 +25,8 @@ import java.util.Map;
 
 import static io.confluent.connect.elasticsearch.DataConverter.BehaviorOnNullValues;
 import static io.confluent.connect.elasticsearch.bulk.BulkProcessor.BehaviorOnMalformedDoc;
+import static org.apache.http.util.TextUtils.isBlank;
+import static org.apache.kafka.common.config.SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG;
 import static org.apache.kafka.common.config.SslConfigs.addClientSslSupport;
 
 public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
@@ -454,6 +456,12 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
     ConfigDef sslConfigDef = new ConfigDef();
     addClientSslSupport(sslConfigDef);
     return sslConfigDef.parse(originalsWithPrefix(CONNECTION_SSL_CONFIG_PREFIX));
+  }
+
+  public boolean shouldDisableHostnameVerification() {
+    String sslEndpointIdentificationAlgorithm = getString(
+            CONNECTION_SSL_CONFIG_PREFIX + SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG);
+    return isBlank(sslEndpointIdentificationAlgorithm);
   }
 
   public static void main(String[] args) {

--- a/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
@@ -48,6 +48,7 @@ import io.searchbox.indices.DeleteIndex;
 import io.searchbox.indices.IndicesExists;
 import io.searchbox.indices.Refresh;
 import io.searchbox.indices.mapping.PutMapping;
+import javax.net.ssl.HostnameVerifier;
 import org.apache.http.HttpHost;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.nio.conn.ssl.SSLIOSessionStrategy;
@@ -194,14 +195,17 @@ public class JestElasticsearchClient implements ElasticsearchClient {
     kafkaSslFactory.configure(config.sslConfigs());
     SSLContext sslContext = kafkaSslFactory.sslContext();
 
+    HostnameVerifier hostnameVerifier = config.shouldDisableHostnameVerification()
+            ? (hostname, session) -> true
+            : SSLConnectionSocketFactory.getDefaultHostnameVerifier();
+
     // Sync calls
-    SSLConnectionSocketFactory sslSocketFactory = new SSLConnectionSocketFactory(sslContext,
-        SSLConnectionSocketFactory.getDefaultHostnameVerifier());
+    SSLConnectionSocketFactory sslSocketFactory = new SSLConnectionSocketFactory(
+            sslContext, hostnameVerifier);
     builder.sslSocketFactory(sslSocketFactory);
 
     // Async calls
-    SSLIOSessionStrategy sessionStrategy = new SSLIOSessionStrategy(sslContext,
-        SSLConnectionSocketFactory.getDefaultHostnameVerifier());
+    SSLIOSessionStrategy sessionStrategy = new SSLIOSessionStrategy(sslContext, hostnameVerifier);
     builder.httpsIOSessionStrategy(sessionStrategy);
   }
 

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/HostnameVerificationDisabledIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/HostnameVerificationDisabledIT.java
@@ -1,0 +1,36 @@
+package io.confluent.connect.elasticsearch.integration;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+public class HostnameVerificationDisabledIT extends SecurityIT {
+    private static final Logger log = LoggerFactory.getLogger(HostnameVerificationDisabledIT.class);
+
+    @Test
+    public void testSecureConnectionHostnameVerificationDisabled() throws Throwable {
+        // Use 'localhost' here that is not in self-signed cert
+        String address = container.getConnectionUrl();
+        address = address.replace(container.getContainerIpAddress(), "localhost");
+        log.info("Creating connector for {}", address);
+
+        connect.kafka().createTopic(KAFKA_TOPIC, 1);
+
+        Map<String, String> props = getProps();
+        props.put("connection.url", address);
+        props.put("elastic.security.protocol", "SSL");
+        props.put("elastic.https.ssl.keystore.location", container.getKeystorePath());
+        props.put("elastic.https.ssl.keystore.password", container.getKeystorePassword());
+        props.put("elastic.https.ssl.key.password", container.getKeyPassword());
+        props.put("elastic.https.ssl.truststore.location", container.getTruststorePath());
+        props.put("elastic.https.ssl.truststore.password", container.getTruststorePassword());
+
+        // disable hostname verification
+        props.put("elastic.https.ssl.endpoint.identification.algorithm", "");
+
+        // Start connector
+        testSecureConnection(props);
+    }
+}

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/SecurityIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/SecurityIT.java
@@ -18,6 +18,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.net.Inet4Address;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -81,7 +82,8 @@ public class SecurityIT {
   @Test
   public void testSecureConnectionVerifiedHostname() throws Throwable {
     // Use 'localhost' here because that's the hostname the certificates allow
-    final String address = container.getConnectionUrl();
+    String address = container.getConnectionUrl();
+    address = address.replace(container.getContainerIpAddress(), "localhost");
     log.info("Creating connector for {}", address);
 
     connect.kafka().createTopic(KAFKA_TOPIC, 1);
@@ -103,7 +105,7 @@ public class SecurityIT {
   public void testSecureConnectionHostnameVerificationDisabled() throws Throwable {
     // Use an IP address that is not in self-signed cert
     String address = container.getConnectionUrl();
-    address = address.replace("localhost", "127.0.0.1");
+    address = address.replace(container.getContainerIpAddress(), Inet4Address.getLocalHost().getHostAddress());
     log.info("Creating connector for {}", address);
 
     connect.kafka().createTopic(KAFKA_TOPIC, 1);

--- a/src/test/resources/ssl/instances.yml
+++ b/src/test/resources/ssl/instances.yml
@@ -3,8 +3,6 @@ instances:
     dns:
       - elasticsearch
       - localhost
-    ip:
-      - ipAddress
   - name: kibana
     dns:
       - kibana

--- a/src/test/resources/ssl/instances.yml
+++ b/src/test/resources/ssl/instances.yml
@@ -2,7 +2,8 @@ instances:
   - name: elasticsearch
     dns:
       - elasticsearch
-      - localhost
+    ip:
+      - ipAddress
   - name: kibana
     dns:
       - kibana


### PR DESCRIPTION
When `elastic.https.ssl.endpoint.identification.algorithm` is empty, instead
of default hostname verifier, use an all-trusting verifier.

Updated SecurityIT with testcase to verify