### PR TITLE
CC-9347: Inspect interrupted state before next attempt

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/bulk/BulkProcessor.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/bulk/BulkProcessor.java
@@ -418,7 +418,7 @@ public class BulkProcessor<R, B> {
             time.sleep(sleepTimeMs);
             if (Thread.interrupted()) {
               log.error(
-                      "Shutdown interrupted batch {} of {} records after attempt {}/{}",
+                      "Retrying batch {} of {} records interrupted after attempt {}/{}",
                       batchId, batch.size(), attempts, maxAttempts, e);
               throw e;
             }

--- a/src/main/java/io/confluent/connect/elasticsearch/bulk/BulkProcessor.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/bulk/BulkProcessor.java
@@ -416,6 +416,12 @@ public class BulkProcessor<R, B> {
                       + "will attempt retry after {} ms. Failure reason: {}",
                       batchId, batch.size(), attempts, maxAttempts, sleepTimeMs, e.getMessage());
             time.sleep(sleepTimeMs);
+            if (Thread.currentThread().isInterrupted()) {
+              log.error(
+                      "Shutdown interrupted batch {} of {} records after total of {} attempt(s)",
+                      batchId, batch.size(), attempts, e);
+              throw e;
+            }
           } else {
             log.error("Failed to execute batch {} of {} records after total of {} attempt(s)",
                     batchId, batch.size(), attempts, e);

--- a/src/main/java/io/confluent/connect/elasticsearch/bulk/BulkProcessor.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/bulk/BulkProcessor.java
@@ -416,10 +416,10 @@ public class BulkProcessor<R, B> {
                       + "will attempt retry after {} ms. Failure reason: {}",
                       batchId, batch.size(), attempts, maxAttempts, sleepTimeMs, e.getMessage());
             time.sleep(sleepTimeMs);
-            if (Thread.currentThread().isInterrupted()) {
+            if (Thread.interrupted()) {
               log.error(
-                      "Shutdown interrupted batch {} of {} records after total of {} attempt(s)",
-                      batchId, batch.size(), attempts, e);
+                      "Shutdown interrupted batch {} of {} records after attempt {}/{}",
+                      batchId, batch.size(), attempts, maxAttempts, e);
               throw e;
             }
           } else {


### PR DESCRIPTION
During executor shutdown, it attempts to terminate existing tasks by sending interrupts to the threads. The `Time.sleep` that we use to sleep between retry attempts wraps around AK `Utils.sleep` that handles the `InterruptedException` by setting `Thread.currentThread().interrupt()`. We just need to inspect the interrupted state of current thread before making our next retry attempt.