### PR TITLE
MINOR: fix tests

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClient.java
@@ -600,7 +600,6 @@ public class JestElasticsearchClient implements ElasticsearchClient {
       search.addType(type);
     }
 
-    search.setParameter("size", 100);
     log.info("Executing search on index '{}' (type={}): {}", index, type, query);
     final SearchResult result = client.execute(search.build());
     if (result.isSucceeded()) {

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorBaseIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorBaseIT.java
@@ -45,6 +45,7 @@ import org.junit.Before;
 
 public class ElasticsearchConnectorBaseIT extends BaseConnectorIT {
 
+  protected static final int NUM_RECORDS = 5;
   protected static final int TASKS_MAX = 1;
   protected static final String CONNECTOR_NAME = "es-connector";
   protected static final String TOPIC = "test";
@@ -107,9 +108,9 @@ public class ElasticsearchConnectorBaseIT extends BaseConnectorIT {
     // wait for tasks to spin up
     waitForConnectorToStart(CONNECTOR_NAME, TASKS_MAX);
 
-    writeRecords(10);
+    writeRecords(NUM_RECORDS);
 
-    verifySearchResults(10);
+    verifySearchResults(NUM_RECORDS);
   }
 
   protected void writeRecords(int numRecords) {

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorIT.java
@@ -58,8 +58,8 @@ public class ElasticsearchConnectorIT extends ElasticsearchConnectorBaseIT {
     connect.configureConnector(CONNECTOR_NAME, props);
 
     // write some more
-    writeRecords(10);
-    verifySearchResults(20);
+    writeRecords(NUM_RECORDS);
+    verifySearchResults(NUM_RECORDS * 2);
   }
 
   @Test
@@ -68,13 +68,13 @@ public class ElasticsearchConnectorIT extends ElasticsearchConnectorBaseIT {
     props.put(IGNORE_KEY_CONFIG, "false");
     runSimpleTest(props);
 
-    // should have 10 records at this point
+    // should have 5 records at this point
     // try deleting last one
-    int lastRecord = 9;
+    int lastRecord = NUM_RECORDS - 1;
     connect.kafka().produce(TOPIC, String.valueOf(lastRecord), null);
 
     // should have one less records
-    verifySearchResults(9);
+    verifySearchResults(NUM_RECORDS - 1);
   }
 
   @Test
@@ -98,12 +98,12 @@ public class ElasticsearchConnectorIT extends ElasticsearchConnectorBaseIT {
   public void testNullValue() throws Exception {
     runSimpleTest(props);
 
-    // should have 10 records at this point
+    // should have 5 records at this point
     // try writing null value
-    connect.kafka().produce(TOPIC, String.valueOf(10), null);
+    connect.kafka().produce(TOPIC, String.valueOf(NUM_RECORDS), null);
 
-    // should still have 10 records
-    verifySearchResults(10);
+    // should still have 5 records
+    verifySearchResults(NUM_RECORDS);
   }
 
   /*
@@ -119,7 +119,7 @@ public class ElasticsearchConnectorIT extends ElasticsearchConnectorBaseIT {
     // wait for tasks to spin up
     waitForConnectorToStart(CONNECTOR_NAME, TASKS_MAX);
 
-    for (int i  = 0; i < 10; i++) {
+    for (int i  = 0; i < NUM_RECORDS; i++) {
       connect.kafka().produce(TOPIC, String.valueOf(i),  String.valueOf(i));
     }
 

--- a/src/test/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClientTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/jest/JestElasticsearchClientTest.java
@@ -371,7 +371,7 @@ public class JestElasticsearchClientTest {
   @Test
   public void searches() throws Exception {
     JestElasticsearchClient client = new JestElasticsearchClient(jestClient);
-    Search search = new Search.Builder(QUERY).addIndex(INDEX).addType(TYPE).setParameter("size", 100).build();
+    Search search = new Search.Builder(QUERY).addIndex(INDEX).addType(TYPE).build();
     JsonObject queryResult = new JsonObject();
     SearchResult result = new SearchResult(new Gson());
     result.setJsonObject(queryResult);


### PR DESCRIPTION
Signed-off-by: Lev Zemlyanov <lev@confluent.io>

## Problem
for some reason, specifying a parameter breaks Jenkins tests on `5.5.x` and `10.0.x` (green locally)

## Solution
remove the parameter for now

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
backport to `5.5.x` where the tests break