### PR TITLE
CC-10923: add reasonable validators for number configs

### DIFF
--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
@@ -1,5 +1,10 @@
 package io.confluent.connect.elasticsearch;
 
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_TIMEOUT_MS_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_URL_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_KEY_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.READ_TIMEOUT_MS_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.TYPE_NAME_CONFIG;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Before;
@@ -15,9 +20,9 @@ public class ElasticsearchSinkConnectorConfigTest {
   @Before
   public void setup() {
     props = new HashMap<>();
-    props.put(ElasticsearchSinkConnectorConfig.TYPE_NAME_CONFIG, ElasticsearchSinkTestBase.TYPE);
-    props.put(ElasticsearchSinkConnectorConfig.CONNECTION_URL_CONFIG, "localhost");
-    props.put(ElasticsearchSinkConnectorConfig.IGNORE_KEY_CONFIG, "true");
+    props.put(TYPE_NAME_CONFIG, ElasticsearchSinkTestBase.TYPE);
+    props.put(CONNECTION_URL_CONFIG, "localhost");
+    props.put(IGNORE_KEY_CONFIG, "true");
   }
 
   @Test
@@ -29,8 +34,8 @@ public class ElasticsearchSinkConnectorConfigTest {
 
   @Test
   public void testSetHttpTimeoutsConfig() {
-    props.put(ElasticsearchSinkConnectorConfig.READ_TIMEOUT_MS_CONFIG, "10000");
-    props.put(ElasticsearchSinkConnectorConfig.CONNECTION_TIMEOUT_MS_CONFIG, "15000");
+    props.put(READ_TIMEOUT_MS_CONFIG, "10000");
+    props.put(CONNECTION_TIMEOUT_MS_CONFIG, "15000");
     ElasticsearchSinkConnectorConfig config = new ElasticsearchSinkConnectorConfig(props);
     assertEquals(config.readTimeoutMs(), 10000);
     assertEquals(config.connectionTimeoutMs(), 15000);

--- a/src/test/java/io/confluent/connect/elasticsearch/ValidatorTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ValidatorTest.java
@@ -123,8 +123,8 @@ public class ValidatorTest {
 
   @Test
   public void testInvalidLingerMs() {
-    props.put(LINGER_MS_CONFIG, "2");
-    props.put(FLUSH_TIMEOUT_MS_CONFIG, "1");
+    props.put(LINGER_MS_CONFIG, "1001");
+    props.put(FLUSH_TIMEOUT_MS_CONFIG, "1000");
     validator = new Validator(props);
 
     Config result = validator.validate();
@@ -134,8 +134,8 @@ public class ValidatorTest {
 
   @Test
   public void testValidLingerMs() {
-    props.put(LINGER_MS_CONFIG, "1");
-    props.put(FLUSH_TIMEOUT_MS_CONFIG, "2");
+    props.put(LINGER_MS_CONFIG, "999");
+    props.put(FLUSH_TIMEOUT_MS_CONFIG, "1000");
     validator = new Validator(props);
 
     Config result = validator.validate();


### PR DESCRIPTION
Signed-off-by: Lev Zemlyanov <lev@confluent.io>

## Problem
need to backport reasonable validators for numbered configs #456 

## Solution
backport to `5.0.x`

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?
all branches up to `master`

## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
backport to `5.0.x`