### PR TITLE
CC-11969: do not report successful records in failed batches

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -26,6 +26,12 @@
 
     <suppress
             checks="MethodLengthCheck"
-            files="ElasticsearchSinkConnectorConfig.java"/>
+            files="ElasticsearchSinkConnectorConfig.java"
+    />
+
+    <suppress
+      checks="NPathComplexity"
+      files="JestElasticsearchClient.java"
+    />
 
 </suppressions>

--- a/src/main/java/io/confluent/connect/elasticsearch/bulk/BulkProcessor.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/bulk/BulkProcessor.java
@@ -493,7 +493,7 @@ public class BulkProcessor<R, B> {
                 SinkRecord original = recordsToReportOnError.get(record);
                 BulkResultItem result = bulkRsp.failedRecords.get(record);
                 String error = result != null ? result.error : null;
-                if (original != null && error != null) {
+                if (error != null && original != null) {
                   reporter.report(
                       original, new ReportingException("Bulk request failed: " + error)
                   );

--- a/src/main/java/io/confluent/connect/elasticsearch/bulk/BulkResponse.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/bulk/BulkResponse.java
@@ -15,26 +15,43 @@
 
 package io.confluent.connect.elasticsearch.bulk;
 
+import io.confluent.connect.elasticsearch.IndexableRecord;
+import io.searchbox.core.BulkResult.BulkResultItem;
+import java.util.Collections;
+import java.util.Map;
+
 public class BulkResponse {
 
-  private static final BulkResponse SUCCESS_RESPONSE = new BulkResponse(true, false, "");
+  private static final BulkResponse SUCCESS_RESPONSE =
+      new BulkResponse(true, false, "", Collections.emptyMap());
 
   public final boolean succeeded;
   public final boolean retriable;
   public final String errorInfo;
+  public final Map<IndexableRecord, BulkResultItem> failedRecords;
 
-  private BulkResponse(boolean succeeded, boolean retriable, String errorInfo) {
+  private BulkResponse(
+      boolean succeeded,
+      boolean retriable,
+      String errorInfo,
+      Map<IndexableRecord, BulkResultItem> failedRecords
+  ) {
     this.succeeded = succeeded;
     this.retriable = retriable;
     this.errorInfo = errorInfo;
+    this.failedRecords = failedRecords;
   }
 
   public static BulkResponse success() {
     return SUCCESS_RESPONSE;
   }
 
-  public static BulkResponse failure(boolean retriable, String errorInfo) {
-    return new BulkResponse(false, retriable, errorInfo);
+  public static BulkResponse failure(
+      boolean retriable,
+      String errorInfo,
+      Map<IndexableRecord, BulkResultItem> failedRecords
+  ) {
+    return new BulkResponse(false, retriable, errorInfo, failedRecords);
   }
 
   public boolean isSucceeded() {

--- a/src/main/java/io/confluent/connect/elasticsearch/bulk/BulkResponse.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/bulk/BulkResponse.java
@@ -30,6 +30,13 @@ public class BulkResponse {
   public final String errorInfo;
   public final Map<IndexableRecord, BulkResultItem> failedRecords;
 
+  /**
+   * Creates a BulkResponse.
+   * @param succeeded whether the bulk request was successful or not.
+   * @param retriable whether the bulk request should be retried.
+   * @param errorInfo the error string
+   * @param failedRecords map of failed records and their results. Never null.
+   */
   private BulkResponse(
       boolean succeeded,
       boolean retriable,
@@ -46,6 +53,13 @@ public class BulkResponse {
     return SUCCESS_RESPONSE;
   }
 
+  /**
+   * Creates a failed BulkResponse.
+   * @param retriable whether the error is retriable
+   * @param errorInfo the error string
+   * @param failedRecords map of failed records and their results. Never null.
+   * @return
+   */
   public static BulkResponse failure(
       boolean retriable,
       String errorInfo,

--- a/src/main/java/io/confluent/connect/elasticsearch/jest/JestBulkRequest.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/JestBulkRequest.java
@@ -15,18 +15,25 @@
 
 package io.confluent.connect.elasticsearch.jest;
 
+import io.confluent.connect.elasticsearch.IndexableRecord;
+import io.confluent.connect.elasticsearch.Key;
 import io.confluent.connect.elasticsearch.bulk.BulkRequest;
 import io.searchbox.core.Bulk;
+import java.util.List;
 
 public class JestBulkRequest implements BulkRequest {
 
   private final Bulk bulk;
+  private final List<IndexableRecord> records;
 
-  public JestBulkRequest(Bulk bulk) {
+  public JestBulkRequest(Bulk bulk, List<IndexableRecord> records) {
     this.bulk = bulk;
+    this.records = records;
   }
 
   public Bulk getBulk() {
     return bulk;
   }
+
+  public List<IndexableRecord> records() { return records; }
 }

--- a/src/main/java/io/confluent/connect/elasticsearch/jest/JestBulkRequest.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/JestBulkRequest.java
@@ -16,7 +16,6 @@
 package io.confluent.connect.elasticsearch.jest;
 
 import io.confluent.connect.elasticsearch.IndexableRecord;
-import io.confluent.connect.elasticsearch.Key;
 import io.confluent.connect.elasticsearch.bulk.BulkRequest;
 import io.searchbox.core.Bulk;
 import java.util.List;
@@ -35,5 +34,7 @@ public class JestBulkRequest implements BulkRequest {
     return bulk;
   }
 
-  public List<IndexableRecord> records() { return records; }
+  public List<IndexableRecord> records() {
+    return records;
+  }
 }

--- a/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
@@ -52,7 +52,6 @@ import io.searchbox.indices.IndicesExists;
 import io.searchbox.indices.Refresh;
 import io.searchbox.indices.mapping.PutMapping;
 import java.util.HashMap;
-import java.util.function.Function;
 import javax.net.ssl.HostnameVerifier;
 import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;

--- a/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
@@ -52,6 +52,7 @@ import io.searchbox.indices.IndicesExists;
 import io.searchbox.indices.Refresh;
 import io.searchbox.indices.mapping.PutMapping;
 import java.util.HashMap;
+import java.util.Objects;
 import javax.net.ssl.HostnameVerifier;
 import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
@@ -654,16 +655,17 @@ public class JestElasticsearchClient implements ElasticsearchClient {
 
     Map<IndexableRecord, BulkResultItem> failedResponses = new HashMap<>();
     List<BulkResultItem> items = result.getItems();
-    for (int i = 0; i < items.size() && i < ((JestBulkRequest) bulk).records().size() ; i++) {
+    List<IndexableRecord> records = ((JestBulkRequest) bulk).records();
+    for (int i = 0; i < items.size() && i < records.size() ; i++) {
       BulkResultItem item = items.get(i);
-      IndexableRecord record = ((JestBulkRequest) bulk).records().get(i);
-      if (item.error != null && item.id.equals(record.key.id)) {
+      IndexableRecord record = records.get(i);
+      if (item.error != null && Objects.equals(item.id, record.key.id)) {
         // sanity check matching IDs
         failedResponses.put(record, item);
       }
     }
 
-    if (items.size() != ((JestBulkRequest) bulk).records().size()) {
+    if (items.size() != records.size()) {
       log.error(
           "Elasticsearch bulk response size ({}) does not correspond to records sent ({})",
           ((JestBulkRequest) bulk).records().size(),


### PR DESCRIPTION
## Problem
the reporter currently reports all records in a batch as failed if even 1 record failed due to the connector design. This is incorrect and produces a lot of unnecessary logs as well.

## Solution
refactor the reporter to only report failed records in failed batches

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
write unit test to make sure only failed records are written

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
backport to `10.0.x` when reporter was first introduced