### PR TITLE
CCMSG-635: Test DLQ logs with errant reporter

### DIFF
--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorIT.java
@@ -148,17 +148,13 @@ public class ElasticsearchConnectorIT extends ElasticsearchConnectorBaseIT {
     }
   }
   
-  /*
-   * Currently writing primitives to ES fails because ES expects a JSON document and the connector
-   * does not wrap primitives in any way into a JSON document.
-   */
   @Test
   public void testBadRecordsInDLQ() throws Exception {
     props.put(VALUE_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
     props.put(BEHAVIOR_ON_MALFORMED_DOCS_CONFIG,"ignore");
     props.put(DROP_INVALID_MESSAGE_CONFIG,"true");
     props.put("errors.tolerance","all");
-    props.put("errors.deadletterqueue.topic.name","dlq_file_sink_02");
+    props.put("errors.deadletterqueue.topic.name","dlq");
     props.put("errors.deadletterqueue.topic.replication.factor", "1");
     SinkTaskContext context = mock(SinkTaskContext.class);
     ErrantRecordReporter reporter = mock(ErrantRecordReporter.class);

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -28,3 +28,16 @@ log4j.logger.org.eclipse.jetty=ERROR
 log4j.logger.org.glassfish.jersey.internal=ERROR
 
 log4j.logger.io.confluent.connect.elasticsearch=DEBUG
+
+
+# Send the Errant Reporter logs to a DLQ file, rolling the file connect-dlq.log based on a Max Size of 1MB.
+#
+log4j.appender.dlqLogAppender=org.apache.log4j.RollingFileAppender
+log4j.appender.dlqLogAppender.File=connect-dlq.log
+log4j.appender.dlqLogAppender.layout=org.apache.log4j.PatternLayout
+log4j.appender.dlqLogAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+log4j.appender.dlqLogAppender.MaxFileSize=1MB
+log4j.appender.dlqLogAppender.MaxBackupIndex=5
+log4j.appender.dlqLogAppender.append=true
+
+log4j.logger.org.apache.kafka.connect.sink.ErrantRecordReporter=ERROR, dlqLogAppender


### PR DESCRIPTION
## Problem
Change the Log4J configuration for each worker to send DLQ log messages to a different file, with its own rolling and file limit specification (see https://github.com/confluentinc/ce-kafka/blob/master/config/log4j.properties for examples of how Kafka sends different messages to different files)

## Solution
Test these log4j changes with IT
Relates to https://github.com/confluentinc/ce-kafka/pull/2826

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
