### PR TITLE
CC-12825: remove auto.create.index.at.start config

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -159,13 +159,6 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   private static final String READ_TIMEOUT_MS_DISPLAY = "Read Timeout";
   private static final int READ_TIMEOUT_MS_DEFAULT = (int) TimeUnit.SECONDS.toMillis(3);
 
-  public static final String CREATE_INDICES_AT_START_CONFIG = "auto.create.indices.at.start";
-  private static final String CREATE_INDICES_AT_START_DOC = "Auto create the Elasticsearch"
-      + " indices at startup. This is useful when the indices are a direct mapping "
-      + " of the Kafka topics.";
-  private static final String CREATE_INDICES_AT_START_DISPLAY = "Create indices at startup";
-  private static final boolean CREATE_INDICES_AT_START_DEFAULT = true;
-
   // Data Conversion configs
   public static final String TYPE_NAME_CONFIG = "type.name";
   private static final String TYPE_NAME_DOC = "The Elasticsearch type name to use when indexing.";
@@ -454,16 +447,6 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
             ++order,
             Width.SHORT,
             READ_TIMEOUT_MS_DISPLAY
-        ).define(
-            CREATE_INDICES_AT_START_CONFIG,
-            Type.BOOLEAN,
-            CREATE_INDICES_AT_START_DEFAULT,
-            Importance.LOW,
-            CREATE_INDICES_AT_START_DOC,
-            CONNECTOR_GROUP,
-            ++order,
-            Width.SHORT,
-            CREATE_INDICES_AT_START_DISPLAY
     );
   }
 
@@ -704,10 +687,6 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
 
   public Set<String> connectionUrls() {
     return new HashSet<>(getList(CONNECTION_URL_CONFIG));
-  }
-
-  public boolean createIndicesAtStart() {
-    return getBoolean(CREATE_INDICES_AT_START_CONFIG);
   }
 
   public boolean dropInvalidMessage() {

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -26,9 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 public class ElasticsearchSinkTask extends SinkTask {
@@ -36,7 +34,6 @@ public class ElasticsearchSinkTask extends SinkTask {
   private static final Logger log = LoggerFactory.getLogger(ElasticsearchSinkTask.class);
   private volatile ElasticsearchWriter writer;
   private ElasticsearchClient client;
-  private Boolean createIndicesAtStartTime;
 
   @Override
   public String version() {
@@ -102,8 +99,6 @@ public class ElasticsearchSinkTask extends SinkTask {
         log.warn("AK versions prior to 2.6 do not support the errant record reporter");
       }
 
-      this.createIndicesAtStartTime = config.createIndicesAtStart();
-
       writer = builder.build();
       writer.start();
       log.info(
@@ -116,18 +111,6 @@ public class ElasticsearchSinkTask extends SinkTask {
           "Couldn't start ElasticsearchSinkTask due to configuration error:",
           e
       );
-    }
-  }
-
-  @Override
-  public void open(Collection<TopicPartition> partitions) {
-    log.debug("Opening the task for topic partitions: {}", partitions);
-    if (createIndicesAtStartTime) {
-      Set<String> topics = new HashSet<>();
-      for (TopicPartition tp : partitions) {
-        topics.add(tp.topic());
-      }
-      writer.createIndicesForTopics(topics);
     }
   }
 

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
@@ -47,11 +47,6 @@ public class ElasticsearchSinkTaskTest extends ElasticsearchSinkTestBase {
   private static final int PARTITION_113 = 113;
   private static final TopicPartition TOPIC_IN_CAPS_PARTITION = new TopicPartition(TOPIC_IN_CAPS, PARTITION_113);
 
-  private static final String UNSEEN_TOPIC = "UnseenTopic";
-  private static final int PARTITION_114 = 114;
-  private static final TopicPartition UNSEEN_TOPIC_PARTITION = new TopicPartition(UNSEEN_TOPIC, PARTITION_114);
-
-
   private Map<String, String> createProps() {
     Map<String, String> props = new HashMap<>();
     props.put(ElasticsearchSinkConnectorConfig.TYPE_NAME_CONFIG, TYPE);
@@ -123,39 +118,8 @@ public class ElasticsearchSinkTaskTest extends ElasticsearchSinkTestBase {
     } finally {
       task.stop();
     }
-  }
 
-  @Test
-  public void testCreateAndWriteToIndexNotCreatedAtStartTime() {
-    InternalTestCluster cluster = ESIntegTestCase.internalCluster();
-    cluster.ensureAtLeastNumDataNodes(3);
-    Map<String, String> props = createProps();
-
-    props.put(ElasticsearchSinkConnectorConfig.CREATE_INDICES_AT_START_CONFIG, "false");
-
-    ElasticsearchSinkTask task = new ElasticsearchSinkTask();
-    task.initialize(mock(SinkTaskContext.class));
-
-    String key = "key";
-    Schema schema = createSchema();
-    Struct record = createRecord(schema);
-
-    SinkRecord sinkRecord = new SinkRecord(UNSEEN_TOPIC,
-        PARTITION_114,
-        Schema.STRING_SCHEMA,
-        key,
-        schema,
-        record,
-        0 );
-
-    task.start(props, client);
-    task.open(new HashSet<>(Collections.singletonList(TOPIC_IN_CAPS_PARTITION)));
-    task.put(Collections.singleton(sinkRecord));
-    task.stop();
-
-    assertTrue(UNSEEN_TOPIC + " index created without errors ",
-        verifyIndexExist(cluster, UNSEEN_TOPIC.toLowerCase()));
-
+    assertTrue(verifyIndexExist(cluster, TOPIC_IN_CAPS.toLowerCase()));
   }
 
   @Test


### PR DESCRIPTION
Signed-off-by: Lev Zemlyanov <lev@confluent.io>

## Problem
`auto.create.index.at.start` is an obsolete config and the connector should permanently function as if `auto.create.index.at.start=false`

## Solution
remove the config

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
remove old test and modify existing test to make sure index is still being created properly

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
`master` and bump to `11.0.x` because breaking backward compatibility