### PR TITLE
CC-12597: remove topic.index.map

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>io.confluent</groupId>
     <artifactId>kafka-connect-elasticsearch</artifactId>
-    <version>10.1.0-SNAPSHOT</version>
+    <version>11.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>kafka-connect-elasticsearch</name>
     <organization>

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -18,7 +18,6 @@ package io.confluent.connect.elasticsearch;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -208,16 +207,6 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
           + "so set this to ``false`` to use that older behavior.";
   private static final String COMPACT_MAP_ENTRIES_DISPLAY = "Compact Map Entries";
   private static final boolean COMPACT_MAP_ENTRIES_DEFAULT = true;
-
-  @Deprecated
-  public static final String TOPIC_INDEX_MAP_CONFIG = "topic.index.map";
-  private static final String TOPIC_INDEX_MAP_DOC =
-      "This option is now deprecated. A future version may remove it completely. Please use "
-          + "single message transforms, such as RegexRouter, to map topic names to index names.\n"
-          + "A map from Kafka topic name to the destination Elasticsearch index, represented as "
-          + "a list of ``topic:index`` pairs.";
-  private static final String TOPIC_INDEX_MAP_DISPLAY = "Topic to Index Map";
-  private static final String TOPIC_INDEX_MAP_DEFAULT = "";
 
   private static final String IGNORE_KEY_TOPICS_DOC =
       "List of topics for which ``" + IGNORE_KEY_CONFIG + "`` should be ``true``.";
@@ -521,16 +510,6 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
             Width.SHORT,
             COMPACT_MAP_ENTRIES_DISPLAY
         ).define(
-            TOPIC_INDEX_MAP_CONFIG,
-            Type.LIST,
-            TOPIC_INDEX_MAP_DEFAULT,
-            Importance.LOW,
-            TOPIC_INDEX_MAP_DOC,
-            DATA_CONVERSION_GROUP,
-            ++order,
-            Width.LONG,
-            TOPIC_INDEX_MAP_DISPLAY
-        ).define(
             IGNORE_KEY_TOPICS_CONFIG,
             Type.LIST,
             IGNORE_KEY_TOPICS_DEFAULT,
@@ -813,11 +792,6 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
     return sslConfigDef.parse(originalsWithPrefix(SSL_CONFIG_PREFIX));
   }
 
-  @Deprecated
-  public Map<String, String> topicToIndexMap() {
-    return parseMapConfig(getList(TOPIC_INDEX_MAP_CONFIG));
-  }
-
   public String type() {
     return getString(TYPE_NAME_CONFIG);
   }
@@ -832,18 +806,6 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
 
   public WriteMethod writeMethod() {
     return WriteMethod.valueOf(getString(WRITE_METHOD_CONFIG).toUpperCase());
-  }
-
-  private Map<String, String> parseMapConfig(List<String> values) {
-    Map<String, String> map = new HashMap<>();
-    for (String value : values) {
-      String[] parts = value.split(":");
-      String topic = parts[0];
-      String type = parts[1];
-      map.put(topic, type);
-    }
-
-    return map;
   }
 
   private static class UrlListValidator implements Validator {

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -79,7 +79,6 @@ public class ElasticsearchSinkTask extends SinkTask {
           .setIgnoreKey(config.ignoreKey(), config.ignoreKeyTopics())
           .setIgnoreSchema(config.ignoreSchema(), config.ignoreSchemaTopics())
           .setCompactMapEntries(config.useCompactMapEntries())
-          .setTopicToIndexMap(config.topicToIndexMap())
           .setFlushTimoutMs(config.flushTimeoutMs())
           .setMaxBufferedRecords(config.maxBufferedRecords())
           .setMaxInFlightRequests(config.maxInFlightRequests())

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java
@@ -26,9 +26,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -44,8 +42,6 @@ public class ElasticsearchWriter {
   private final Set<String> ignoreKeyTopics;
   private final boolean ignoreSchema;
   private final Set<String> ignoreSchemaTopics;
-  @Deprecated
-  private final Map<String, String> topicToIndexMap;
   private final long flushTimeoutMs;
   private final BulkProcessor<IndexableRecord, ?> bulkProcessor;
   private final boolean dropInvalidMessage;
@@ -62,7 +58,6 @@ public class ElasticsearchWriter {
       Set<String> ignoreKeyTopics,
       boolean ignoreSchema,
       Set<String> ignoreSchemaTopics,
-      Map<String, String> topicToIndexMap,
       long flushTimeoutMs,
       int maxBufferedRecords,
       int maxInFlightRequests,
@@ -81,7 +76,6 @@ public class ElasticsearchWriter {
     this.ignoreKeyTopics = ignoreKeyTopics;
     this.ignoreSchema = ignoreSchema;
     this.ignoreSchemaTopics = ignoreSchemaTopics;
-    this.topicToIndexMap = topicToIndexMap;
     this.flushTimeoutMs = flushTimeoutMs;
     this.dropInvalidMessage = dropInvalidMessage;
     this.behaviorOnNullValues = behaviorOnNullValues;
@@ -111,7 +105,6 @@ public class ElasticsearchWriter {
     private Set<String> ignoreKeyTopics = Collections.emptySet();
     private boolean ignoreSchema = false;
     private Set<String> ignoreSchemaTopics = Collections.emptySet();
-    private Map<String, String> topicToIndexMap = new HashMap<>();
     private long flushTimeoutMs;
     private int maxBufferedRecords;
     private int maxInFlightRequests;
@@ -147,11 +140,6 @@ public class ElasticsearchWriter {
 
     public Builder setCompactMapEntries(boolean useCompactMapEntries) {
       this.useCompactMapEntries = useCompactMapEntries;
-      return this;
-    }
-
-    public Builder setTopicToIndexMap(Map<String, String> topicToIndexMap) {
-      this.topicToIndexMap = topicToIndexMap;
       return this;
     }
 
@@ -226,7 +214,6 @@ public class ElasticsearchWriter {
           ignoreKeyTopics,
           ignoreSchema,
           ignoreSchemaTopics,
-          topicToIndexMap,
           flushTimeoutMs,
           maxBufferedRecords,
           maxInFlightRequests,
@@ -328,13 +315,12 @@ public class ElasticsearchWriter {
   }
 
   /**
-   * Return the expected index name for a given topic, using the configured mapping or the topic
-   * name. Elasticsearch accepts only lowercase index names
+   * Return the expected index name for a given topic using the topic name. Elasticsearch accepts
+   * only lowercase index names
    * (<a href="https://github.com/elastic/elasticsearch/issues/29420">ref</a>_.
    */
   private String convertTopicToIndexName(String topic) {
-    final String indexOverride = topicToIndexMap.get(topic);
-    String index = indexOverride != null ? indexOverride : topic.toLowerCase();
+    String index = topic.toLowerCase();
     log.trace("Topic '{}' was translated as index '{}'", topic, index);
     return index;
   }


### PR DESCRIPTION
Signed-off-by: Lev Zemlyanov <lev@confluent.io>

## Problem
`topic.index.map` is deprecated and is set to be removed for the upcoming jest client replacement work #468 

## Solution
remove the config

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?
update the docs to mark this config as removed

## Test Strategy
N/A - verify existing tests still pass

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
`master` to a new major version because this breaks backward compatibility