### PR TITLE
CC-8546: add Kerberos support

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -14,7 +14,7 @@
 
     <suppress
       checks="(ClassDataAbstractionCoupling)"
-      files="(ElasticsearchClient|ClientConfigCallbackHandler).java"
+      files="(ElasticsearchClient|ConfigCallbackHandler).java"
     />
 
     <suppress

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -8,13 +8,13 @@
 
     <!-- switch statements on types exceed maximum complexity -->
     <suppress
-            checks="(CyclomaticComplexity)"
-            files="Mapping.java"
+      checks="(CyclomaticComplexity)"
+      files="Mapping.java"
     />
 
     <suppress
-            checks="(ClassDataAbstractionCoupling)"
-            files="(ElasticsearchClient|ClientConfigCallbackHandler).java"
+      checks="(ClassDataAbstractionCoupling)"
+      files="(ElasticsearchClient|ClientConfigCallbackHandler).java"
     />
 
     <suppress

--- a/pom.xml
+++ b/pom.xml
@@ -340,7 +340,7 @@
                                 enabled and disabled cases with the same cert. So, disable this IT
                                 in jenkins.
                                 -->
-                                <exclude>**/ElasticsearchConnectorSecureIT.java</exclude>
+                                <exclude>**/ElasticsearchConnectorSslIT.java</exclude>
                             </excludes>
                         </configuration>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,8 @@
         <test.containers.version>1.15.0</test.containers.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
+        <hadoop.version>3.3.0</hadoop.version>
+        <apacheds-jdbm1.version>2.0.0-M2</apacheds-jdbm1.version>
     </properties>
 
     <repositories>
@@ -160,6 +162,13 @@
             <artifactId>elasticsearch</artifactId>
             <version>${test.containers.version}</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-minikdc</artifactId>
+            <version>${hadoop.version}</version>
+            <scope>test</scope>
+
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,6 @@
             <artifactId>hadoop-minikdc</artifactId>
             <version>${hadoop.version}</version>
             <scope>test</scope>
-
         </dependency>
     </dependencies>
 

--- a/src/main/java/io/confluent/connect/elasticsearch/ClientConfigCallbackHandler.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ClientConfigCallbackHandler.java
@@ -291,9 +291,10 @@ public class ClientConfigCallbackHandler implements HttpClientConfigCallback {
   }
 
   /**
-   * Creates and returns a login context for the given kerberos user principle.
+   * Logs in and returns a login context for the given kerberos user principle.
+   *
    * @return the login context
-   * @throws PrivilegedActionException
+   * @throws PrivilegedActionException if the login failed
    */
   private LoginContext loginContext() throws PrivilegedActionException {
     Configuration conf = new Configuration() {

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -284,17 +284,17 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   private static final String SECURITY_PROTOCOL_DEFAULT = SecurityProtocol.PLAINTEXT.name();
 
   // Kerberos configs
-  public static final String USER_PRINCIPAL_CONFIG = "kerberos.user.principal";
-  private static final String USER_PRINCIPAL_DISPLAY = "Kerberos User Principal";
-  private static final String USER_PRINCIPAL_DOC = "The Kerberos user principal the connector may"
-      + " use to authenticate with Kerberos.";
-  private static final String USER_PRINCIPAL_DEFAULT = null;
+  public static final String KERBEROS_PRINCIPAL_CONFIG = "kerberos.user.principal";
+  private static final String KERBEROS_PRINCIPAL_DISPLAY = "Kerberos User Principal";
+  private static final String KERBEROS_PRINCIPAL_DOC = "The Kerberos user principal the connector"
+      + " may use to authenticate with Kerberos.";
+  private static final String KERBEROS_PRINCIPAL_DEFAULT = null;
 
-  public static final String KEYTAB_FILE_PATH_CONFIG = "kerberos.keytab.path";
-  private static final String KEYTAB_FILE_PATH_DISPLAY = "Kerberos Keytab File Path";
-  private static final String KEYTAB_FILE_PATH_DOC = "The path to the keytab file to use for"
+  public static final String KERBEROS_KEYTAB_PATH_CONFIG = "kerberos.keytab.path";
+  private static final String KERBEROS_KEYTAB_PATH = "Kerberos Keytab File Path";
+  private static final String KERBEROS_KEYTAB_PATH_DOC = "The path to the keytab file to use for"
       + " authentication with Kerberos.";
-  private static final String KEYTAB_FILE_PATH_DEFAULT = null;
+  private static final String KERBEROS_KEYTAB_PATH_DEFAULT = null;
 
   private static final String CONNECTOR_GROUP = "Connector";
   private static final String DATA_CONVERSION_GROUP = "Data Conversion";
@@ -680,26 +680,26 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
     int orderInGroup = 0;
     configDef
         .define(
-            USER_PRINCIPAL_CONFIG,
+            KERBEROS_PRINCIPAL_CONFIG,
             Type.STRING,
-            USER_PRINCIPAL_DEFAULT,
+            KERBEROS_PRINCIPAL_DEFAULT,
             Importance.LOW,
-            USER_PRINCIPAL_DOC,
+            KERBEROS_PRINCIPAL_DOC,
             KERBEROS_GROUP,
             orderInGroup++,
             Width.LONG,
-            USER_PRINCIPAL_DISPLAY
+            KERBEROS_PRINCIPAL_DISPLAY
         ).define(
-            KEYTAB_FILE_PATH_CONFIG,
+            KERBEROS_KEYTAB_PATH_CONFIG,
             Type.STRING,
-            KEYTAB_FILE_PATH_DEFAULT,
+            KERBEROS_KEYTAB_PATH_DEFAULT,
             new FilePathValidator("keytab"),
             Importance.LOW,
-            KEYTAB_FILE_PATH_DOC,
+            KERBEROS_KEYTAB_PATH_DOC,
             KERBEROS_GROUP,
             orderInGroup++,
             Width.LONG,
-            KEYTAB_FILE_PATH_DISPLAY
+            KERBEROS_KEYTAB_PATH
     );
   }
 
@@ -797,11 +797,11 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   }
 
   public String kerberosUserPrincipal() {
-    return getString(USER_PRINCIPAL_CONFIG);
+    return getString(KERBEROS_PRINCIPAL_CONFIG);
   }
 
   public String keytabPath() {
-    return getString(KEYTAB_FILE_PATH_CONFIG);
+    return getString(KERBEROS_KEYTAB_PATH_CONFIG);
   }
 
   public long lingerMs() {

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -286,8 +286,8 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   // Kerberos configs
   public static final String USER_PRINCIPAL_CONFIG = "kerberos.user.principal";
   private static final String USER_PRINCIPAL_DISPLAY = "Kerberos User Principal";
-  private static final String USER_PRINCIPAL_DOC = "The Kerberos user principal for the connector"
-      + " to use to authenticate with Kerberos.";
+  private static final String USER_PRINCIPAL_DOC = "The Kerberos user principal the connector may"
+      + " use to authenticate with Kerberos.";
   private static final String USER_PRINCIPAL_DEFAULT = null;
 
   public static final String KEYTAB_FILE_PATH_CONFIG = "kerberos.keytab.path";

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -15,6 +15,7 @@
 
 package io.confluent.connect.elasticsearch;
 
+import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
@@ -276,16 +277,30 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
 
   public static final String SECURITY_PROTOCOL_CONFIG = "elastic.security.protocol";
   private static final String SECURITY_PROTOCOL_DOC =
-      "The security protocol to use when connecting to Elasticsearch. "
-          + "Values can be `PLAINTEXT` or `SSL`. If `PLAINTEXT` is passed, "
-          + "all configs prefixed by " + SSL_CONFIG_PREFIX + " will be ignored.";
+      "The security protocol to use when connecting to Elasticsearch. Values can be `PLAINTEXT` or"
+          + " `SSL`. If `PLAINTEXT` is passed, all configs prefixed by " + SSL_CONFIG_PREFIX
+          + " will be ignored.";
   private static final String SECURITY_PROTOCOL_DISPLAY = "Security protocol";
   private static final String SECURITY_PROTOCOL_DEFAULT = SecurityProtocol.PLAINTEXT.name();
+
+  // Kerberos configs
+  public static final String USER_PRINCIPAL_CONFIG = "kerberos.user.principal";
+  private static final String USER_PRINCIPAL_DISPLAY = "Kerberos User Principal";
+  private static final String USER_PRINCIPAL_DOC = "The Kerberos user principal for the connector"
+      + " to use to authenticate with Kerberos.";
+  private static final String USER_PRINCIPAL_DEFAULT = null;
+
+  public static final String KEYTAB_FILE_PATH_CONFIG = "kerberos.keytab.path";
+  private static final String KEYTAB_FILE_PATH_DISPLAY = "Kerberos Keytab File Path";
+  private static final String KEYTAB_FILE_PATH_DOC = "The path to the keytab file to use for"
+      + " authentication with Kerberos.";
+  private static final String KEYTAB_FILE_PATH_DEFAULT = null;
 
   private static final String CONNECTOR_GROUP = "Connector";
   private static final String DATA_CONVERSION_GROUP = "Data Conversion";
   private static final String PROXY_GROUP = "Proxy";
   private static final String SSL_GROUP = "Security";
+  private static final String KERBEROS_GROUP = "Kerberos";
 
   public enum BehaviorOnMalformedDoc {
     IGNORE,
@@ -314,7 +329,8 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
     addConnectorConfigs(configDef);
     addConversionConfigs(configDef);
     addProxyConfigs(configDef);
-    addSecurityConfigs(configDef);
+    addSslConfigs(configDef);
+    addKerberosConfigs(configDef);
     return configDef;
   }
 
@@ -636,7 +652,7 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
     );
   }
 
-  private static void addSecurityConfigs(ConfigDef configDef) {
+  private static void addSslConfigs(ConfigDef configDef) {
     ConfigDef sslConfigDef = new ConfigDef();
     addClientSslSupport(sslConfigDef);
     int order = 0;
@@ -660,6 +676,33 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
     configDef.embed(SSL_CONFIG_PREFIX, SSL_GROUP, configDef.configKeys().size() + 2, sslConfigDef);
   }
 
+  private static void addKerberosConfigs(ConfigDef configDef) {
+    int orderInGroup = 0;
+    configDef
+        .define(
+            USER_PRINCIPAL_CONFIG,
+            Type.STRING,
+            USER_PRINCIPAL_DEFAULT,
+            Importance.LOW,
+            USER_PRINCIPAL_DOC,
+            KERBEROS_GROUP,
+            orderInGroup++,
+            Width.LONG,
+            USER_PRINCIPAL_DISPLAY
+        ).define(
+            KEYTAB_FILE_PATH_CONFIG,
+            Type.STRING,
+            KEYTAB_FILE_PATH_DEFAULT,
+            new FilePathValidator("keytab"),
+            Importance.LOW,
+            KEYTAB_FILE_PATH_DOC,
+            KERBEROS_GROUP,
+            orderInGroup++,
+            Width.LONG,
+            KEYTAB_FILE_PATH_DISPLAY
+    );
+  }
+
   public static final ConfigDef CONFIG = baseConfigDef();
 
   public ElasticsearchSinkConnectorConfig(Map<String, String> props) {
@@ -680,7 +723,11 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
         && getPassword(PROXY_PASSWORD_CONFIG) != null;
   }
 
-  public boolean secured() {
+  public boolean isKerberosEnabled() {
+    return kerberosUserPrincipal() != null || keytabPath() != null;
+  }
+
+  public boolean isSslEnabled() {
     return SecurityProtocol.SSL == securityProtocol();
   }
 
@@ -747,6 +794,14 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
 
   public Set<String> ignoreSchemaTopics() {
     return new HashSet<>(getList(IGNORE_SCHEMA_TOPICS_CONFIG));
+  }
+
+  public String kerberosUserPrincipal() {
+    return getString(USER_PRINCIPAL_CONFIG);
+  }
+
+  public String keytabPath() {
+    return getString(KEYTAB_FILE_PATH_CONFIG);
   }
 
   public long lingerMs() {
@@ -825,10 +880,9 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
     @SuppressWarnings("unchecked")
     public void ensureValid(String name, Object value) {
       if (value == null) {
-        throw new ConfigException(
-            name, value, "The provided url list is null."
-        );
+        throw new ConfigException(name, value, "The config must be provided and non-null.");
       }
+
       List<String> urls = (List<String>) value;
       for (String url : urls) {
         try {
@@ -844,6 +898,37 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
     @Override
     public String toString() {
       return "List of valid URIs.";
+    }
+  }
+
+  private static class FilePathValidator implements Validator {
+
+    private String extension;
+
+    public FilePathValidator(String extension) {
+      this.extension = extension;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void ensureValid(String name, Object value) {
+      if (value == null) {
+        return;
+      }
+
+      if (!((String) value).endsWith(extension)) {
+        throw new ConfigException(name, value, "The specified file must end with ." + extension);
+      }
+
+      File file = new File((String) value);
+      if (!file.exists()) {
+        throw new ConfigException(name, value, "The specified file does not exist.");
+      }
+    }
+
+    @Override
+    public String toString() {
+      return "Existing file with " + extension + " extension.";
     }
   }
 

--- a/src/main/java/io/confluent/connect/elasticsearch/Validator.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/Validator.java
@@ -34,7 +34,7 @@ import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfi
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_KEY_TOPICS_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_SCHEMA_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_SCHEMA_TOPICS_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.KEYTAB_FILE_PATH_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.KERBEROS_KEYTAB_PATH_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.LINGER_MS_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.MAX_BUFFERED_RECORDS_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.MAX_IN_FLIGHT_REQUESTS_CONFIG;
@@ -43,7 +43,7 @@ import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfi
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.PROXY_USERNAME_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SECURITY_PROTOCOL_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SSL_CONFIG_PREFIX;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.USER_PRINCIPAL_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.KERBEROS_PRINCIPAL_CONFIG;
 
 public class Validator {
 
@@ -114,11 +114,11 @@ public class Validator {
     if (onlyOneSet) {
       String errorMessage = String.format(
           "Either both or neither '%s' and '%s' must be set.",
-          USER_PRINCIPAL_CONFIG,
-          KEYTAB_FILE_PATH_CONFIG
+          KERBEROS_PRINCIPAL_CONFIG,
+          KERBEROS_KEYTAB_PATH_CONFIG
       );
-      addErrorMessage(USER_PRINCIPAL_CONFIG, errorMessage);
-      addErrorMessage(KEYTAB_FILE_PATH_CONFIG, errorMessage);
+      addErrorMessage(KERBEROS_PRINCIPAL_CONFIG, errorMessage);
+      addErrorMessage(KERBEROS_KEYTAB_PATH_CONFIG, errorMessage);
     }
 
     if (config.isKerberosEnabled()) {
@@ -126,13 +126,13 @@ public class Validator {
       if (config.isAuthenticatedConnection()) {
         String errorMessage = String.format(
             "Either only Kerberos (%s, %s) or connection credentials (%s, %s) must be set.",
-            USER_PRINCIPAL_CONFIG,
-            KEYTAB_FILE_PATH_CONFIG,
+            KERBEROS_PRINCIPAL_CONFIG,
+            KERBEROS_KEYTAB_PATH_CONFIG,
             CONNECTION_USERNAME_CONFIG,
             CONNECTION_PASSWORD_CONFIG
         );
-        addErrorMessage(USER_PRINCIPAL_CONFIG, errorMessage);
-        addErrorMessage(KEYTAB_FILE_PATH_CONFIG, errorMessage);
+        addErrorMessage(KERBEROS_PRINCIPAL_CONFIG, errorMessage);
+        addErrorMessage(KERBEROS_KEYTAB_PATH_CONFIG, errorMessage);
         addErrorMessage(CONNECTION_USERNAME_CONFIG, errorMessage);
         addErrorMessage(CONNECTION_PASSWORD_CONFIG, errorMessage);
       }
@@ -141,12 +141,12 @@ public class Validator {
       if (config.isBasicProxyConfigured()) {
         String errorMessage = String.format(
             "Kerberos (%s, %s) is not supported with proxy settings (%s).",
-            USER_PRINCIPAL_CONFIG,
-            KEYTAB_FILE_PATH_CONFIG,
+            KERBEROS_PRINCIPAL_CONFIG,
+            KERBEROS_KEYTAB_PATH_CONFIG,
             PROXY_HOST_CONFIG
         );
-        addErrorMessage(USER_PRINCIPAL_CONFIG, errorMessage);
-        addErrorMessage(KEYTAB_FILE_PATH_CONFIG, errorMessage);
+        addErrorMessage(KERBEROS_PRINCIPAL_CONFIG, errorMessage);
+        addErrorMessage(KERBEROS_KEYTAB_PATH_CONFIG, errorMessage);
         addErrorMessage(PROXY_HOST_CONFIG, errorMessage);
       }
     }

--- a/src/main/java/io/confluent/connect/elasticsearch/Validator.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/Validator.java
@@ -34,6 +34,7 @@ import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfi
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_KEY_TOPICS_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_SCHEMA_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_SCHEMA_TOPICS_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.KEYTAB_FILE_PATH_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.LINGER_MS_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.MAX_BUFFERED_RECORDS_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.MAX_IN_FLIGHT_REQUESTS_CONFIG;
@@ -42,6 +43,7 @@ import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfi
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.PROXY_USERNAME_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SECURITY_PROTOCOL_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SSL_CONFIG_PREFIX;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.USER_PRINCIPAL_CONFIG;
 
 public class Validator {
 
@@ -68,6 +70,7 @@ public class Validator {
 
     validateCredentials();
     validateIgnoreConfigs();
+    validateKerberos();
     validateLingerMs();
     validateMaxBufferedRecords();
     validateProxy();
@@ -104,6 +107,50 @@ public class Validator {
       addErrorMessage(IGNORE_SCHEMA_CONFIG, errorMessage);
       addErrorMessage(IGNORE_SCHEMA_TOPICS_CONFIG, errorMessage);
     }
+  }
+
+  private void validateKerberos() {
+    boolean onlyOneSet = config.kerberosUserPrincipal() != null ^ config.keytabPath() != null;
+    if (onlyOneSet) {
+      String errorMessage = String.format(
+          "Either both or neither '%s' and '%s' must be set.",
+          USER_PRINCIPAL_CONFIG,
+          KEYTAB_FILE_PATH_CONFIG
+      );
+      addErrorMessage(USER_PRINCIPAL_CONFIG, errorMessage);
+      addErrorMessage(KEYTAB_FILE_PATH_CONFIG, errorMessage);
+    }
+
+    if (config.isKerberosEnabled()) {
+      // currently do not support Kerberos with regular auth
+      if (config.isAuthenticatedConnection()) {
+        String errorMessage = String.format(
+            "Either only Kerberos (%s, %s) or connection credentials (%s, %s) must be set.",
+            USER_PRINCIPAL_CONFIG,
+            KEYTAB_FILE_PATH_CONFIG,
+            CONNECTION_USERNAME_CONFIG,
+            CONNECTION_PASSWORD_CONFIG
+        );
+        addErrorMessage(USER_PRINCIPAL_CONFIG, errorMessage);
+        addErrorMessage(KEYTAB_FILE_PATH_CONFIG, errorMessage);
+        addErrorMessage(CONNECTION_USERNAME_CONFIG, errorMessage);
+        addErrorMessage(CONNECTION_PASSWORD_CONFIG, errorMessage);
+      }
+
+      // currently do not support Kerberos with proxy
+      if (config.isBasicProxyConfigured()) {
+        String errorMessage = String.format(
+            "Kerberos (%s, %s) is not supported with proxy settings (%s).",
+            USER_PRINCIPAL_CONFIG,
+            KEYTAB_FILE_PATH_CONFIG,
+            PROXY_HOST_CONFIG
+        );
+        addErrorMessage(USER_PRINCIPAL_CONFIG, errorMessage);
+        addErrorMessage(KEYTAB_FILE_PATH_CONFIG, errorMessage);
+        addErrorMessage(PROXY_HOST_CONFIG, errorMessage);
+      }
+    }
+
   }
 
   private void validateLingerMs() {
@@ -165,7 +212,7 @@ public class Validator {
 
   private void validateSsl() {
     Map<String, Object> sslConfigs = config.originalsWithPrefix(SSL_CONFIG_PREFIX);
-    if (!config.secured()) {
+    if (!config.isSslEnabled()) {
       if (!sslConfigs.isEmpty()) {
         String errorMessage = String.format(
             "'%s' must be set to '%s' to use SSL configs.",

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
@@ -95,7 +95,7 @@ public class ElasticsearchClientTest {
     props.put(IGNORE_KEY_CONFIG, "true");
     config = new ElasticsearchSinkConnectorConfig(props);
     converter = new DataConverter(config);
-    helperClient = new ElasticsearchHelperClient(container.getConnectionUrl());
+    helperClient = new ElasticsearchHelperClient(container.getConnectionUrl(), config);
   }
 
   @After
@@ -512,7 +512,7 @@ public class ElasticsearchClientTest {
     converter = new DataConverter(config);
 
     ElasticsearchClient client = new ElasticsearchClient(config, null);
-    helperClient = new ElasticsearchHelperClient(client.client());
+    helperClient = new ElasticsearchHelperClient(address, config);
     client.createIndex(INDEX);
 
     writeRecord(sinkRecord(0), client);

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
@@ -2,7 +2,7 @@ package io.confluent.connect.elasticsearch;
 
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_TIMEOUT_MS_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_URL_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.KEYTAB_FILE_PATH_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.KERBEROS_KEYTAB_PATH_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.PROXY_HOST_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.PROXY_PASSWORD_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.PROXY_PORT_CONFIG;
@@ -167,20 +167,20 @@ public class ElasticsearchSinkConnectorConfigTest {
 
   @Test(expected = ConfigException.class)
   public void shouldNotAllowInvalidExtensionKeytab() {
-    props.put(KEYTAB_FILE_PATH_CONFIG, "keytab.wrongextension");
+    props.put(KERBEROS_KEYTAB_PATH_CONFIG, "keytab.wrongextension");
     new ElasticsearchSinkConnectorConfig(props);
   }
 
   @Test(expected = ConfigException.class)
   public void shouldNotAllowNonExistingKeytab() {
-    props.put(KEYTAB_FILE_PATH_CONFIG, "idontexist.keytab");
+    props.put(KERBEROS_KEYTAB_PATH_CONFIG, "idontexist.keytab");
     new ElasticsearchSinkConnectorConfig(props);
   }
 
   @Test
   public void shouldAllowValidKeytab() throws IOException {
     Path keytab = Files.createTempFile("iexist", ".keytab");
-    props.put(KEYTAB_FILE_PATH_CONFIG, keytab.toString());
+    props.put(KERBEROS_KEYTAB_PATH_CONFIG, keytab.toString());
 
     new ElasticsearchSinkConnectorConfig(props);
 

--- a/src/test/java/io/confluent/connect/elasticsearch/ValidatorTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ValidatorTest.java
@@ -25,7 +25,7 @@ import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfi
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_KEY_TOPICS_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_SCHEMA_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_SCHEMA_TOPICS_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.KEYTAB_FILE_PATH_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.KERBEROS_KEYTAB_PATH_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.LINGER_MS_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.MAX_BUFFERED_RECORDS_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.MAX_IN_FLIGHT_REQUESTS_CONFIG;
@@ -34,7 +34,7 @@ import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfi
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.PROXY_USERNAME_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SECURITY_PROTOCOL_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SSL_CONFIG_PREFIX;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.USER_PRINCIPAL_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.KERBEROS_PRINCIPAL_CONFIG;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -139,23 +139,23 @@ public class ValidatorTest {
 
   @Test
   public void testInvalidKerberos() throws IOException {
-    props.put(USER_PRINCIPAL_CONFIG, "principal");
+    props.put(KERBEROS_PRINCIPAL_CONFIG, "principal");
     validator = new Validator(props);
 
     Config result = validator.validate();
-    assertHasErrorMessage(result, USER_PRINCIPAL_CONFIG, "must be set");
-    assertHasErrorMessage(result, KEYTAB_FILE_PATH_CONFIG, "must be set");
+    assertHasErrorMessage(result, KERBEROS_PRINCIPAL_CONFIG, "must be set");
+    assertHasErrorMessage(result, KERBEROS_KEYTAB_PATH_CONFIG, "must be set");
 
     // proxy
     Path keytab = Files.createTempFile("es", ".keytab");
-    props.put(USER_PRINCIPAL_CONFIG, "principal");
-    props.put(KEYTAB_FILE_PATH_CONFIG, keytab.toString());
+    props.put(KERBEROS_PRINCIPAL_CONFIG, "principal");
+    props.put(KERBEROS_KEYTAB_PATH_CONFIG, keytab.toString());
     props.put(PROXY_HOST_CONFIG, "proxy.com");
     validator = new Validator(props);
 
     result = validator.validate();
-    assertHasErrorMessage(result, USER_PRINCIPAL_CONFIG, "not supported with proxy settings");
-    assertHasErrorMessage(result, KEYTAB_FILE_PATH_CONFIG, "not supported with proxy settings");
+    assertHasErrorMessage(result, KERBEROS_PRINCIPAL_CONFIG, "not supported with proxy settings");
+    assertHasErrorMessage(result, KERBEROS_KEYTAB_PATH_CONFIG, "not supported with proxy settings");
     assertHasErrorMessage(result, PROXY_HOST_CONFIG, "not supported with proxy settings");
 
     // basic credentials
@@ -165,8 +165,8 @@ public class ValidatorTest {
     validator = new Validator(props);
 
     result = validator.validate();
-    assertHasErrorMessage(result, USER_PRINCIPAL_CONFIG, "Either only Kerberos");
-    assertHasErrorMessage(result, KEYTAB_FILE_PATH_CONFIG, "Either only Kerberos");
+    assertHasErrorMessage(result, KERBEROS_PRINCIPAL_CONFIG, "Either only Kerberos");
+    assertHasErrorMessage(result, KERBEROS_KEYTAB_PATH_CONFIG, "Either only Kerberos");
     assertHasErrorMessage(result, CONNECTION_USERNAME_CONFIG, "Either only Kerberos");
     assertHasErrorMessage(result, CONNECTION_PASSWORD_CONFIG, "Either only Kerberos");
 
@@ -183,8 +183,8 @@ public class ValidatorTest {
 
     // kerberos configs both false
     Path keytab = Files.createTempFile("es", ".keytab");
-    props.put(USER_PRINCIPAL_CONFIG, "principal");
-    props.put(KEYTAB_FILE_PATH_CONFIG, keytab.toString());
+    props.put(KERBEROS_PRINCIPAL_CONFIG, "principal");
+    props.put(KERBEROS_KEYTAB_PATH_CONFIG, keytab.toString());
     validator = new Validator(props);
 
     result = validator.validate();

--- a/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchContainer.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchContainer.java
@@ -23,7 +23,6 @@ import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Duration;
-import java.util.concurrent.Future;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,9 +33,6 @@ import org.testcontainers.images.builder.ImageFromDockerfile;
 import org.testcontainers.images.builder.dockerfile.DockerfileBuilder;
 import org.testcontainers.shaded.org.apache.commons.io.IOUtils;
 import org.testcontainers.utility.DockerImageName;
-
-import static java.net.HttpURLConnection.HTTP_OK;
-import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
 
 /**
  * A specialized TestContainer container for testing Elasticsearch, optionally with SSL support.
@@ -113,6 +109,7 @@ public class ElasticsearchContainer
 
   private final String imageName;
   private boolean enableSsl = false;
+  private String keytabPath;
   private String localKeystorePath;
   private String localTruststorePath;
 
@@ -129,7 +126,12 @@ public class ElasticsearchContainer
   }
 
   public ElasticsearchContainer withSslEnabled(boolean enable) {
-    setSslEnabled(enable);
+    enableSsl(enable);
+    return this;
+  }
+
+  public ElasticsearchContainer withKerberosEnabled(String keytab) {
+    enableKerberos(keytab);
     return this;
   }
 
@@ -140,10 +142,10 @@ public class ElasticsearchContainer
    *
    * @param enable true if SSL is to be enabled, or false otherwise
    */
-  public void setSslEnabled(boolean enable) {
+  public void enableSsl(boolean enable) {
     if (isCreated()) {
       throw new IllegalStateException(
-          "setSslEnabled can only be used before the Container is created."
+          "enableSsl can only be used before the Container is created."
       );
     }
     enableSsl = enable;
@@ -158,67 +160,108 @@ public class ElasticsearchContainer
     return enableSsl;
   }
 
+  /**
+   * Set whether the Elasticsearch instance should use Kerberos.
+   *
+   * <p>This can only be called <em>before</em> the container is started.
+   *
+   * @param keytab non-null keytab path if Kerberos is enabled
+   */
+  public void enableKerberos(String keytab) {
+    if (isCreated()) {
+      throw new IllegalStateException(
+          "enableKerberos can only be used before the container is created."
+      );
+    }
+    keytabPath = keytab;
+  }
+
+  /**
+   * Get whether the Elasticsearch instance is configured to use Kerberos.
+   *
+   * @return true if Kerberos is enabled, or false otherwise
+   */
+  public boolean isKerberosEnabled() {
+    return keytabPath != null;
+  }
+
+  private String getFullResourcePath(String resourceName) {
+    if (isSslEnabled() && isKerberosEnabled()) {
+      return "/both/" + resourceName;
+    } else if (isSslEnabled()) {
+      return "/ssl/" + resourceName;
+    } else if (isKerberosEnabled()) {
+      return "/kerberos/" + resourceName;
+    } else {
+      return resourceName;
+    }
+  }
+
   @Override
   protected void configure() {
     super.configure();
-    Future<String> image;
+
+    waitingFor(
+        Wait
+            .forLogMessage(".*(Security is enabled|license .* valid).*", 1)
+            .withStartupTimeout(Duration.ofMinutes(5))
+    );
+
+    if (!isSslEnabled() && !isKerberosEnabled()) {
+      setImage(new RemoteDockerImage(DockerImageName.parse(imageName)));
+      return;
+    }
+
+    ImageFromDockerfile image = new ImageFromDockerfile()
+        // Copy the Elasticsearch config file
+        .withFileFromClasspath("elasticsearch.yml", getFullResourcePath("elasticsearch.yml"))
+        // Copy the network definitions
+        .withFileFromClasspath("instances.yml", getFullResourcePath("instances.yml"))
+        .withDockerfileFromBuilder(this::buildImage);
+
     if (isSslEnabled()) {
+      log.info("Extending Docker image to generate certs and enable SSL");
       withEnv("ELASTIC_PASSWORD", ELASTIC_PASSWORD);
       withEnv("STORE_PASSWORD", KEY_PASSWORD);
       withEnv("IP_ADDRESS", hostMachineIpAddress());
-      log.info("Extending Docker image to generate certs and enable SSL");
-      log.info("Wait for 'license .* valid' in log file, signaling Elasticsearch has started");
-      // Because this is an secured Elasticsearch instance, we can't use HTTPS checks
-      // because of the untrusted cert
-      waitingFor(
-          Wait.forLogMessage(".*(Security is enabled|license .* valid).*", 1)
-              .withStartupTimeout(Duration.ofMinutes(5))
-      );
-      image = new ImageFromDockerfile()
-          // Copy the Elasticsearch config file for SSL
-          .withFileFromClasspath(
-              "elasticsearch.yml",
-              "/ssl/elasticsearch.yml"
-          )
-          // Copy the network definitions
-          .withFileFromClasspath(
-              "instances.yml",
-              "/ssl/instances.yml"
-          )
+
+      image
           // Copy the script to generate the certs and start Elasticsearch
-          .withFileFromClasspath(
-              "start-elasticsearch.sh",
-              "/ssl/start-elasticsearch.sh"
-          )
-          .withDockerfileFromBuilder(this::build);
-    } else {
-      log.info("Will use HTTP check to wait for Elasticsearch image");
-      // Because this is an unsecured Elasticsearch instance, we can use HTTP checks
-      waitingFor(
-          Wait.forHttp("/")
-              .forPort(ELASTICSEARCH_DEFAULT_PORT)
-              .forStatusCodeMatching(status -> status == HTTP_OK || status == HTTP_UNAUTHORIZED)
-              .withStartupTimeout(Duration.ofMinutes(2))
-      );
-      image = new RemoteDockerImage(DockerImageName.parse(imageName));
+          .withFileFromClasspath("start-elasticsearch.sh", getFullResourcePath("start-elasticsearch.sh"));
     }
+
+    if (isKerberosEnabled()) {
+      log.info("Creating Kerberized Elasticsearch image.");
+      image.withFileFromFile("es.keytab", new File(keytabPath));
+    }
+
     setImage(image);
   }
 
-  protected void build(DockerfileBuilder builder) {
-    log.info("Building Elasticsearch image with SSL configuration");
-    builder.from(imageName)
-           // OpenSSL and Java's Keytool used to generate the certs, so install them
-           .run("yum -y install openssl")
-           // Copy the Elasticsearch configuration
-           .copy("elasticsearch.yml", CONFIG_PATH +"/elasticsearch.yml")
-           // Copy and run the script to generate the certs
-           .copy("instances.yml", CONFIG_SSL_PATH + "/instances.yml")
-           .copy("start-elasticsearch.sh", CONFIG_SSL_PATH + "/start-elasticsearch.sh")
-           .run("chmod +x " + CONFIG_SSL_PATH + "/start-elasticsearch.sh")
-           .entryPoint(
-               CONFIG_SSL_PATH + "/start-elasticsearch.sh"
-           );
+  private void buildImage(DockerfileBuilder builder) {
+    builder
+        .from(imageName)
+        // Copy the Elasticsearch configuration
+        .copy("elasticsearch.yml", CONFIG_PATH +"/elasticsearch.yml");
+
+    if (isSslEnabled()) {
+      log.info("Building Elasticsearch image with SSL configuration");
+      builder
+          .copy("instances.yml", CONFIG_SSL_PATH + "/instances.yml")
+          .copy("start-elasticsearch.sh", CONFIG_SSL_PATH + "/start-elasticsearch.sh")
+          // OpenSSL and Java's Keytool used to generate the certs, so install them
+          .run("yum -y install openssl")
+          .run("chmod +x " + CONFIG_SSL_PATH + "/start-elasticsearch.sh")
+          .entryPoint(CONFIG_SSL_PATH + "/start-elasticsearch.sh");
+    }
+
+    if (isKerberosEnabled()) {
+      log.info("Building Elasticsearch image with Kerberos configuration.");
+      builder.copy("es.keytab", CONFIG_PATH + "/es.keytab");
+      if (!isSslEnabled()) {
+        builder.copy("instances.yml", CONFIG_PATH + "/instances.yml");
+      }
+    }
   }
 
   public String hostMachineIpAddress() {

--- a/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchContainer.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchContainer.java
@@ -202,8 +202,7 @@ public class ElasticsearchContainer
     super.configure();
 
     waitingFor(
-        Wait
-            .forLogMessage(".*(Security is enabled|license .* valid).*", 1)
+        Wait.forLogMessage(".*(Security is enabled|license .* valid).*", 1)
             .withStartupTimeout(Duration.ofMinutes(5))
     );
 

--- a/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchHelperClient.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchHelperClient.java
@@ -15,10 +15,11 @@
 
 package io.confluent.connect.elasticsearch.helper;
 
+import io.confluent.connect.elasticsearch.ConfigCallbackHandler;
+import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig;
 import java.io.IOException;
 import org.apache.http.HttpHost;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
-import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestClient;
@@ -38,12 +39,14 @@ public class ElasticsearchHelperClient {
 
   private RestHighLevelClient client;
 
-  public ElasticsearchHelperClient(String url) {
-    this.client = new RestHighLevelClient(RestClient.builder(HttpHost.create(url)));
-  }
-
-  public ElasticsearchHelperClient(RestHighLevelClient client) {
-    this.client = client;
+  public ElasticsearchHelperClient(String url, ElasticsearchSinkConnectorConfig config) {
+    ConfigCallbackHandler configCallbackHandler = new ConfigCallbackHandler(config);
+    this.client = new RestHighLevelClient(
+        RestClient
+            .builder(HttpHost.create(url))
+            .setHttpClientConfigCallback(configCallbackHandler)
+            .setRequestConfigCallback(configCallbackHandler)
+    );
   }
 
   public void deleteIndex(String index) throws IOException {

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorBaseIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorBaseIT.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import io.confluent.connect.elasticsearch.ElasticsearchSinkConnector;
+import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig;
 import io.confluent.connect.elasticsearch.helper.ElasticsearchContainer;
 import io.confluent.connect.elasticsearch.helper.ElasticsearchHelperClient;
 import java.io.IOException;
@@ -66,15 +67,20 @@ public class ElasticsearchConnectorBaseIT extends BaseConnectorIT {
     connect.kafka().createTopic(TOPIC);
 
     props = createProps();
-    helperClient = new ElasticsearchHelperClient(container.getConnectionUrl());
+    helperClient = new ElasticsearchHelperClient(
+        container.getConnectionUrl(),
+        new ElasticsearchSinkConnectorConfig(props)
+    );
   }
 
   @After
   public void cleanup() throws IOException {
     stopConnect();
-    helperClient.deleteIndex(TOPIC);
 
-    helperClient.close();
+    if (helperClient != null) {
+      helperClient.deleteIndex(TOPIC);
+      helperClient.close();
+    }
   }
 
   protected Map<String, String> createProps() {

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorKerberosIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorKerberosIT.java
@@ -1,0 +1,104 @@
+package io.confluent.connect.elasticsearch.integration;
+
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.KEYTAB_FILE_PATH_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.USER_PRINCIPAL_CONFIG;
+
+import io.confluent.connect.elasticsearch.ElasticsearchClient;
+import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig;
+import io.confluent.connect.elasticsearch.helper.ElasticsearchContainer;
+import io.confluent.connect.elasticsearch.helper.ElasticsearchHelperClient;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Properties;
+import org.apache.hadoop.minikdc.MiniKdc;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class ElasticsearchConnectorKerberosIT extends ElasticsearchConnectorBaseIT {
+
+  private static File baseDir;
+  private static MiniKdc kdc;
+  private static String esPrincipal;
+  private static String esKeytab;
+  private static String userPrincipal;
+  private static String userKeytab;
+
+  @BeforeClass
+  public static void setupBeforeAll() throws Exception {
+    initKdc();
+
+    container = ElasticsearchContainer.fromSystemProperties().withKerberosEnabled(esKeytab);
+    container.start();
+  }
+
+  /**
+   * Shuts down the KDC and cleans up files.
+   */
+  @AfterClass
+  public static void cleanupAfterAll() {
+    container.close();
+    closeKdc();
+  }
+
+  @Test
+  public void testKerberos() throws Exception {
+    addKerberosConfigs(props);
+    helperClient = new ElasticsearchHelperClient(new ElasticsearchClient(new ElasticsearchSinkConnectorConfig(props), null).client());
+    runSimpleTest(props);
+  }
+
+  private static void closeKdc() {
+    if (kdc != null) {
+      kdc.stop();
+    }
+
+    if (baseDir.exists()) {
+      deleteDirectory(baseDir.toPath());
+    }
+  }
+
+  private static void deleteDirectory(Path directoryPath) {
+    try {
+      Files.walk(directoryPath)
+          .sorted(Comparator.reverseOrder())
+          .map(Path::toFile)
+          .forEach(File::delete);
+    } catch (IOException e) {
+      throw new ConnectException(e);
+    }
+  }
+
+  private static void initKdc() throws Exception {
+    baseDir = new File(System.getProperty("test.build.dir", "target/test-dir"));
+    if (baseDir.exists()) {
+      deleteDirectory(baseDir.toPath());
+    }
+
+    Properties kdcConf = MiniKdc.createConf();
+    kdc = new MiniKdc(kdcConf, baseDir);
+    kdc.start();
+
+    String es = "es";
+    File keytabFile = new File(baseDir, es + ".keytab");
+    esKeytab = keytabFile.getAbsolutePath();
+    kdc.createPrincipal(keytabFile, es + "/localhost", "HTTP/localhost");
+    esPrincipal = es + "/localhost@" + kdc.getRealm();
+
+    String user = "connect-es";
+    keytabFile = new File(baseDir, user + ".keytab");
+    userKeytab = keytabFile.getAbsolutePath();
+    kdc.createPrincipal(keytabFile, user + "/localhost");
+    userPrincipal = user + "/localhost@" + kdc.getRealm();
+  }
+
+  private static void addKerberosConfigs(Map<String, String> props) {
+    props.put(USER_PRINCIPAL_CONFIG, userPrincipal);
+    props.put(KEYTAB_FILE_PATH_CONFIG, userKeytab);
+  }
+}

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorKerberosIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorKerberosIT.java
@@ -1,7 +1,7 @@
 package io.confluent.connect.elasticsearch.integration;
 
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.KEYTAB_FILE_PATH_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.USER_PRINCIPAL_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.KERBEROS_KEYTAB_PATH_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.KERBEROS_PRINCIPAL_CONFIG;
 
 import io.confluent.connect.elasticsearch.ElasticsearchClient;
 import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig;
@@ -98,7 +98,7 @@ public class ElasticsearchConnectorKerberosIT extends ElasticsearchConnectorBase
   }
 
   private static void addKerberosConfigs(Map<String, String> props) {
-    props.put(USER_PRINCIPAL_CONFIG, userPrincipal);
-    props.put(KEYTAB_FILE_PATH_CONFIG, userKeytab);
+    props.put(KERBEROS_PRINCIPAL_CONFIG, userPrincipal);
+    props.put(KERBEROS_KEYTAB_PATH_CONFIG, userKeytab);
   }
 }

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorKerberosWithSslIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorKerberosWithSslIT.java
@@ -1,0 +1,63 @@
+package io.confluent.connect.elasticsearch.integration;
+
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_PASSWORD_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_URL_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_USERNAME_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SECURITY_PROTOCOL_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SSL_CONFIG_PREFIX;
+import static io.confluent.connect.elasticsearch.helper.ElasticsearchContainer.ELASTIC_PASSWORD;
+
+import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig;
+import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SecurityProtocol;
+import io.confluent.connect.elasticsearch.helper.ElasticsearchContainer;
+import io.confluent.connect.elasticsearch.helper.ElasticsearchHelperClient;
+import org.apache.kafka.common.config.SslConfigs;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class ElasticsearchConnectorKerberosWithSslIT extends ElasticsearchConnectorKerberosIT{
+
+  @BeforeClass
+  public static void setupBeforeAll() throws Exception {
+    initKdc();
+
+    container = ElasticsearchContainer
+        .fromSystemProperties()
+        .withKerberosEnabled(esKeytab)
+        .withSslEnabled(true);
+    container.start();
+  }
+
+  @Override
+  @Test
+  public void testKerberos() {
+    // skip as parent is running this
+    helperClient = null;
+  }
+
+  @Test
+  public void testKerberosWithSsl() throws Exception {
+    // Use IP address here because that's what the certificates allow
+    String address = container.getConnectionUrl().replace(
+        container.getContainerIpAddress(),
+        container.hostMachineIpAddress()
+    );
+
+    props.put(CONNECTION_URL_CONFIG, address);
+    props.put(SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SSL.name());
+    props.put(SSL_CONFIG_PREFIX + SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, container.getKeystorePath());
+    props.put(SSL_CONFIG_PREFIX + SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, container.getKeystorePassword());
+    props.put(SSL_CONFIG_PREFIX + SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, container.getTruststorePath());
+    props.put(SSL_CONFIG_PREFIX + SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, container.getTruststorePassword());
+    props.put(SSL_CONFIG_PREFIX + SslConfigs.SSL_KEY_PASSWORD_CONFIG, container.getKeyPassword());
+    addKerberosConfigs(props);
+
+    helperClient = new ElasticsearchHelperClient(
+        address,
+        new ElasticsearchSinkConnectorConfig(props)
+    );
+
+    // Start connector
+    runSimpleTest(props);
+  }
+}

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorSslIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorSslIT.java
@@ -36,9 +36,9 @@ import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfi
 import static io.confluent.connect.elasticsearch.helper.ElasticsearchContainer.ELASTIC_PASSWORD;
 
 @Category(IntegrationTest.class)
-public class ElasticsearchConnectorSecureIT extends ElasticsearchConnectorBaseIT {
+public class ElasticsearchConnectorSslIT extends ElasticsearchConnectorBaseIT {
 
-  private static final Logger log = LoggerFactory.getLogger(ElasticsearchConnectorSecureIT.class);
+  private static final Logger log = LoggerFactory.getLogger(ElasticsearchConnectorSslIT.class);
 
   @BeforeClass
   public static void setupBeforeAll() {

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorSslIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorSslIT.java
@@ -16,7 +16,6 @@
 package io.confluent.connect.elasticsearch.integration;
 
 import io.confluent.common.utils.IntegrationTest;
-import io.confluent.connect.elasticsearch.ElasticsearchClient;
 import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig;
 import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SecurityProtocol;
 import io.confluent.connect.elasticsearch.helper.ElasticsearchContainer;
@@ -60,7 +59,10 @@ public class ElasticsearchConnectorSslIT extends ElasticsearchConnectorBaseIT {
     props.put(CONNECTION_URL_CONFIG, address);
     addSslProps();
 
-    helperClient = new ElasticsearchHelperClient(new ElasticsearchClient(new ElasticsearchSinkConnectorConfig(props), null).client());
+    helperClient = new ElasticsearchHelperClient(
+        address,
+        new ElasticsearchSinkConnectorConfig(props)
+    );
 
     // Start connector
     runSimpleTest(props);
@@ -79,7 +81,10 @@ public class ElasticsearchConnectorSslIT extends ElasticsearchConnectorBaseIT {
     // disable hostname verification
     props.put(SSL_CONFIG_PREFIX + SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "");
 
-    helperClient = new ElasticsearchHelperClient(new ElasticsearchClient(new ElasticsearchSinkConnectorConfig(props), null).client());
+    helperClient = new ElasticsearchHelperClient(
+        address,
+        new ElasticsearchSinkConnectorConfig(props)
+    );
 
     // Start connector
     runSimpleTest(props);

--- a/src/test/resources/both/elasticsearch.yml
+++ b/src/test/resources/both/elasticsearch.yml
@@ -1,0 +1,34 @@
+## Used by Docker images in our integration test
+http.host: 0.0.0.0
+network.host: 0.0.0.0
+transport.host: 0.0.0.0
+
+node.store.allow_mmap: false
+cluster.routing.allocation.disk.threshold_enabled: false
+
+xpack.license.self_generated.type: trial
+xpack.security.enabled: true
+xpack.security.http.ssl.enabled: true
+xpack.security.http.ssl.client_authentication: optional
+xpack.security.http.ssl.verification_mode: certificate
+xpack.security.http.ssl.key:  ssl/elasticsearch.key
+xpack.security.http.ssl.certificate: ssl/elasticsearch.crt
+xpack.security.http.ssl.certificate_authorities: [ "ssl/ca/ca.crt" ]
+
+xpack.security.transport.ssl.enabled: true
+xpack.security.transport.ssl.key:  ssl/elasticsearch.key
+xpack.security.transport.ssl.certificate: ssl/elasticsearch.crt
+xpack.security.transport.ssl.certificate_authorities: [ "ssl/ca/ca.crt" ]
+
+# enable anonymous connections since setting passwords requires running a command
+xpack.security.authc:
+  anonymous:
+    username: connect_user
+    roles: superuser
+    authz_exception: true
+
+# Kerberos realm
+xpack.security.authc.realms.kerberos.kerb1:
+  order: 3
+  keytab.path: es.keytab
+  remove_realm_name: false

--- a/src/test/resources/both/instances.yml
+++ b/src/test/resources/both/instances.yml
@@ -1,0 +1,18 @@
+instances:
+  - name: elasticsearch
+    dns:
+      - elasticsearch
+    ip:
+      - ipAddress
+  - name: kibana
+    dns:
+      - kibana
+      - localhost
+    ip:
+      - ipAddress
+  - name: logstash
+    dns:
+      - logstash
+      - localhost
+    ip:
+      - ipAddress

--- a/src/test/resources/both/start-elasticsearch.sh
+++ b/src/test/resources/both/start-elasticsearch.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+# Generate the certificates used in the HTTPS tests.
+# Copy these into the docker image to make available to client (Java class in this repo) and
+# elastic server (docker container started in test setup). Volume mounting is unsolved issue.
+
+ES_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}"/ )" >/dev/null 2>&1 && pwd )"
+cd $ES_DIR/../..
+ES_DIR=$(pwd)
+export PATH=/usr/share/elasticsearch/jdk/bin/:$PATH
+
+if [[ -z "${IP_ADDRESS}" ]]; then
+    IP_ADDRESS=$(hostname -I)
+fi
+
+echo
+echo "Replacing the ip address in the ${ES_DIR}/config/ssl/instances.yml file with ${IP_ADDRESS}"
+sed -i "s/ipAddress/${IP_ADDRESS}/g" ${ES_DIR}/config/ssl/instances.yml
+
+
+echo "Setting up Elasticsearch and generating certificates in ${ES_DIR}"
+
+if [[ -n "$ELASTIC_PASSWORD" ]]; then
+
+    echo "=== CREATE Keystore ==="
+    echo "Elastic password is: $ELASTIC_PASSWORD"
+    if [ -f ${ES_DIR}/config/elasticsearch.keystore ]; then
+        echo "Removing old ${ES_DIR}/config/elasticsearch.keystore"
+        rm ${ES_DIR}/config/elasticsearch.keystore
+    fi
+    [[ -f ${ES_DIR}/config/elasticsearch.keystore ]] || (${ES_DIR}/bin/elasticsearch-keystore create)
+    echo "Setting bootstrap.password..."
+    (echo "$ELASTIC_PASSWORD" | ${ES_DIR}/bin/elasticsearch-keystore add -x 'bootstrap.password')
+
+    # Create SSL Certs
+    echo "=== CREATE SSL CERTS ==="
+
+    # check if old cluster-ca.zip exists, if it does remove and create a new one.
+    if [ -f ${ES_DIR}/config/ssl/cluster-ca.zip ]; then
+        echo "Removing old ca zip..."
+        rm ${ES_DIR}/config/ssl/cluster-ca.zip
+    fi
+    echo "Creating cluster-ca.zip... (warnings are benign)"
+    ${ES_DIR}/bin/elasticsearch-certutil ca --pem --silent --out ${ES_DIR}/config/ssl/cluster-ca.zip
+
+    # check if ca directory exists, if does, remove then unzip new files
+    if [ -d ${ES_DIR}/config/ssl/ca ]; then
+        echo "CA directory exists, removing..."
+        rm -rf ${ES_DIR}/config/ssl/ca
+    fi
+
+    echo "Unzip ca files..."
+    unzip ${ES_DIR}/config/ssl/cluster-ca.zip -d ${ES_DIR}/config/ssl
+    rm -f ${ES_DIR}/config/ssl/cluster-ca.zip
+
+    # check if certs zip exist. If it does remove and create a new one.
+    if [ -f ${ES_DIR}/config/ssl/cluster.zip ]; then
+        echo "Remove old cluster.zip zip..."
+        rm ${ES_DIR}/config/ssl/cluster.zip
+    fi
+    echo "Create cluster certs zipfile... (warnings are benign)"
+    ${ES_DIR}/bin/elasticsearch-certutil cert --silent --pem --in ${ES_DIR}/config/ssl/instances.yml --out ${ES_DIR}/config/ssl/cluster.zip --ca-cert ${ES_DIR}/config/ssl/ca/ca.crt --ca-key ${ES_DIR}/config/ssl/ca/ca.key
+
+    if [ -d ${ES_DIR}/config/ssl/docker-cluster ]; then
+        rm -rf ${ES_DIR}/config/ssl/cluster
+    fi
+    echo "Unzipping cluster certs zipfile..."
+    unzip ${ES_DIR}/config/ssl/cluster.zip -d ${ES_DIR}/config/ssl/cluster
+    rm -f ${ES_DIR}/config/ssl/cluster.zip
+
+    echo "Move elasticsearch certs to SSL config dir..."
+    mv ${ES_DIR}/config/ssl/cluster/elasticsearch/* ${ES_DIR}/config/ssl/
+
+    echo "Generating truststore at ${ES_DIR}/config/ssl/truststore.jks"
+    keytool -keystore ${ES_DIR}/config/ssl/truststore.jks -import -file ${ES_DIR}/config/ssl/ca/ca.crt -alias cacert -storepass $STORE_PASSWORD -noprompt
+
+    echo "Generating keystore for client at ${ES_DIR}/config/ssl/keystore.jks"
+    # Generate a new PKCS12 keystore using our CA
+    openssl pkcs12 -export -in ${ES_DIR}/config/ssl/ca/ca.crt -inkey ${ES_DIR}/config/ssl/ca/ca.key -out ${ES_DIR}/config/ssl/client.p12 -name "clientkey" -passin pass:$STORE_PASSWORD -passout pass:$STORE_PASSWORD
+
+    # Convert the PKCS12 keystore to JKS keytstore
+    keytool -importkeystore -destkeystore ${ES_DIR}/config/ssl/keystore.jks -deststorepass $STORE_PASSWORD -srckeystore ${ES_DIR}/config/ssl/client.p12 -srcstoretype PKCS12 -srcstorepass $STORE_PASSWORD -noprompt
+    rm -f ${ES_DIR}/config/ssl/client.p12
+fi
+
+echo
+echo "Starting Elasticsearch with SSL enabled ..."
+/usr/local/bin/docker-entrypoint.sh

--- a/src/test/resources/kerberos/elasticsearch.yml
+++ b/src/test/resources/kerberos/elasticsearch.yml
@@ -1,0 +1,22 @@
+## Used by Docker images in our integration test
+http.host: 0.0.0.0
+network.host: 0.0.0.0
+transport.host: 0.0.0.0
+
+node.store.allow_mmap: false
+cluster.routing.allocation.disk.threshold_enabled: false
+
+xpack.license.self_generated.type: trial
+
+# Kerberos realm
+xpack.security.authc.realms.kerberos.kerb1:
+  order: 3
+  keytab.path: es.keytab
+  remove_realm_name: false
+
+# enable anonymous connections since setting passwords requires running a command
+xpack.security.authc:
+  anonymous:
+    username: connect_user
+    roles: superuser
+    authz_exception: true

--- a/src/test/resources/kerberos/instances.yml
+++ b/src/test/resources/kerberos/instances.yml
@@ -1,0 +1,18 @@
+instances:
+  - name: elasticsearch
+    dns:
+      - elasticsearch
+    ip:
+      - ipAddress
+  - name: kibana
+    dns:
+      - kibana
+      - localhost
+    ip:
+      - ipAddress
+  - name: logstash
+    dns:
+      - logstash
+      - localhost
+    ip:
+      - ipAddress


### PR DESCRIPTION
## Problem
the connector does not support kerberos authentication

## Solution
implement kerberos authentication, built on top of #468 

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests - new ITs testing kerberos auth
- [ ] System tests
- [x] Manual tests - set up a KDC docker instance and verified manually the connect can authenticate with kerberos

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
new feature hence `master`, building on top of #468 