### PR TITLE
fix reporter to catch NoSuchMethodFoundError as well

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -146,7 +146,7 @@ public class ElasticsearchSinkTask extends SinkTask {
 
         // may be null if DLQ not enabled
         builder.setErrantRecordReporter(context.errantRecordReporter());
-      } catch (NoClassDefFoundError e) {
+      } catch (NoClassDefFoundError | NoSuchMethodError e) {
         // Will occur in Connect runtimes earlier than 2.6
         log.warn("AK versions prior to 2.6 do not support the errant record reporter");
       }


### PR DESCRIPTION
Signed-off-by: Lev Zemlyanov <lev@confluent.io>

## Problem
the reporter will fail with `NoSuchMethodFoundError` on old Connect workers. 

## Solution
add `NoSuchMethodFoundError` to the try catch
https://cwiki.apache.org/confluence/display/KAFKA/KIP-610%3A+Error+Reporting+in+Sink+Connectors

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
unfortunately I do not see a way that this can be tested. If anyone has suggestions, I will gladly implement. 

edit: I have run a manual test using CP 5.5.0 which runs on AK < 2.6 and the connector runs

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
`master` where this feature was first implemented