### PR TITLE
MINOR: Fix semver test to correctly accept qualifiers in the end

### DIFF
--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorTest.java
@@ -77,6 +77,7 @@ public class ElasticsearchSinkConnectorTest {
     assertNotNull(connector.version());
     assertFalse(connector.version().equals("0.0.0.0"));
     assertFalse(connector.version().equals("unknown"));
-    assertTrue(connector.version().matches("^(\\d+\\.)?(\\d+\\.)?(\\*|\\d+)(-\\w+)?$"));
+    // Match semver with potentially a qualifier in the end
+    assertTrue(connector.version().matches("^(\\d+\\.){2}?(\\*|\\d+)(-.*)?$"));
   }
 }

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
@@ -270,6 +270,8 @@ public class ElasticsearchSinkTaskTest {
     assertNotNull(task.version());
     assertFalse(task.version().equals("0.0.0.0"));
     assertTrue(task.version().matches("^(\\d+\\.)?(\\d+\\.)?(\\*|\\d+)(-\\w+)?$"));
+    // Match semver with potentially a qualifier in the end
+    assertTrue(task.version().matches("^(\\d+\\.){2}?(\\*|\\d+)(-.*)?$"));
   }
 
   @Test


### PR DESCRIPTION
## Problem
We need to be more lax on the qualifiers we accept in versions

## Solution
Fix regex

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
