### PR TITLE
Added guava dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
         <hamcrest.version>1.3</hamcrest.version>
         <mockito.version>2.28.2</mockito.version>
         <jest.version>6.3.1</jest.version>
+        <guava.version>30.0-jre</guava.version>
         <test.containers.version>1.15.0-rc2</test.containers.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
@@ -71,6 +72,11 @@
             <groupId>io.searchbox</groupId>
             <artifactId>jest</artifactId>
             <version>${jest.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
@@ -119,13 +125,6 @@
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-expressions</artifactId>
             <version>${lucene.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <!--Require newer version than inherited-->
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>27.0.1-jre</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Problem
There's a compiled JAR-package on [Confluent Hub](https://www.confluent.io/hub/confluentinc/kafka-connect-elasticsearch) without [guava.jar](https://mvnrepository.com/artifact/com.google.guava/guava). But it depends on [Guava](https://github.com/google/guava) - #366 an #409.

## Solution
Removed scope `test` from `pom.xml` for Guava package.

For #453 