### PR TITLE
Add query-parameter support for index/bulk APIs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <lucene.version>5.5.2</lucene.version>
         <hamcrest.version>1.3</hamcrest.version>
         <mockito.version>2.28.2</mockito.version>
-        <jest.version>6.3.1</jest.version>
+        <jest.version>6.3.2-SNAPSHOT</jest.version>
         <test.containers.version>1.11.4</test.containers.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
@@ -127,7 +127,6 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>27.0.1-jre</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -186,6 +186,10 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
           + "Values can be `PLAINTEXT` or `SSL`. If `PLAINTEXT` is passed, "
           + "all configs prefixed by " + CONNECTION_SSL_CONFIG_PREFIX + " will be ignored.";
 
+  public static final String ELASTICSEARCH_INDEX_PARAM_PREFIX = "elasticsearch.index.param.";
+
+  public final Map<String, Object> indexParams;
+
   protected static ConfigDef baseConfigDef() {
     final ConfigDef configDef = new ConfigDef();
     addConnectorConfigs(configDef);
@@ -490,6 +494,7 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
 
   public ElasticsearchSinkConnectorConfig(Map<String, String> props) {
     super(CONFIG, props);
+    indexParams = originalsWithPrefix(ELASTICSEARCH_INDEX_PARAM_PREFIX);
   }
 
   public Map<String, Object> sslConfigs() {

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.ConfigDef.Width;
 
+import java.util.Collections;
 import java.util.Map;
 
 import static io.confluent.connect.elasticsearch.jest.JestElasticsearchClient.WriteMethod;
@@ -494,7 +495,8 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
 
   public ElasticsearchSinkConnectorConfig(Map<String, String> props) {
     super(CONFIG, props);
-    indexParams = originalsWithPrefix(ELASTICSEARCH_INDEX_PARAM_PREFIX);
+    indexParams = Collections.unmodifiableMap(
+        originalsWithPrefix(ELASTICSEARCH_INDEX_PARAM_PREFIX));
   }
 
   public Map<String, Object> sslConfigs() {

--- a/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
@@ -469,7 +469,6 @@ public class JestElasticsearchClient implements ElasticsearchClient {
       builder.addAction(toBulkableAction(record));
     }
     indexParams.forEach((k, v) -> {
-      LOG.warn(String.format("createBulkRequest indexParam: %s:%s", k, v));
       builder.setParameter(k, v);
     });
     return new JestBulkRequest(builder.build());
@@ -504,7 +503,6 @@ public class JestElasticsearchClient implements ElasticsearchClient {
       req.setParameter("version_type", "external").setParameter("version", record.version);
     }
     indexParams.forEach((k, v) -> {
-      LOG.warn(String.format("toIndexRequest indexParam: %s:%s", k, v));
       req.setParameter(k, v);
     });
     return req.build();
@@ -519,7 +517,6 @@ public class JestElasticsearchClient implements ElasticsearchClient {
         .id(record.key.id);
 
     indexParams.forEach((k, v) -> {
-      LOG.warn(String.format("toUpdateRequest indexParam: %s:%s", k, v));
       req.setParameter(k, v);
     });
     return req.build();


### PR DESCRIPTION
Adds processing for configuration properties of the form `elasticsearch.index.param.<name>=<value>`.  The name/value should be a valid query-string parameter name and value for the Index/Bulk APIs, to be applied to API calls.

See:
- https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html#docs-index-api-query-params
- https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html#docs-bulk-api-query-params

That the original motivation for this PR is to allow configuration of pipeline-processing when writing records, e.g. `?pipeline=mypipelineinelastic`.  This change itself is not sufficient to allow that, since in the Jest client used by the connector, query-param names are filtered by an enumeration.  So to achieve testing of Elasticsearch pipelines, this Jest PR and a snapshot build are required: https://github.com/searchbox-io/Jest/pull/679 .

items worth review:
- Config property name/prefix
- Should separate config be required for Index and Bulk APIs, and maybe even for Delete (tombstone when configured) - if these have different subsets of allowed query-string parameters, or if different behaviour is desired for each operation.

# Testing

There's a `cp-demo` custom branch/build with an updated readme for testing: https://github.com/confluentinc/cp-demo/tree/javabrett/FF-1556-elasticsearch-test .  This includes a custom build which incorporates a Jest patch to demonstrate parameter support including `?pipeline` for date-based index-name processing.