### PR TITLE
CC-12129: catch resource_already_exists_exception when creating indices

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
@@ -85,6 +85,8 @@ public class JestElasticsearchClient implements ElasticsearchClient {
       = "version_conflict_engine_exception";
   protected static final String ALL_FIELD_PARAM
       = "_all";
+  protected static final String RESOURCE_ALREADY_EXISTS_EXCEPTION
+      = "resource_already_exists_exception";
 
   private static final Logger LOG = LoggerFactory.getLogger(JestElasticsearchClient.class);
 
@@ -401,8 +403,11 @@ public class JestElasticsearchClient implements ElasticsearchClient {
       JestResult result = client.execute(createIndex);
       log.debug("Received response for request to create index '{}'", index);
       if (!result.isSucceeded()) {
+        boolean exists = result.getErrorMessage().contains(RESOURCE_ALREADY_EXISTS_EXCEPTION)
+            || indexExists(index);
+
         // Check if index was created by another client
-        if (!indexExists(index)) {
+        if (!exists) {
           String msg =
               result.getErrorMessage() != null ? ": " + result.getErrorMessage() : "";
           throw new ConnectException("Could not create index '" + index + "'" + msg);


### PR DESCRIPTION
Signed-off-by: Lev Zemlyanov <lev@confluent.io>

## Problem
index exists can return a 404 Not Found when it exists

## Solution
check that the reason index creation failed was because it already exists and only then check if the index exists

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
add unit test to mock a failed index creation

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
backport where this was first introduced