### PR TITLE
MINOR: move proxy validators to validator class

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -663,7 +663,6 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
 
   public ElasticsearchSinkConnectorConfig(Map<String, String> props) {
     super(CONFIG, props);
-    validateProxyConfigs();
   }
 
   public boolean isAuthenticatedConnection() {
@@ -835,30 +834,6 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
     }
 
     return map;
-  }
-
-  private void validateProxyConfigs() {
-
-    if (!isBasicProxyConfigured()) {
-      if (!proxyUsername().isEmpty() || proxyPassword() != null) {
-        throw new ConfigException(
-            String.format(
-                "%s and %s cannot be set without %s.",
-                PROXY_USERNAME_CONFIG,
-                PROXY_PASSWORD_CONFIG,
-                PROXY_HOST_CONFIG
-            )
-        );
-      }
-    } else {
-      if (proxyUsername().isEmpty() ^ proxyPassword() == null) {
-        throw new ConfigException(
-            String.format(
-                "Both %s and %s must be set.", PROXY_PASSWORD_CONFIG, PROXY_PASSWORD_CONFIG
-            )
-        );
-      }
-    }
   }
 
   private static class UrlListValidator implements Validator {

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
@@ -119,18 +119,4 @@ public class ElasticsearchSinkConnectorConfigTest {
     props.put(PROXY_PORT_CONFIG, "-666");
     new ElasticsearchSinkConnectorConfig(props);
   }
-
-  @Test(expected = ConfigException.class)
-  public void shouldNotAllowProxyCredentialsWithoutProxy() {
-    props.put(PROXY_USERNAME_CONFIG, "username");
-    props.put(PROXY_PASSWORD_CONFIG, "password");
-    new ElasticsearchSinkConnectorConfig(props);
-  }
-
-  @Test(expected = ConfigException.class)
-  public void shouldNotAllowPartialProxyCredentials() {
-    props.put(PROXY_HOST_CONFIG, "proxy host");
-    props.put(PROXY_USERNAME_CONFIG, "username");
-    new ElasticsearchSinkConnectorConfig(props);
-  }
 }

--- a/src/test/java/io/confluent/connect/elasticsearch/ValidatorTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ValidatorTest.java
@@ -31,6 +31,9 @@ import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfi
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.LINGER_MS_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.MAX_BUFFERED_RECORDS_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.MAX_IN_FLIGHT_REQUESTS_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.PROXY_HOST_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.PROXY_PASSWORD_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.PROXY_USERNAME_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.TYPE_NAME_CONFIG;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -167,6 +170,46 @@ public class ValidatorTest {
     validator = new Validator(props);
 
     Config result = validator.validate();
+    assertNoErrors(result);
+  }
+
+  @Test
+  public void testInvalidProxy() {
+    props.put(PROXY_HOST_CONFIG, "");
+    props.put(PROXY_USERNAME_CONFIG, "username");
+    props.put(PROXY_PASSWORD_CONFIG, "password");
+    validator = new Validator(props);
+
+    Config result = validator.validate();
+    assertHasErrorMessage(result, PROXY_HOST_CONFIG, " must be set to use");
+    assertHasErrorMessage(result, PROXY_USERNAME_CONFIG, " must be set to use");
+    assertHasErrorMessage(result, PROXY_PASSWORD_CONFIG, " must be set to use");
+
+    props.remove(PROXY_USERNAME_CONFIG);
+
+    props.put(PROXY_HOST_CONFIG, "proxy");
+    props.put(PROXY_PASSWORD_CONFIG, "password");
+    validator = new Validator(props);
+
+    result = validator.validate();
+    assertHasErrorMessage(result, PROXY_USERNAME_CONFIG, "Either both or neither");
+    assertHasErrorMessage(result, PROXY_PASSWORD_CONFIG, "Either both or neither");
+  }
+
+  @Test
+  public void testValidProxy() {
+    props.put(PROXY_HOST_CONFIG, "proxy");
+    validator = new Validator(props);
+
+    Config result = validator.validate();
+    assertNoErrors(result);
+
+    props.put(PROXY_HOST_CONFIG, "proxy");
+    props.put(PROXY_USERNAME_CONFIG, "password");
+    props.put(PROXY_PASSWORD_CONFIG, "password");
+    validator = new Validator(props);
+
+    result = validator.validate();
     assertNoErrors(result);
   }
 


### PR DESCRIPTION
Signed-off-by: Lev Zemlyanov <lev@confluent.io>

## Problem
config combo validations for proxy should be moved to combo validator class

## Solution
move them there

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
unit tests

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
backport to where these validators were first introduced `10.0.x`