### PR TITLE
HCD-449: Added support for Initial retries when failed due to connection refused.

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
@@ -416,7 +416,7 @@ public class JestElasticsearchClient implements ElasticsearchClient {
               retryBackoffMs);
           log.info("Failed to create connection to the ElasticSearch with attempt {}/{}, "
                   + "will attempt retry after {} ms. Failure reason: {}",
-              retryAttempts, maxRetryAttempts, sleepTimeMs, ex.getMessage());
+              retryAttempts, maxRetryAttempts, sleepTimeMs, ex);
           time.sleep(sleepTimeMs);
         } else {
           throw ex;


### PR DESCRIPTION
The feature request to add support for initial retries when the ElasticSearch connection is refused.
Jira: https://confluentinc.atlassian.net/browse/HCD-449