### PR TITLE
CC-7635: implement DLQ reporter for malformed doc records

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -9,7 +9,7 @@
     <!-- switch statements on types exceed maximum complexity -->
     <suppress
             checks="(CyclomaticComplexity)"
-            files="(JestElasticsearchClient|Mapping).java"
+            files="(JestElasticsearchClient|Mapping|BulkProcessor).java"
     />
 
     <!-- TODO: Undecided if this is too much -->

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -91,7 +91,7 @@ public class ElasticsearchSinkTask extends SinkTask {
           config.getInt(ElasticsearchSinkConnectorConfig.MAX_RETRIES_CONFIG);
       boolean dropInvalidMessage =
           config.getBoolean(ElasticsearchSinkConnectorConfig.DROP_INVALID_MESSAGE_CONFIG);
-      boolean createIndicesAtStartTime =
+      final boolean createIndicesAtStartTime =
           config.getBoolean(ElasticsearchSinkConnectorConfig.AUTO_CREATE_INDICES_AT_START_CONFIG);
 
       DataConverter.BehaviorOnNullValues behaviorOnNullValues =

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -140,10 +140,15 @@ public class ElasticsearchSinkTask extends SinkTask {
           .setBehaviorOnMalformedDoc(behaviorOnMalformedDoc);
 
       try {
+        if (context.errantRecordReporter() == null) {
+          log.info("Errant record reporter not configured.");
+        }
+
         // may be null if DLQ not enabled
         builder.setErrantRecordReporter(context.errantRecordReporter());
       } catch (NoClassDefFoundError e) {
         // Will occur in Connect runtimes earlier than 2.6
+        log.warn("AK versions prior to 2.6 do not support the errant record reporter");
       }
 
       this.createIndicesAtStartTime = createIndicesAtStartTime;

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -139,6 +139,13 @@ public class ElasticsearchSinkTask extends SinkTask {
           .setBehaviorOnNullValues(behaviorOnNullValues)
           .setBehaviorOnMalformedDoc(behaviorOnMalformedDoc);
 
+      try {
+        // may be null if DLQ not enabled
+        builder.setErrantRecordReporter(context.errantRecordReporter());
+      } catch (NoClassDefFoundError e) {
+        // Will occur in Connect runtimes earlier than 2.6
+      }
+
       this.createIndicesAtStartTime = createIndicesAtStartTime;
 
       writer = builder.build();

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
@@ -53,8 +53,6 @@ public class ElasticsearchWriter {
   private final DataConverter converter;
 
   private final Set<String> existingMappings;
-  private final BehaviorOnMalformedDoc behaviorOnMalformedDoc;
-  private final ErrantRecordReporter reporter;
 
   ElasticsearchWriter(
       ElasticsearchClient client,
@@ -88,8 +86,6 @@ public class ElasticsearchWriter {
     this.dropInvalidMessage = dropInvalidMessage;
     this.behaviorOnNullValues = behaviorOnNullValues;
     this.converter = new DataConverter(useCompactMapEntries, behaviorOnNullValues);
-    this.behaviorOnMalformedDoc = behaviorOnMalformedDoc;
-    this.reporter = reporter;
 
     bulkProcessor = new BulkProcessor<>(
         new SystemTime(),

--- a/src/main/java/io/confluent/connect/elasticsearch/bulk/BulkProcessor.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/bulk/BulkProcessor.java
@@ -468,7 +468,7 @@ public class BulkProcessor<R, B> {
                 if (original != null) {
                   reporter.report(
                       original,
-                      new NoStackTraceConnectException(
+                      new ReportingException(
                           "Bulk request failed: " + bulkRsp.getErrorInfo()
                       )
                   );
@@ -618,12 +618,22 @@ public class BulkProcessor<R, B> {
     }
   }
 
-  public static class NoStackTraceConnectException extends RuntimeException {
+  /**
+   * Exception that swallows the stack trace used for reporting errors from Elasticsearch
+   * (mapper_parser_exception, illegal_argument_exception, and action_request_validation_exception)
+   * resulting from bad records using the AK 2.6 reporter DLQ interface.
+   */
+  public static class ReportingException extends RuntimeException {
 
-    public NoStackTraceConnectException(String message) {
+    public ReportingException(String message) {
       super(message);
     }
 
+    /**
+     * This method is overriden to swallow the stack trace.
+     *
+     * @return Throwable
+     */
     @Override
     public synchronized Throwable fillInStackTrace() {
       return this;

--- a/src/main/java/io/confluent/connect/elasticsearch/bulk/BulkProcessor.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/bulk/BulkProcessor.java
@@ -16,12 +16,17 @@
 package io.confluent.connect.elasticsearch.bulk;
 
 import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig;
+import io.confluent.connect.elasticsearch.IndexableRecord;
 import io.confluent.connect.elasticsearch.LogContext;
 import io.confluent.connect.elasticsearch.RetryUtil;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.sink.ErrantRecordReporter;
+import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,6 +65,7 @@ public class BulkProcessor<R, B> {
   private final int maxRetries;
   private final long retryBackoffMs;
   private final BehaviorOnMalformedDoc behaviorOnMalformedDoc;
+  private final ErrantRecordReporter reporter;
 
   private final Thread farmer;
   private final ExecutorService executor;
@@ -73,6 +79,7 @@ public class BulkProcessor<R, B> {
   // shared state, synchronized on (this), may be part of wait() conditions so need notifyAll() on
   // changes
   private final Deque<R> unsentRecords;
+  private final Map<R, SinkRecord> recordMap;
   private int inFlightRecords = 0;
   private final LogContext logContext = new LogContext();
 
@@ -85,7 +92,8 @@ public class BulkProcessor<R, B> {
       long lingerMs,
       int maxRetries,
       long retryBackoffMs,
-      BehaviorOnMalformedDoc behaviorOnMalformedDoc
+      BehaviorOnMalformedDoc behaviorOnMalformedDoc,
+      ErrantRecordReporter reporter
   ) {
     this.time = time;
     this.bulkClient = bulkClient;
@@ -95,8 +103,10 @@ public class BulkProcessor<R, B> {
     this.maxRetries = maxRetries;
     this.retryBackoffMs = retryBackoffMs;
     this.behaviorOnMalformedDoc = behaviorOnMalformedDoc;
+    this.reporter = reporter;
 
     unsentRecords = new ArrayDeque<>(maxBufferedRecords);
+    recordMap = new ConcurrentHashMap<>(maxBufferedRecords);
 
     final ThreadFactory threadFactory = makeThreadFactory();
     farmer = threadFactory.newThread(farmerTask());
@@ -303,7 +313,7 @@ public class BulkProcessor<R, B> {
    * <p>If any task has failed prior to or while blocked in the add, or if the timeout expires
    * while blocked, {@link ConnectException} will be thrown.
    */
-  public synchronized void add(R record, long timeoutMs) {
+  public synchronized void add(R record, SinkRecord original, long timeoutMs) {
     throwIfTerminal();
 
     int numBufferedRecords = bufferedRecords();
@@ -336,6 +346,7 @@ public class BulkProcessor<R, B> {
     }
 
     unsentRecords.addLast(record);
+    recordMap.put(record, original);
     notifyAll();
   }
 
@@ -449,10 +460,21 @@ public class BulkProcessor<R, B> {
                   System.currentTimeMillis() - startTime
               );
             }
+            batch.forEach(r -> recordMap.remove(r));
             return bulkRsp;
           } else if (responseContainsMalformedDocError(bulkRsp)) {
             retriable = bulkRsp.isRetriable();
             handleMalformedDoc(bulkRsp);
+            for (R record : batch) {
+              SinkRecord original = recordMap.get(record);
+              if (original != null && reporter != null) {
+                reporter.report(
+                    original,
+                    new ConnectException("Bulk request failed: " + bulkRsp.getErrorInfo())
+                );
+              }
+            }
+            batch.forEach(r -> recordMap.remove(r));
             return bulkRsp;
           } else {
             // for all other errors, throw the error up

--- a/src/main/java/io/confluent/connect/elasticsearch/bulk/BulkProcessor.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/bulk/BulkProcessor.java
@@ -468,7 +468,9 @@ public class BulkProcessor<R, B> {
                 if (original != null) {
                   reporter.report(
                       original,
-                      new ConnectException("Bulk request failed: " + bulkRsp.getErrorInfo())
+                      new NoStackTraceConnectException(
+                          "Bulk request failed: " + bulkRsp.getErrorInfo()
+                      )
                   );
                 }
               }
@@ -613,6 +615,18 @@ public class BulkProcessor<R, B> {
     @Override
     public String toString() {
       return name().toLowerCase(Locale.ROOT);
+    }
+  }
+
+  public static class NoStackTraceConnectException extends RuntimeException {
+
+    public NoStackTraceConnectException(String message) {
+      super(message);
+    }
+
+    @Override
+    public synchronized Throwable fillInStackTrace() {
+      return this;
     }
   }
 }

--- a/src/main/java/io/confluent/connect/elasticsearch/bulk/BulkProcessor.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/bulk/BulkProcessor.java
@@ -16,7 +16,6 @@
 package io.confluent.connect.elasticsearch.bulk;
 
 import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig;
-import io.confluent.connect.elasticsearch.IndexableRecord;
 import io.confluent.connect.elasticsearch.LogContext;
 import io.confluent.connect.elasticsearch.RetryUtil;
 

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
@@ -15,12 +15,15 @@
 
 package io.confluent.connect.elasticsearch;
 
+import static org.mockito.Mockito.mock;
+
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.sink.SinkTaskContext;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
@@ -68,6 +71,7 @@ public class ElasticsearchSinkTaskTest extends ElasticsearchSinkTestBase {
     Map<String, String> props = createProps();
 
     ElasticsearchSinkTask task = new ElasticsearchSinkTask();
+    task.initialize(mock(SinkTaskContext.class));
     task.start(props, client);
     task.open(new HashSet<>(Arrays.asList(TOPIC_PARTITION, TOPIC_PARTITION2, TOPIC_PARTITION3)));
 
@@ -99,6 +103,7 @@ public class ElasticsearchSinkTaskTest extends ElasticsearchSinkTestBase {
     Map<String, String> props = createProps();
 
     ElasticsearchSinkTask task = new ElasticsearchSinkTask();
+    task.initialize(mock(SinkTaskContext.class));
 
     String key = "key";
     Schema schema = createSchema();
@@ -132,6 +137,7 @@ public class ElasticsearchSinkTaskTest extends ElasticsearchSinkTestBase {
     props.put(ElasticsearchSinkConnectorConfig.AUTO_CREATE_INDICES_AT_START_CONFIG, "false");
 
     ElasticsearchSinkTask task = new ElasticsearchSinkTask();
+    task.initialize(mock(SinkTaskContext.class));
 
     String key = "key";
     Schema schema = createSchema();

--- a/src/test/java/io/confluent/connect/elasticsearch/bulk/BulkProcessorTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/bulk/BulkProcessorTest.java
@@ -81,7 +81,7 @@ public class BulkProcessorTest {
     }
 
     @Override
-    public BulkResponse execute(List<Integer> request) throws IOException {
+    public BulkResponse execute(List<Integer> request) {
       final Expectation expectation;
       try {
         expectation = expectQ.remove();
@@ -259,7 +259,7 @@ public class BulkProcessorTest {
   }
 
   @Test
-  public void retriableErrorsHitMaxRetries() throws InterruptedException, ExecutionException {
+  public void retriableErrorsHitMaxRetries() throws InterruptedException {
     final int maxBufferedRecords = 100;
     final int maxInFlightBatches = 5;
     final int batchSize = 2;
@@ -337,7 +337,7 @@ public class BulkProcessorTest {
   }
 
   @Test
-  public void failOnMalformedDoc() throws InterruptedException {
+  public void failOnMalformedDoc() {
     final int maxBufferedRecords = 100;
     final int maxInFlightBatches = 5;
     final int batchSize = 2;
@@ -380,7 +380,7 @@ public class BulkProcessorTest {
   }
 
   @Test
-  public void ignoreOrWarnOnMalformedDoc() throws InterruptedException {
+  public void ignoreOrWarnOnMalformedDoc() {
     final int maxBufferedRecords = 100;
     final int maxInFlightBatches = 5;
     final int batchSize = 2;
@@ -429,7 +429,7 @@ public class BulkProcessorTest {
       }
     }
 
-    verify(reporter, times(4)).report(any(), any());
+    verify(reporter, times(4)).report(sinkRecord(), any());
   }
 
   @Test
@@ -469,7 +469,7 @@ public class BulkProcessorTest {
   }
 
   @Test
-  public void terminateRetriesWhenInterruptedInSleep() throws Exception {
+  public void terminateRetriesWhenInterruptedInSleep() {
     final int maxBufferedRecords = 100;
     final int maxInFlightBatches = 5;
     final int batchSize = 2;

--- a/src/test/java/io/confluent/connect/elasticsearch/bulk/BulkProcessorTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/bulk/BulkProcessorTest.java
@@ -23,7 +23,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -42,6 +41,7 @@ import static org.junit.Assert.fail;
 import static io.confluent.connect.elasticsearch.bulk.BulkProcessor.BehaviorOnMalformedDoc;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -429,7 +429,7 @@ public class BulkProcessorTest {
       }
     }
 
-    verify(reporter, times(4)).report(sinkRecord(), any());
+    verify(reporter, times(4)).report(eq(sinkRecord()), any());
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/elasticsearch/bulk/BulkProcessorTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/bulk/BulkProcessorTest.java
@@ -15,7 +15,10 @@
 package io.confluent.connect.elasticsearch.bulk;
 
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.sink.ErrantRecordReporter;
+import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -37,9 +40,12 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import static io.confluent.connect.elasticsearch.bulk.BulkProcessor.BehaviorOnMalformedDoc;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 public class BulkProcessorTest {
 
@@ -120,22 +126,23 @@ public class BulkProcessorTest {
         lingerMs,
         maxRetries,
         retryBackoffMs,
-        behaviorOnMalformedDoc
+        behaviorOnMalformedDoc,
+        null
     );
 
     final int addTimeoutMs = 10;
-    bulkProcessor.add(1, addTimeoutMs);
-    bulkProcessor.add(2, addTimeoutMs);
-    bulkProcessor.add(3, addTimeoutMs);
-    bulkProcessor.add(4, addTimeoutMs);
-    bulkProcessor.add(5, addTimeoutMs);
-    bulkProcessor.add(6, addTimeoutMs);
-    bulkProcessor.add(7, addTimeoutMs);
-    bulkProcessor.add(8, addTimeoutMs);
-    bulkProcessor.add(9, addTimeoutMs);
-    bulkProcessor.add(10, addTimeoutMs);
-    bulkProcessor.add(11, addTimeoutMs);
-    bulkProcessor.add(12, addTimeoutMs);
+    bulkProcessor.add(1, sinkRecord(), addTimeoutMs);
+    bulkProcessor.add(2, sinkRecord(), addTimeoutMs);
+    bulkProcessor.add(3, sinkRecord(), addTimeoutMs);
+    bulkProcessor.add(4, sinkRecord(), addTimeoutMs);
+    bulkProcessor.add(5, sinkRecord(), addTimeoutMs);
+    bulkProcessor.add(6, sinkRecord(), addTimeoutMs);
+    bulkProcessor.add(7, sinkRecord(), addTimeoutMs);
+    bulkProcessor.add(8, sinkRecord(), addTimeoutMs);
+    bulkProcessor.add(9, sinkRecord(), addTimeoutMs);
+    bulkProcessor.add(10, sinkRecord(), addTimeoutMs);
+    bulkProcessor.add(11, sinkRecord(), addTimeoutMs);
+    bulkProcessor.add(12, sinkRecord(), addTimeoutMs);
 
     client.expect(Arrays.asList(1, 2, 3, 4, 5), BulkResponse.success());
     client.expect(Arrays.asList(6, 7, 8, 9, 10), BulkResponse.success());
@@ -164,7 +171,8 @@ public class BulkProcessorTest {
         lingerMs,
         maxRetries,
         retryBackoffMs,
-        behaviorOnMalformedDoc
+        behaviorOnMalformedDoc,
+        null
     );
 
     client.expect(Arrays.asList(1, 2, 3), BulkResponse.success());
@@ -172,9 +180,9 @@ public class BulkProcessorTest {
     bulkProcessor.start();
 
     final int addTimeoutMs = 10;
-    bulkProcessor.add(1, addTimeoutMs);
-    bulkProcessor.add(2, addTimeoutMs);
-    bulkProcessor.add(3, addTimeoutMs);
+    bulkProcessor.add(1, sinkRecord(), addTimeoutMs);
+    bulkProcessor.add(2, sinkRecord(), addTimeoutMs);
+    bulkProcessor.add(3, sinkRecord(), addTimeoutMs);
 
     assertFalse(client.expectationsMet());
 
@@ -201,15 +209,16 @@ public class BulkProcessorTest {
         lingerMs,
         maxRetries,
         retryBackoffMs,
-        behaviorOnMalformedDoc
+        behaviorOnMalformedDoc,
+        null
     );
 
     final int addTimeoutMs = 10;
-    bulkProcessor.add(42, addTimeoutMs);
+    bulkProcessor.add(42, sinkRecord(), addTimeoutMs);
     assertEquals(1, bulkProcessor.bufferedRecords());
     try {
       // BulkProcessor not started, so this add should timeout & throw
-      bulkProcessor.add(43, addTimeoutMs);
+      bulkProcessor.add(43, sinkRecord(), addTimeoutMs);
       fail();
     } catch (ConnectException good) {
     }
@@ -238,12 +247,13 @@ public class BulkProcessorTest {
         lingerMs,
         maxRetries,
         retryBackoffMs,
-        behaviorOnMalformedDoc
+        behaviorOnMalformedDoc,
+        null
     );
 
     final int addTimeoutMs = 10;
-    bulkProcessor.add(42, addTimeoutMs);
-    bulkProcessor.add(43, addTimeoutMs);
+    bulkProcessor.add(42, sinkRecord(), addTimeoutMs);
+    bulkProcessor.add(43, sinkRecord(), addTimeoutMs);
 
     assertTrue(bulkProcessor.submitBatchWhenReady().get().succeeded);
   }
@@ -272,12 +282,13 @@ public class BulkProcessorTest {
         lingerMs,
         maxRetries,
         retryBackoffMs,
-        behaviorOnMalformedDoc
+        behaviorOnMalformedDoc,
+        null
     );
 
     final int addTimeoutMs = 10;
-    bulkProcessor.add(42, addTimeoutMs);
-    bulkProcessor.add(43, addTimeoutMs);
+    bulkProcessor.add(42, sinkRecord(), addTimeoutMs);
+    bulkProcessor.add(43, sinkRecord(), addTimeoutMs);
 
     try {
       bulkProcessor.submitBatchWhenReady().get();
@@ -309,12 +320,13 @@ public class BulkProcessorTest {
         lingerMs,
         maxRetries,
         retryBackoffMs,
-        behaviorOnMalformedDoc
+        behaviorOnMalformedDoc,
+        null
     );
 
     final int addTimeoutMs = 10;
-    bulkProcessor.add(42, addTimeoutMs);
-    bulkProcessor.add(43, addTimeoutMs);
+    bulkProcessor.add(42, sinkRecord(), addTimeoutMs);
+    bulkProcessor.add(43, sinkRecord(), addTimeoutMs);
 
     try {
       bulkProcessor.submitBatchWhenReady().get();
@@ -348,13 +360,14 @@ public class BulkProcessorTest {
         lingerMs,
         maxRetries,
         retryBackoffMs,
-        behaviorOnMalformedDoc
+        behaviorOnMalformedDoc,
+        null
     );
 
     bulkProcessor.start();
 
-    bulkProcessor.add(42, 1);
-    bulkProcessor.add(43, 1);
+    bulkProcessor.add(42, sinkRecord(),1);
+    bulkProcessor.add(43, sinkRecord(), 1);
 
     try {
       final int flushTimeoutMs = 1000;
@@ -374,6 +387,7 @@ public class BulkProcessorTest {
     final int lingerMs = 5;
     final int maxRetries = 3;
     final int retryBackoffMs = 1;
+    final ErrantRecordReporter reporter = mock(ErrantRecordReporter.class);
 
     // Test both IGNORE and WARN options
     // There is no difference in logic between IGNORE and WARN, except for the logging.
@@ -398,13 +412,14 @@ public class BulkProcessorTest {
           lingerMs,
           maxRetries,
           retryBackoffMs,
-          behaviorOnMalformedDoc
+          behaviorOnMalformedDoc,
+          reporter
       );
 
       bulkProcessor.start();
 
-      bulkProcessor.add(42, 1);
-      bulkProcessor.add(43, 1);
+      bulkProcessor.add(42, sinkRecord(), 1);
+      bulkProcessor.add(43, sinkRecord(), 1);
 
       try {
         final int flushTimeoutMs = 1000;
@@ -413,6 +428,8 @@ public class BulkProcessorTest {
         fail(e.getMessage());
       }
     }
+
+    verify(reporter, times(4)).report(any(), any());
   }
 
   @Test
@@ -437,12 +454,13 @@ public class BulkProcessorTest {
             lingerMs,
             maxRetries,
             retryBackoffMs,
-            behaviorOnMalformedDoc
+            behaviorOnMalformedDoc,
+        null
     );
 
     final int addTimeoutMs = 10;
-    bulkProcessor.add(42, addTimeoutMs);
-    bulkProcessor.add(43, addTimeoutMs);
+    bulkProcessor.add(42, sinkRecord(), addTimeoutMs);
+    bulkProcessor.add(43, sinkRecord(), addTimeoutMs);
 
     Runnable farmer = bulkProcessor.farmerTask();
     ConnectException e = assertThrows(
@@ -477,15 +495,20 @@ public class BulkProcessorTest {
             lingerMs,
             maxRetries,
             retryBackoffMs,
-            behaviorOnMalformedDoc
+            behaviorOnMalformedDoc,
+            null
     );
 
     final int addTimeoutMs = 10;
-    bulkProcessor.add(42, addTimeoutMs);
-    bulkProcessor.add(43, addTimeoutMs);
+    bulkProcessor.add(42, sinkRecord(), addTimeoutMs);
+    bulkProcessor.add(43, sinkRecord(), addTimeoutMs);
 
     ExecutionException e = assertThrows(ExecutionException.class,
             () -> bulkProcessor.submitBatchWhenReady().get());
     assertThat(e.getMessage(), containsString("a retriable error"));
+  }
+
+  private static SinkRecord sinkRecord() {
+    return new SinkRecord("topic", 0, Schema.STRING_SCHEMA, "key", Schema.INT32_SCHEMA, 0, 0L);
   }
 }

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchSinkTaskIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchSinkTaskIT.java
@@ -15,6 +15,8 @@
 
 package io.confluent.connect.elasticsearch.integration;
 
+import static org.mockito.Mockito.mock;
+
 import io.confluent.common.utils.IntegrationTest;
 import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig;
 import io.confluent.connect.elasticsearch.ElasticsearchSinkTask;
@@ -27,6 +29,7 @@ import java.util.Map;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.sink.SinkTaskContext;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -42,6 +45,7 @@ public class ElasticsearchSinkTaskIT extends ElasticsearchIntegrationTestBase {
   public void beforeEach() {
     MDC.put("connector.context", "[MyConnector|task1] ");
     Map<String, String> props = createProps();
+    task.initialize(mock(SinkTaskContext.class));
     task.start(props, client);
   }
 


### PR DESCRIPTION
## Problem
the connector currently can fail/ignore records that are malformed on the ES side. Reporting them using the new AK 2.6 reporter feature would be beneficial.

## Solution
Add the AK 2.6 reporter DLQ feature

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
modify unit tests to check whether the reporter is called

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
this is a new feature therefore pushing to `master`

Signed-off-by: Lev Zemlyanov <lev@confluent.io>