### PR TITLE
CC-12452: add config combination validators 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <hamcrest.version>1.3</hamcrest.version>
         <mockito.version>2.13.0</mockito.version>
         <jest.version>6.3.1</jest.version>
-        <test.containers.version>1.11.4</test.containers.version>
+        <test.containers.version>1.15.0-rc2</test.containers.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
     </properties>

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnector.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnector.java
@@ -16,6 +16,7 @@
 
 package io.confluent.connect.elasticsearch;
 
+import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.connect.connector.Task;
@@ -74,5 +75,11 @@ public class ElasticsearchSinkConnector extends SinkConnector {
   @Override
   public ConfigDef config() {
     return ElasticsearchSinkConnectorConfig.CONFIG;
+  }
+
+  @Override
+  public Config validate(Map<String, String> connectorConfigs) {
+    Validator validator = new Validator(connectorConfigs);
+    return validator.validate();
   }
 }

--- a/src/main/java/io/confluent/connect/elasticsearch/Validator.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/Validator.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ **/
+
+package io.confluent.connect.elasticsearch;
+
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BATCH_SIZE_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_PASSWORD_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_USERNAME_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.FLUSH_TIMEOUT_MS_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_KEY_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_KEY_TOPICS_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_SCHEMA_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_SCHEMA_TOPICS_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.LINGER_MS_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.MAX_BUFFERED_RECORDS_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.MAX_IN_FLIGHT_REQUESTS_CONFIG;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.apache.kafka.common.config.Config;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.config.ConfigValue;
+
+public class Validator {
+
+  private ElasticsearchSinkConnectorConfig config;
+  private Map<String, ConfigValue> values;
+  private List<ConfigValue> validations;
+
+  public Validator(Map<String, String> props) {
+    try {
+      this.config = new ElasticsearchSinkConnectorConfig(props);
+    } catch (ConfigException e) {
+      // some configs are invalid
+    }
+
+    validations = ElasticsearchSinkConnectorConfig.CONFIG.validate(props);
+    values = validations.stream().collect(Collectors.toMap(ConfigValue::name, Function.identity()));
+  }
+
+  public Config validate() {
+    if (config == null) {
+      // individual configs are invalid, no point in validating combinations
+      return new Config(validations);
+    }
+
+    validateCredentials();
+    validateIgnoreConfigs();
+    validateLingerMs();
+    validateMaxBufferedRecords();
+
+    return new Config(validations);
+  }
+
+
+  private void validateCredentials() {
+    boolean onlyOneSet = config.username() != null ^ config.password() != null;
+    if (onlyOneSet) {
+      String errorMessage = String.format(
+          "Both %s and %s must be set.", CONNECTION_USERNAME_CONFIG, CONNECTION_PASSWORD_CONFIG
+      );
+      addErrorMessage(CONNECTION_USERNAME_CONFIG, errorMessage);
+      addErrorMessage(CONNECTION_PASSWORD_CONFIG, errorMessage);
+    }
+  }
+
+  private void validateIgnoreConfigs() {
+    if (config.ignoreKey() && !config.ignoreKeyTopics().isEmpty()) {
+      String errorMessage = String.format(
+          "%s can not be set if %s is true.", IGNORE_KEY_TOPICS_CONFIG, IGNORE_KEY_CONFIG
+      );
+      addErrorMessage(IGNORE_KEY_CONFIG, errorMessage);
+      addErrorMessage(IGNORE_KEY_TOPICS_CONFIG, errorMessage);
+    }
+
+    if (config.ignoreSchema() && !config.ignoreSchemaTopics().isEmpty()) {
+      String errorMessage = String.format(
+          "%s can not be set if %s is true.", IGNORE_SCHEMA_TOPICS_CONFIG, IGNORE_SCHEMA_CONFIG
+      );
+      addErrorMessage(IGNORE_SCHEMA_CONFIG, errorMessage);
+      addErrorMessage(IGNORE_SCHEMA_TOPICS_CONFIG, errorMessage);
+    }
+  }
+
+  private void validateLingerMs() {
+    if (config.lingerMs() > config.flushTimeoutMs()) {
+      String errorMessage = String.format(
+          "%s (%d) can not be larger than %s (%d).",
+          LINGER_MS_CONFIG, config.lingerMs(), FLUSH_TIMEOUT_MS_CONFIG, config.flushTimeoutMs()
+      );
+      addErrorMessage(LINGER_MS_CONFIG, errorMessage);
+      addErrorMessage(FLUSH_TIMEOUT_MS_CONFIG, errorMessage);
+    }
+  }
+
+  private void validateMaxBufferedRecords() {
+    if (config.maxBufferedRecords() < config.batchSize() * config.maxInFlightRequests()) {
+      String errorMessage = String.format(
+          "%s (%d) must be larger than or equal to %s (%d) x %s (%d).",
+          MAX_BUFFERED_RECORDS_CONFIG, config.maxBufferedRecords(),
+          BATCH_SIZE_CONFIG, config.batchSize(),
+          MAX_IN_FLIGHT_REQUESTS_CONFIG, config.maxInFlightRequests()
+      );
+
+      addErrorMessage(MAX_BUFFERED_RECORDS_CONFIG, errorMessage);
+      addErrorMessage(BATCH_SIZE_CONFIG, errorMessage);
+      addErrorMessage(MAX_IN_FLIGHT_REQUESTS_CONFIG, errorMessage);
+    }
+  }
+
+  private void addErrorMessage(String property, String error) {
+    values.get(property).addErrorMessage(error);
+  }
+}

--- a/src/test/java/io/confluent/connect/elasticsearch/ValidatorTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ValidatorTest.java
@@ -1,0 +1,181 @@
+/**
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ **/
+
+package io.confluent.connect.elasticsearch;
+
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BATCH_SIZE_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_PASSWORD_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_URL_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_USERNAME_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.FLUSH_TIMEOUT_MS_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_KEY_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_KEY_TOPICS_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_SCHEMA_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_SCHEMA_TOPICS_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.LINGER_MS_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.MAX_BUFFERED_RECORDS_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.MAX_IN_FLIGHT_REQUESTS_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.TYPE_NAME_CONFIG;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.common.config.Config;
+import org.apache.kafka.common.config.ConfigValue;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ValidatorTest {
+
+  private Map<String, String> props;
+  private Validator validator;
+
+  @Before
+  public void setup() {
+    props = new HashMap<>();
+    props.put(TYPE_NAME_CONFIG, "type");
+    props.put(CONNECTION_URL_CONFIG, "localhost:8080");
+  }
+
+  @Test
+  public void testInvalidCredentials() {
+    props.put(CONNECTION_USERNAME_CONFIG, "username");
+    validator = new Validator(props);
+
+    Config result = validator.validate();
+    assertHasErrorMessage(result, CONNECTION_USERNAME_CONFIG, "must be set");
+    assertHasErrorMessage(result, CONNECTION_PASSWORD_CONFIG, "must be set");
+    props.remove(CONNECTION_USERNAME_CONFIG);
+
+    props.put(CONNECTION_PASSWORD_CONFIG, "password");
+    validator = new Validator(props);
+    result = validator.validate();
+    assertHasErrorMessage(result, CONNECTION_USERNAME_CONFIG, "must be set");
+    assertHasErrorMessage(result, CONNECTION_PASSWORD_CONFIG, "must be set");
+  }
+
+  @Test
+  public void testValidCredentials() {
+    // username and password not set
+    validator = new Validator(props);
+
+    Config result = validator.validate();
+    assertNoErrors(result);
+
+    // both set
+    props.put(CONNECTION_USERNAME_CONFIG, "username");
+    props.put(CONNECTION_PASSWORD_CONFIG, "password");
+    validator = new Validator(props);
+
+    result = validator.validate();
+    assertNoErrors(result);
+  }
+
+  @Test
+  public void testInvalidIgnoreConfigs() {
+    props.put(IGNORE_KEY_CONFIG, "true");
+    props.put(IGNORE_KEY_TOPICS_CONFIG, "some,topics");
+    props.put(IGNORE_SCHEMA_CONFIG, "true");
+    props.put(IGNORE_SCHEMA_TOPICS_CONFIG, "some,other,topics");
+    validator = new Validator(props);
+
+    Config result = validator.validate();
+    assertHasErrorMessage(result, IGNORE_KEY_CONFIG, "is true");
+    assertHasErrorMessage(result, IGNORE_KEY_TOPICS_CONFIG, "is true");
+    assertHasErrorMessage(result, IGNORE_SCHEMA_CONFIG, "is true");
+    assertHasErrorMessage(result, IGNORE_SCHEMA_TOPICS_CONFIG, "is true");
+  }
+
+  @Test
+  public void testValidIgnoreConfigs() {
+    // topics configs not set
+    props.put(IGNORE_KEY_CONFIG, "true");
+    props.put(IGNORE_SCHEMA_CONFIG, "true");
+    validator = new Validator(props);
+
+    Config result = validator.validate();
+    assertNoErrors(result);
+
+    // ignore configs are false
+    props.put(IGNORE_KEY_CONFIG, "false");
+    props.put(IGNORE_KEY_TOPICS_CONFIG, "some,topics");
+    props.put(IGNORE_SCHEMA_CONFIG, "false");
+    props.put(IGNORE_SCHEMA_TOPICS_CONFIG, "some,other,topics");
+    validator = new Validator(props);
+
+    result = validator.validate();
+    assertNoErrors(result);
+  }
+
+  @Test
+  public void testInvalidLingerMs() {
+    props.put(LINGER_MS_CONFIG, "2");
+    props.put(FLUSH_TIMEOUT_MS_CONFIG, "1");
+    validator = new Validator(props);
+
+    Config result = validator.validate();
+    assertHasErrorMessage(result, LINGER_MS_CONFIG, "can not be larger than");
+    assertHasErrorMessage(result, FLUSH_TIMEOUT_MS_CONFIG, "can not be larger than");
+  }
+
+  @Test
+  public void testValidLingerMs() {
+    props.put(LINGER_MS_CONFIG, "1");
+    props.put(FLUSH_TIMEOUT_MS_CONFIG, "2");
+    validator = new Validator(props);
+
+    Config result = validator.validate();
+    assertNoErrors(result);
+  }
+
+  @Test
+  public void testInvalidMaxBufferedRecords() {
+    props.put(MAX_BUFFERED_RECORDS_CONFIG, "1");
+    props.put(BATCH_SIZE_CONFIG, "2");
+    props.put(MAX_IN_FLIGHT_REQUESTS_CONFIG, "2");
+    validator = new Validator(props);
+
+    Config result = validator.validate();
+    assertHasErrorMessage(result, MAX_BUFFERED_RECORDS_CONFIG, "must be larger than or equal to");
+    assertHasErrorMessage(result, BATCH_SIZE_CONFIG, "must be larger than or equal to");
+    assertHasErrorMessage(result, MAX_IN_FLIGHT_REQUESTS_CONFIG, "must be larger than or equal to");
+  }
+
+  @Test
+  public void testValidMaxBufferedRecords() {
+    props.put(MAX_BUFFERED_RECORDS_CONFIG, "5");
+    props.put(BATCH_SIZE_CONFIG, "2");
+    props.put(MAX_IN_FLIGHT_REQUESTS_CONFIG, "2");
+    validator = new Validator(props);
+
+    Config result = validator.validate();
+    assertNoErrors(result);
+  }
+
+  private static void assertHasErrorMessage(Config config, String property, String msg) {
+    for (ConfigValue configValue : config.configValues()) {
+      if (configValue.name().equals(property)) {
+        assertFalse(configValue.errorMessages().isEmpty());
+        assertTrue(configValue.errorMessages().get(0).contains(msg));
+      }
+    }
+  }
+
+  private static void assertNoErrors(Config config) {
+    config.configValues().forEach(c -> assertTrue(c.errorMessages().isEmpty()));
+  }
+}


### PR DESCRIPTION
Signed-off-by: Lev Zemlyanov <lev@confluent.io>

## Problem
the connector does not validate config combinations at all
config combinations for ssl, proxy, and connectivity will come in later PRs

## Solution
add config combo validations

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?
other branches for configs added there i.e proxy and ssl

## Test Strategy
new unit tests that test both valid and invalid configs

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
backport to `5.0.x` and then add more validators in follow up PRs