### PR TITLE
Check for unexpected datatypes in response from server

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
@@ -178,6 +178,11 @@ public class JestElasticsearchClient implements ElasticsearchClient {
       LOG.warn("Couldn't get Elasticsearch version, result is null");
       return defaultVersion;
     }
+    if (!result.has("nodes")) {
+      LOG.error("Couldn't get Elasticsearch version (result is has no nodes); "
+              + "assuming {}, result: {}", defaultVersion, result);
+      return defaultVersion;
+    }
 
     checkForError(result);
 

--- a/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
@@ -179,8 +179,7 @@ public class JestElasticsearchClient implements ElasticsearchClient {
       return defaultVersion;
     }
     if (!result.has("nodes")) {
-      LOG.error("Couldn't get Elasticsearch version (result is has no nodes); "
-              + "assuming {}, result: {}", defaultVersion, result);
+      LOG.warn("Couldn't get Elasticsearch version from result {} (result has no nodes). Assuming {}.", result, defaultVersion);
       return defaultVersion;
     }
 

--- a/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
@@ -179,7 +179,8 @@ public class JestElasticsearchClient implements ElasticsearchClient {
       return defaultVersion;
     }
     if (!result.has("nodes")) {
-      LOG.warn("Couldn't get Elasticsearch version from result {} (result has no nodes). Assuming {}.", result, defaultVersion);
+      LOG.warn("Couldn't get Elasticsearch version from result {} (result has no nodes). "
+          + "Assuming {}.", result, defaultVersion);
       return defaultVersion;
     }
 


### PR DESCRIPTION
## Problem
Sometimes the response from the ES server does not have the "nodes" element we expect to parse, and we get an NPE when we should be returning default version. 

## Solution
I added some more look-before-you-leap logic to log a warning and return default.

Alternative proposal: Wrap the whole function in blanket try-catch and return default version. I considered this to just put this to rest once and for all, but decided this would be faster and less controversial.

## Release Plan
Will target 5.1.x which is the earliest one that has logic kind of like this.