### PR TITLE
MINOR: fix test/build

### DIFF
--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
@@ -161,6 +161,7 @@ public class ElasticsearchSinkTaskTest extends ElasticsearchSinkTestBase {
   @Test
   public void testStopThenFlushDoesNotThrow() {
     ElasticsearchSinkTask task = new ElasticsearchSinkTask();
+    task.initialize(mock(SinkTaskContext.class));
     task.start(createProps(), client);
     task.stop();
     task.flush(new HashMap<>());


### PR DESCRIPTION
Signed-off-by: Lev Zemlyanov <lev@confluent.io>

## Problem
test is throwing NPE due to the reporter in `10.0.x`

## Solution
mock context

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
rerun tests

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
backport to `10.0.x` where test breaks