### PR TITLE
HCD-448: Adding support for size-based batching of sink records.

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -21,7 +21,7 @@
     <!-- TODO: Pass some parameters in common config object? -->
     <suppress
             checks="(ParameterNumber)"
-            files="(ElasticsearchWriter).java"
+            files="(ElasticsearchWriter|BulkProcessor).java"
     />
 
     <suppress

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -646,10 +646,6 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
             && sslEndpointIdentificationAlgorithm.isEmpty();
   }
 
-  public static void main(String[] args) {
-    System.out.println(CONFIG.toEnrichedRst());
-  }
-
   private static class MaxBatchSizeValidator implements ConfigDef.Validator {
     @Override
     public void ensureValid(String config, Object value) {
@@ -667,5 +663,9 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
         );
       }
     }
+  }
+
+  public static void main(String[] args) {
+    System.out.println(CONFIG.toEnrichedRst());
   }
 }

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -54,6 +54,11 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   public static final String BATCH_SIZE_CONFIG = "batch.size";
   private static final String BATCH_SIZE_DOC =
       "The number of records to process as a batch when writing to Elasticsearch.";
+  public static final String MAX_BATCH_BYTES_CONFIG = "max.batch.bytes";
+  private static final String MAX_BATCH_BYTES_DOC =
+      "The maximum number of bytes to process as a batch when writing to Elasticsearch."
+      + "This configuration will enable size-based batching of records irrespective of the"
+      + " records count under ``" + BATCH_SIZE_CONFIG + "`` configuration." ;
   public static final String MAX_IN_FLIGHT_REQUESTS_CONFIG = "max.in.flight.requests";
   private static final String MAX_IN_FLIGHT_REQUESTS_DOC =
       "The maximum number of indexing requests that can be in-flight to Elasticsearch before "
@@ -335,6 +340,16 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
         ++order,
         Width.SHORT,
         "Batch Size"
+    ).define(
+        MAX_BATCH_BYTES_CONFIG,
+        Type.LONG,
+        null,
+        Importance.MEDIUM,
+        MAX_BATCH_BYTES_DOC,
+        group,
+        ++order,
+        Width.SHORT,
+        "Maximum Batch Size in Bytes"
     ).define(
         MAX_IN_FLIGHT_REQUESTS_CONFIG,
         Type.INT,

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -58,7 +58,7 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   private static final String MAX_BATCH_SIZE_BYTES_DOC =
       "The maximum size(in bytes) of the bulk request to be processed by the Connector when"
       + " writing records to Elasticsearch." ;
-  private static final long MAX_BATCH_SIZE_BYTES_DEFAULT = 10 * 1024 * 1024;
+  private static final long MAX_BATCH_SIZE_BYTES_DEFAULT = 15 * 1024 * 1024;
   public static final String MAX_IN_FLIGHT_REQUESTS_CONFIG = "max.in.flight.requests";
   private static final String MAX_IN_FLIGHT_REQUESTS_DOC =
       "The maximum number of indexing requests that can be in-flight to Elasticsearch before "
@@ -653,10 +653,10 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   private static class MaxBatchSizeValidator implements ConfigDef.Validator {
     @Override
     public void ensureValid(String config, Object value) {
-      long minBytes = 0;
+      long minBytes = 1 * 1024 * 1024;
       long maxBytes = 25 * 1024 * 1024;
       long bytes = (long) value;
-      if (!(minBytes < bytes && maxBytes >= bytes)) {
+      if (!(minBytes <= bytes && maxBytes >= bytes)) {
         throw new ConfigException(
             String.format(
                 "The value for `%s` must be in between `%s` to `%s` bytes.",

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -81,7 +81,7 @@ public class ElasticsearchSinkTask extends SinkTask {
           config.getInt(ElasticsearchSinkConnectorConfig.MAX_BUFFERED_RECORDS_CONFIG);
       int batchSize =
           config.getInt(ElasticsearchSinkConnectorConfig.BATCH_SIZE_CONFIG);
-      long maxBatchBytes =
+      long maxBatchSizeBytes =
           config.getLong(ElasticsearchSinkConnectorConfig.MAX_BATCH_SIZE_BYTES_CONFIG);
       long lingerMs =
           config.getLong(ElasticsearchSinkConnectorConfig.LINGER_MS_CONFIG);
@@ -134,7 +134,7 @@ public class ElasticsearchSinkTask extends SinkTask {
           .setMaxBufferedRecords(maxBufferedRecords)
           .setMaxInFlightRequests(maxInFlightRequests)
           .setBatchSize(batchSize)
-          .setMaxBatchSizeBytes(maxBatchBytes)
+          .setMaxBatchSizeBytes(maxBatchSizeBytes)
           .setLingerMs(lingerMs)
           .setRetryBackoffMs(retryBackoffMs)
           .setMaxRetry(maxRetry)

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -81,8 +81,8 @@ public class ElasticsearchSinkTask extends SinkTask {
           config.getInt(ElasticsearchSinkConnectorConfig.MAX_BUFFERED_RECORDS_CONFIG);
       int batchSize =
           config.getInt(ElasticsearchSinkConnectorConfig.BATCH_SIZE_CONFIG);
-      Long maxBatchBytes =
-          config.getLong(ElasticsearchSinkConnectorConfig.MAX_BATCH_BYTES_CONFIG);
+      long maxBatchBytes =
+          config.getLong(ElasticsearchSinkConnectorConfig.MAX_BATCH_SIZE_BYTES_CONFIG);
       long lingerMs =
           config.getLong(ElasticsearchSinkConnectorConfig.LINGER_MS_CONFIG);
       int maxInFlightRequests =
@@ -134,7 +134,7 @@ public class ElasticsearchSinkTask extends SinkTask {
           .setMaxBufferedRecords(maxBufferedRecords)
           .setMaxInFlightRequests(maxInFlightRequests)
           .setBatchSize(batchSize)
-          .setMaxBatchBytes(maxBatchBytes)
+          .setMaxBatchSizeBytes(maxBatchBytes)
           .setLingerMs(lingerMs)
           .setRetryBackoffMs(retryBackoffMs)
           .setMaxRetry(maxRetry)

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -81,6 +81,8 @@ public class ElasticsearchSinkTask extends SinkTask {
           config.getInt(ElasticsearchSinkConnectorConfig.MAX_BUFFERED_RECORDS_CONFIG);
       int batchSize =
           config.getInt(ElasticsearchSinkConnectorConfig.BATCH_SIZE_CONFIG);
+      Long maxBatchBytes =
+          config.getLong(ElasticsearchSinkConnectorConfig.MAX_BATCH_BYTES_CONFIG);
       long lingerMs =
           config.getLong(ElasticsearchSinkConnectorConfig.LINGER_MS_CONFIG);
       int maxInFlightRequests =
@@ -132,6 +134,7 @@ public class ElasticsearchSinkTask extends SinkTask {
           .setMaxBufferedRecords(maxBufferedRecords)
           .setMaxInFlightRequests(maxInFlightRequests)
           .setBatchSize(batchSize)
+          .setMaxBatchBytes(maxBatchBytes)
           .setLingerMs(lingerMs)
           .setRetryBackoffMs(retryBackoffMs)
           .setMaxRetry(maxRetry)

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
@@ -67,7 +67,7 @@ public class ElasticsearchWriter {
       int maxBufferedRecords,
       int maxInFlightRequests,
       int batchSize,
-      Long maxBatchBytes,
+      long maxBatchBytes,
       long lingerMs,
       int maxRetries,
       long retryBackoffMs,
@@ -118,7 +118,7 @@ public class ElasticsearchWriter {
     private int maxBufferedRecords;
     private int maxInFlightRequests;
     private int batchSize;
-    private Long maxBatchBytes;
+    private long maxBatchBytes;
     private long lingerMs;
     private int maxRetry;
     private long retryBackoffMs;
@@ -178,7 +178,7 @@ public class ElasticsearchWriter {
       return this;
     }
 
-    public Builder setMaxBatchBytes(Long maxBatchBytes) {
+    public Builder setMaxBatchSizeBytes(long maxBatchBytes) {
       this.maxBatchBytes = maxBatchBytes;
       return this;
     }

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
@@ -67,7 +67,7 @@ public class ElasticsearchWriter {
       int maxBufferedRecords,
       int maxInFlightRequests,
       int batchSize,
-      long maxBatchBytes,
+      long maxBatchSizeBytes,
       long lingerMs,
       int maxRetries,
       long retryBackoffMs,
@@ -94,7 +94,7 @@ public class ElasticsearchWriter {
         maxBufferedRecords,
         maxInFlightRequests,
         batchSize,
-        maxBatchBytes,
+        maxBatchSizeBytes,
         lingerMs,
         maxRetries,
         retryBackoffMs,
@@ -118,7 +118,7 @@ public class ElasticsearchWriter {
     private int maxBufferedRecords;
     private int maxInFlightRequests;
     private int batchSize;
-    private long maxBatchBytes;
+    private long maxBatchSizeBytes;
     private long lingerMs;
     private int maxRetry;
     private long retryBackoffMs;
@@ -178,8 +178,8 @@ public class ElasticsearchWriter {
       return this;
     }
 
-    public Builder setMaxBatchSizeBytes(long maxBatchBytes) {
-      this.maxBatchBytes = maxBatchBytes;
+    public Builder setMaxBatchSizeBytes(long maxBatchSizeBytes) {
+      this.maxBatchSizeBytes = maxBatchSizeBytes;
       return this;
     }
 
@@ -239,7 +239,7 @@ public class ElasticsearchWriter {
           maxBufferedRecords,
           maxInFlightRequests,
           batchSize,
-          maxBatchBytes,
+          maxBatchSizeBytes,
           lingerMs,
           maxRetry,
           retryBackoffMs,

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
@@ -67,6 +67,7 @@ public class ElasticsearchWriter {
       int maxBufferedRecords,
       int maxInFlightRequests,
       int batchSize,
+      Long maxBatchBytes,
       long lingerMs,
       int maxRetries,
       long retryBackoffMs,
@@ -93,6 +94,7 @@ public class ElasticsearchWriter {
         maxBufferedRecords,
         maxInFlightRequests,
         batchSize,
+        maxBatchBytes,
         lingerMs,
         maxRetries,
         retryBackoffMs,
@@ -116,6 +118,7 @@ public class ElasticsearchWriter {
     private int maxBufferedRecords;
     private int maxInFlightRequests;
     private int batchSize;
+    private Long maxBatchBytes;
     private long lingerMs;
     private int maxRetry;
     private long retryBackoffMs;
@@ -175,6 +178,11 @@ public class ElasticsearchWriter {
       return this;
     }
 
+    public Builder setMaxBatchBytes(Long maxBatchBytes) {
+      this.maxBatchBytes = maxBatchBytes;
+      return this;
+    }
+
     public Builder setLingerMs(long lingerMs) {
       this.lingerMs = lingerMs;
       return this;
@@ -231,6 +239,7 @@ public class ElasticsearchWriter {
           maxBufferedRecords,
           maxInFlightRequests,
           batchSize,
+          maxBatchBytes,
           lingerMs,
           maxRetry,
           retryBackoffMs,

--- a/src/main/java/io/confluent/connect/elasticsearch/IndexableRecord.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/IndexableRecord.java
@@ -47,4 +47,9 @@ public class IndexableRecord {
   public int hashCode() {
     return Objects.hash(key, version, payload);
   }
+
+  @Override
+  public String toString() {
+    return String.format("%s/payload{%s}/version{%s}", key, payload, version);
+  }
 }

--- a/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
@@ -62,7 +62,6 @@ import org.apache.http.nio.conn.ssl.SSLIOSessionStrategy;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.common.network.Mode;
-import org.apache.kafka.common.security.ssl.DefaultSslEngineFactory;
 import org.apache.kafka.common.security.ssl.SslFactory;
 import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.Map;
 
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.MAX_BATCH_SIZE_BYTES_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.PROXY_HOST_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.PROXY_PASSWORD_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.PROXY_PORT_CONFIG;
@@ -138,6 +139,12 @@ public class ElasticsearchSinkConnectorConfigTest {
   public void shouldNotAllowPartialProxyCredentials() {
     props.put(PROXY_HOST_CONFIG, "proxy host");
     props.put(PROXY_USERNAME_CONFIG, "username");
+    ElasticsearchSinkConnectorConfig config = new ElasticsearchSinkConnectorConfig(props);
+  }
+
+  @Test(expected = ConfigException.class)
+  public void shouldNotAllowInvalidBatchSize() {
+    props.put(MAX_BATCH_SIZE_BYTES_CONFIG, Long.toString(30 * 1024 * 1024));
     ElasticsearchSinkConnectorConfig config = new ElasticsearchSinkConnectorConfig(props);
   }
 }

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchWriterTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchWriterTest.java
@@ -540,6 +540,7 @@ public class ElasticsearchWriterTest extends ElasticsearchSinkTestBase {
         .setMaxRetry(3)
         .setDropInvalidMessage(dropInvalidMessage)
         .setBehaviorOnNullValues(behavior)
+        .setMaxBatchSizeBytes(10 * 1024 * 1024)
         .build();
     writer.start();
     writer.createIndicesForTopics(Collections.singleton(TOPIC));

--- a/src/test/java/io/confluent/connect/elasticsearch/bulk/BulkProcessorTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/bulk/BulkProcessorTest.java
@@ -123,6 +123,7 @@ public class BulkProcessorTest {
         maxBufferedRecords,
         maxInFlightBatches,
         batchSize,
+        null,
         lingerMs,
         maxRetries,
         retryBackoffMs,
@@ -153,6 +154,55 @@ public class BulkProcessorTest {
   }
 
   @Test
+  public void enableSizeBasedBatching() throws InterruptedException, ExecutionException {
+    final int maxBufferedRecords = 100;
+    final int maxInFlightBatches = 5;
+    final int batchSize = 1;
+    final Long maxBatchBytes = (long) 5;
+    final int lingerMs = 5;
+    final int maxRetries = 0;
+    final int retryBackoffMs = 0;
+    final BehaviorOnMalformedDoc behaviorOnMalformedDoc = BehaviorOnMalformedDoc.DEFAULT;
+
+    final BulkProcessor<Integer, ?> bulkProcessor = new BulkProcessor<>(
+        Time.SYSTEM,
+        client,
+        maxBufferedRecords,
+        maxInFlightBatches,
+        batchSize,
+        maxBatchBytes,
+        lingerMs,
+        maxRetries,
+        retryBackoffMs,
+        behaviorOnMalformedDoc,
+        null
+    );
+
+    final int addTimeoutMs = 10;
+    bulkProcessor.add(1, sinkRecord(), addTimeoutMs);
+    bulkProcessor.add(2, sinkRecord(), addTimeoutMs);
+    bulkProcessor.add(3, sinkRecord(), addTimeoutMs);
+    bulkProcessor.add(4, sinkRecord(), addTimeoutMs);
+    bulkProcessor.add(5, sinkRecord(), addTimeoutMs);
+    bulkProcessor.add(6, sinkRecord(), addTimeoutMs);
+    bulkProcessor.add(7, sinkRecord(), addTimeoutMs);
+    bulkProcessor.add(8, sinkRecord(), addTimeoutMs);
+    bulkProcessor.add(9, sinkRecord(), addTimeoutMs);
+    bulkProcessor.add(10, sinkRecord(), addTimeoutMs);
+    bulkProcessor.add(11, sinkRecord(), addTimeoutMs);
+    bulkProcessor.add(12, sinkRecord(), addTimeoutMs);
+
+    client.expect(Arrays.asList(1, 2, 3, 4, 5), BulkResponse.success());
+    client.expect(Arrays.asList(6, 7, 8, 9), BulkResponse.success());
+    client.expect(Arrays.asList(10, 11), BulkResponse.success());
+    client.expect(Arrays.asList(12), BulkResponse.success()); // batch not full, but upon linger timeout
+    assertTrue(bulkProcessor.submitBatchWhenReady().get().succeeded);
+    assertTrue(bulkProcessor.submitBatchWhenReady().get().succeeded);
+    assertTrue(bulkProcessor.submitBatchWhenReady().get().succeeded);
+    assertTrue(bulkProcessor.submitBatchWhenReady().get().succeeded);
+  }
+
+  @Test
   public void flushing() {
     final int maxBufferedRecords = 100;
     final int maxInFlightBatches = 5;
@@ -168,6 +218,7 @@ public class BulkProcessorTest {
         maxBufferedRecords,
         maxInFlightBatches,
         batchSize,
+        null,
         lingerMs,
         maxRetries,
         retryBackoffMs,
@@ -206,6 +257,7 @@ public class BulkProcessorTest {
         maxBufferedRecords,
         maxInFlightBatches,
         batchSize,
+        null,
         lingerMs,
         maxRetries,
         retryBackoffMs,
@@ -244,6 +296,7 @@ public class BulkProcessorTest {
         maxBufferedRecords,
         maxInFlightBatches,
         batchSize,
+        null,
         lingerMs,
         maxRetries,
         retryBackoffMs,
@@ -279,6 +332,7 @@ public class BulkProcessorTest {
         maxBufferedRecords,
         maxInFlightBatches,
         batchSize,
+        null,
         lingerMs,
         maxRetries,
         retryBackoffMs,
@@ -317,6 +371,7 @@ public class BulkProcessorTest {
         maxBufferedRecords,
         maxInFlightBatches,
         batchSize,
+        null,
         lingerMs,
         maxRetries,
         retryBackoffMs,
@@ -357,6 +412,7 @@ public class BulkProcessorTest {
         maxBufferedRecords,
         maxInFlightBatches,
         batchSize,
+        null,
         lingerMs,
         maxRetries,
         retryBackoffMs,
@@ -409,6 +465,7 @@ public class BulkProcessorTest {
           maxBufferedRecords,
           maxInFlightBatches,
           batchSize,
+          null,
           lingerMs,
           maxRetries,
           retryBackoffMs,
@@ -451,6 +508,7 @@ public class BulkProcessorTest {
             maxBufferedRecords,
             maxInFlightBatches,
             batchSize,
+            null,
             lingerMs,
             maxRetries,
             retryBackoffMs,
@@ -492,6 +550,7 @@ public class BulkProcessorTest {
             maxBufferedRecords,
             maxInFlightBatches,
             batchSize,
+            null,
             lingerMs,
             maxRetries,
             retryBackoffMs,


### PR DESCRIPTION
The feature request for adding support of size-based batching of sink records in ElasticSearch sink connector.

The batching of records on the basis of size is now configurable using ``max.batch.size.bytes`` configuration.
With this implementation number of records in batches will depend upon the configured records ``batch.size`` and ``max.batch.size.bytes``.
Jira: https://confluentinc.atlassian.net/browse/HCD-448