### PR TITLE
CC-12530: do not throw exception on flush after task close

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
@@ -323,7 +323,7 @@ public class DataConverter {
   }
 
   private Object preProcessArrayValue(Object value, Schema schema, Schema newSchema) {
-    Collection collection = (Collection) value;
+    Collection<?> collection = (Collection<?>) value;
     List<Object> result = new ArrayList<>();
     for (Object element: collection) {
       result.add(preProcessValue(element, schema.valueSchema(), newSchema.valueSchema()));

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -35,7 +35,7 @@ import java.util.concurrent.TimeUnit;
 public class ElasticsearchSinkTask extends SinkTask {
 
   private static final Logger log = LoggerFactory.getLogger(ElasticsearchSinkTask.class);
-  private ElasticsearchWriter writer;
+  private volatile ElasticsearchWriter writer;
   private ElasticsearchClient client;
   private Boolean createIndicesAtStartTime;
 
@@ -125,10 +125,10 @@ public class ElasticsearchSinkTask extends SinkTask {
   @Override
   public void flush(Map<TopicPartition, OffsetAndMetadata> offsets) {
     if (writer != null) {
-      log.trace("Flushing data to Elasticsearch with the following offsets: {}", offsets);
+      log.debug("Flushing data to Elasticsearch with the following offsets: {}", offsets);
       writer.flush();
     } else {
-      log.trace("Could not flush data to Elasticsearch because ESWriter already closed.");
+      log.debug("Could not flush data to Elasticsearch because ESWriter already closed.");
     }
   }
 

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -124,8 +124,12 @@ public class ElasticsearchSinkTask extends SinkTask {
 
   @Override
   public void flush(Map<TopicPartition, OffsetAndMetadata> offsets) {
-    log.trace("Flushing data to Elasticsearch with the following offsets: {}", offsets);
-    writer.flush();
+    if (writer != null) {
+      log.trace("Flushing data to Elasticsearch with the following offsets: {}", offsets);
+      writer.flush();
+    } else {
+      log.trace("Could not flush data to Elasticsearch because ESWriter already closed.");
+    }
   }
 
   @Override
@@ -138,6 +142,7 @@ public class ElasticsearchSinkTask extends SinkTask {
     log.info("Stopping ElasticsearchSinkTask.");
     if (writer != null) {
       writer.stop();
+      writer = null;
     }
     if (client != null) {
       client.close();

--- a/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
@@ -316,7 +316,7 @@ public class JestElasticsearchClient implements ElasticsearchClient {
   }
 
   // visible for testing
-  protected BulkableAction toBulkableAction(IndexableRecord record) {
+  protected BulkableAction<?> toBulkableAction(IndexableRecord record) {
     // If payload is null, the record was a tombstone and we should delete from the index.
     return record.payload != null ? toIndexRequest(record) : toDeleteRequest(record);
   }

--- a/src/test/java/io/confluent/connect/elasticsearch/DataConverterTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/DataConverterTest.java
@@ -235,7 +235,7 @@ public class DataConverterTest {
         SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.INT32_SCHEMA).build(),
         preProcessedSchema
     );
-    HashMap newValue = (HashMap) converter.preProcessValue(origValue, origSchema, preProcessedSchema);
+    HashMap<?, ?> newValue = (HashMap<?, ?>) converter.preProcessValue(origValue, origSchema, preProcessedSchema);
     assertEquals(origValue, newValue);
   }
 

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
@@ -152,6 +152,14 @@ public class ElasticsearchSinkTaskTest extends ElasticsearchSinkTestBase {
 
   }
 
+  @Test
+  public void testStopThenFlushDoesNotThrow() {
+    ElasticsearchSinkTask task = new ElasticsearchSinkTask();
+    task.start(createProps(), client);
+    task.stop();
+    task.flush(new HashMap<>());
+  }
+
   private boolean verifyIndexExist(InternalTestCluster cluster, String ... indices) {
     ActionFuture<IndicesExistsResponse> action = cluster
         .client()

--- a/src/test/java/io/confluent/connect/elasticsearch/bulk/BulkProcessorTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/bulk/BulkProcessorTest.java
@@ -379,10 +379,8 @@ public class BulkProcessorTest {
     // Test both IGNORE and WARN options
     // There is no difference in logic between IGNORE and WARN, except for the logging.
     // Test to ensure they both work the same logically
-    final List<BehaviorOnMalformedDoc> behaviorsToTest = new ArrayList<BehaviorOnMalformedDoc>() {{
-      add(BehaviorOnMalformedDoc.WARN);
-      add(BehaviorOnMalformedDoc.IGNORE);
-    }};
+    final List<BehaviorOnMalformedDoc> behaviorsToTest =
+        Arrays.asList(BehaviorOnMalformedDoc.WARN, BehaviorOnMalformedDoc.IGNORE);
 
     for(BehaviorOnMalformedDoc behaviorOnMalformedDoc : behaviorsToTest)
     {


### PR DESCRIPTION
Signed-off-by: Lev Zemlyanov <lev@confluent.io>

## Problem
the worker calls `SinkTask::close` followed by `SinkTask::flush`, but `SinkTask::close` closes the `BulkProcessor` which causes the consequent flush to throw an exception.

## Solution
only flush if the `BulkProcessor is still open

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
write a test that flushes after close

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
backport as far back as possible