### PR TITLE
MINOR: Removed property ${confluent.maven.repo} from the pom repository

### DIFF
--- a/licenses.html
+++ b/licenses.html
@@ -55,7 +55,7 @@ th {
 <TR>
 <TD><A HREF="https://github.com/searchbox-io/Jest">jest-common-2.0.0</A></TD><TD>jar</TD><TD>2.0.0</TD><TD><A HREF="http://www.apache.org/licenses/LICENSE-2.0.txt">Apache 2.0</A><br></TD></TR>
 <TR>
-<TD><A HREF="${confluent.maven.repo}">kafka-connect-elasticsearch-5.5.1</A></TD><TD>jar</TD><TD>5.5.1</TD><TD></TD></TR>
+<TD><A HREF="http://packages.confluent.io/maven/">kafka-connect-elasticsearch-5.5.1</A></TD><TD>jar</TD><TD>5.5.1</TD><TD></TD></TR>
 <TR>
 <TD><A HREF="http://www.slf4j.org">slf4j-simple-1.7.5</A></TD><TD>jar</TD><TD>1.7.5</TD><TD></TD></TR>
 </TBODY>

--- a/pom.xml
+++ b/pom.xml
@@ -46,14 +46,13 @@
         <jest.version>6.3.1</jest.version>
         <test.containers.version>1.11.4</test.containers.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
-        <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
     </properties>
 
     <repositories>
         <repository>
             <id>confluent</id>
             <name>Confluent</name>
-            <url>${confluent.maven.repo}</url>
+            <url>http://packages.confluent.io/maven/</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
This PR addresses the problem that you can't currently build the `5.5.1-post` branch (and I think other branches equally) with a clean Maven cache and the repositories as-defined.

The `<repository>` definition relies on property `confluent.maven.repo` for `url`.  This is a problem when resolving the parent POM, since Maven resolves the parent before local properties.

Typical error:

```
[INFO] Scanning for projects...
Downloading from central: https://repo.maven.apache.org/maven2/io/confluent/common/5.5.0/common-5.5.0.pom
[ERROR] [ERROR] Some problems were encountered while processing the POMs:
[FATAL] Non-resolvable parent POM for io.confluent:kafka-connect-elasticsearch:5.5.0: Could not transfer artifact io.confluent:common:pom:5.5.0 from/to confluent (${confluent.maven.repo}): Cannot access ${confluent.maven.repo} with type default using the available connector factories: BasicRepositoryConnectorFactory and 'parent.relativePath' points at wrong local POM @ line 7, column 13
 @
[ERROR] The build could not read 1 project -> [Help 1]
[ERROR]
[ERROR]   The project io.confluent:kafka-connect-elasticsearch:5.5.0 (/home/build/src/pom.xml) has 1 error
[ERROR]     Non-resolvable parent POM for io.confluent:kafka-connect-elasticsearch:5.5.0: Could not transfer artifact io.confluent:common:pom:5.5.0 from/to confluent (${confluent.maven.repo}): Cannot access ${confluent.maven.repo} with type default using the available connector factories: BasicRepositoryConnectorFactory and 'parent.relativePath' points at wrong local POM @ line 7, column 13: Cannot access ${confluent.maven.repo} using the registered transporter factories: WagonTransporterFactory: Unsupported transport protocol -> [Help 2]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/ProjectBuildingException
[ERROR] [Help 2] http://cwiki.apache.org/confluence/display/MAVEN/UnresolvableModelException
The command '/bin/sh -c mvn package' returned a non-zero code: 1
```

This command can be used to validate pre/post PR build fail/pass:

```
docker run -it --rm --name kafka-connect-isolated-build -v "$(pwd):/usr/src/mymaven" -w /usr/src/mymaven maven:3-openjdk-8 mvn clean install
```