### PR TITLE
CC-12066: Fix flaky test BulkProcessorTest::farmerTaskPropogatesException

### DIFF
--- a/src/test/java/io/confluent/connect/elasticsearch/bulk/BulkProcessorTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/bulk/BulkProcessorTest.java
@@ -447,8 +447,20 @@ public class BulkProcessorTest {
     bulkProcessor.add(43, addTimeoutMs);
 
     Runnable farmer = bulkProcessor.farmerTask();
-    ConnectException e = assertThrows(
-            ConnectException.class, () -> farmer.run());
+    ConnectException e = assertThrows(ConnectException.class, () -> {
+        farmer.run();
+        // There's a small race condition in the farmer task where a failure on a batch thread
+        // causes the stopRequested flag of the BulkProcessor to get set, and subsequently checked
+        // on the farmer task thread, before the batch thread has time to actually complete and
+        // throw an exception. When this happens, the invocation of farmer::run does not throw an
+        // exception. However, we can still verify that a batch failed and that the bulk processor
+        // is in the expected state by invoking BulkProcessor::throwIfFailed, which throws the first
+        // error encountered on any batch thread. Even if the aforementioned race condition occurs,
+        // the error should still have been captured by the bulk processor and if it is not present
+        // by this point, it is a legitimate sign of a bug in the processor instead of a benign race
+        // condition that just makes testing a little more complicated.
+        bulkProcessor.throwIfFailed();
+    });
     assertThat(e.getMessage(), containsString(errorInfo));
   }
 


### PR DESCRIPTION
[Jira](https://confluentinc.atlassian.net/browse/CC-12066)

## Problem
Flaky test that fails every once in a while due to a benign race condition. Some failures include:
- https://jenkins.confluent.io/job/confluentinc/job/kafka-connect-elasticsearch/job/5.3.x/327
- https://jenkins.confluent.io/job/confluentinc/job/kafka-connect-elasticsearch/job/5.3.x/339
- https://jenkins.confluent.io/job/confluentinc/job/kafka-connect-elasticsearch/job/5.4.x/261
- https://jenkins.confluent.io/job/confluentinc/job/kafka-connect-elasticsearch/job/5.4.x/265
- https://jenkins.confluent.io/job/confluentinc/job/kafka-connect-elasticsearch/job/5.5.x/195
- https://jenkins.confluent.io/job/confluentinc/job/kafka-connect-elasticsearch/job/5.5.x/205
- https://jenkins.confluent.io/job/confluentinc/job/kafka-connect-elasticsearch/job/10.0.x/30
- https://jenkins.confluent.io/job/confluentinc/job/kafka-connect-elasticsearch/job/10.0.x/32
- https://jenkins.confluent.io/job/confluentinc/job/kafka-connect-elasticsearch/job/master/1644
- https://jenkins.confluent.io/job/confluentinc/job/kafka-connect-elasticsearch/job/master/1654

## Solution
Fix the flaky test (for more detail, see the JIRA and/or the comment in the altered test).

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

## Test Strategy
It's a race condition so it's hard to verify for sure. I ran the `BulkProcessorTest` 100 times locally with and without the fix. It never failed once on my machine.

Given that this is just a change to an already-flaky test, it should be acceptable to merge without being able to reproduce locally and re-evaluate if necessary if the test continues to be flaky on our periodic, PR, and post-merge Jenkins builds.

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests (manual invocation of flaky unit tests)

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
Target earliest affect branch (test was added in https://github.com/confluentinc/kafka-connect-elasticsearch/pull/411, which targeted 5.0.x), `pint merge` forward.