### PR TITLE
CC-11959: BulkProcessor does not empty internal record map correctly

### DIFF
--- a/src/test/java/io/confluent/connect/elasticsearch/bulk/BulkProcessorTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/bulk/BulkProcessorTest.java
@@ -35,6 +35,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -569,7 +570,7 @@ public class BulkProcessorTest {
     bulkProcessor.add(43, sinkRecord(), addTimeoutMs);
 
     assertEquals(2, bulkProcessor.bufferedRecords());
-    assertTrue(bulkProcessor.recordsToReportOnError.isEmpty());
+    assertNull(bulkProcessor.recordsToReportOnError);
 
     bulkProcessor.flush(1000);
     assertEquals(0, bulkProcessor.bufferedRecords());

--- a/src/test/java/io/confluent/connect/elasticsearch/bulk/BulkProcessorTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/bulk/BulkProcessorTest.java
@@ -150,6 +150,7 @@ public class BulkProcessorTest {
     assertTrue(bulkProcessor.submitBatchWhenReady().get().succeeded);
     assertTrue(bulkProcessor.submitBatchWhenReady().get().succeeded);
     assertTrue(bulkProcessor.submitBatchWhenReady().get().succeeded);
+    assertTrue(bulkProcessor.recordMap.isEmpty());
   }
 
   @Test
@@ -188,6 +189,7 @@ public class BulkProcessorTest {
 
     final int flushTimeoutMs = 100;
     bulkProcessor.flush(flushTimeoutMs);
+    assertTrue(bulkProcessor.recordMap.isEmpty());
   }
 
   @Test
@@ -222,6 +224,7 @@ public class BulkProcessorTest {
       fail();
     } catch (ConnectException good) {
     }
+    assertEquals(1, bulkProcessor.recordMap.size());
   }
 
   @Test
@@ -256,6 +259,7 @@ public class BulkProcessorTest {
     bulkProcessor.add(43, sinkRecord(), addTimeoutMs);
 
     assertTrue(bulkProcessor.submitBatchWhenReady().get().succeeded);
+    assertTrue(bulkProcessor.recordMap.isEmpty());
   }
 
   @Test
@@ -295,6 +299,7 @@ public class BulkProcessorTest {
       fail();
     } catch (ExecutionException e) {
       assertTrue(e.getCause().getMessage().contains(errorInfo));
+      assertTrue(bulkProcessor.recordMap.isEmpty());
     }
   }
 
@@ -333,6 +338,7 @@ public class BulkProcessorTest {
       fail();
     } catch (ExecutionException e) {
       assertTrue(e.getCause().getMessage().contains(errorInfo));
+      assertTrue(bulkProcessor.recordMap.isEmpty());
     }
   }
 
@@ -376,6 +382,7 @@ public class BulkProcessorTest {
     } catch(ConnectException e) {
       // expected
       assertTrue(e.getMessage().contains("mapper_parsing_exception"));
+      assertTrue(bulkProcessor.recordMap.isEmpty());
     }
   }
 
@@ -427,9 +434,11 @@ public class BulkProcessorTest {
       } catch (ConnectException e) {
         fail(e.getMessage());
       }
+      assertTrue(bulkProcessor.recordMap.isEmpty());
     }
 
     verify(reporter, times(4)).report(eq(sinkRecord()), any());
+
   }
 
   @Test
@@ -506,6 +515,7 @@ public class BulkProcessorTest {
     ExecutionException e = assertThrows(ExecutionException.class,
             () -> bulkProcessor.submitBatchWhenReady().get());
     assertThat(e.getMessage(), containsString("a retriable error"));
+    assertTrue(bulkProcessor.recordMap.isEmpty());
   }
 
   private static SinkRecord sinkRecord() {


### PR DESCRIPTION
Signed-off-by: Lev Zemlyanov <lev@confluent.io>

## Problem
the connector has to keep an internal map (`recordMap`) to keep track of the original `SinkRecords` so that it can report any errors using the DLQ reporter. the connector has been experiencing a memory leak first noticed in #444. On further analysis it was found that the connector did not empty the map on successful writes (only on [failed writes](https://github.com/confluentinc/kafka-connect-elasticsearch/blob/master/src/main/java/io/confluent/connect/elasticsearch/bulk/BulkProcessor.java#L478)).

## Solution
empty the map correctly in all cases

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
modified all existing unit tests to verify that the map is indeed empty

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
backport to `10.0.x` where the DLQ reporter was first introduced