### PR TITLE
CCMSG-796: fix poor performance for lots of update requests

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
@@ -64,6 +64,7 @@ public class ElasticsearchClient {
 
   private static final Logger log = LoggerFactory.getLogger(ElasticsearchClient.class);
 
+  private static final long WAIT_TIME = TimeUnit.MILLISECONDS.toMillis(10);
   private static final String RESOURCE_ALREADY_EXISTS_EXCEPTION =
       "resource_already_exists_exception";
   private static final String VERSION_CONFLICT_EXCEPTION = "version_conflict_engine_exception";
@@ -255,14 +256,14 @@ public class ElasticsearchClient {
       // every request that is flushed and succeeds triggers a callback that removes it from the map
       while (docIdToRecord.containsKey(request.id())) {
         flush();
-        clock.sleep(TimeUnit.SECONDS.toMillis(1));
+        clock.sleep(WAIT_TIME);
       }
     }
 
     // wait for internal buffer to be less than max.buffered.records configuration
     long maxWaitTime = clock.milliseconds() + config.flushTimeoutMs();
     while (numRecords.get() >= config.maxBufferedRecords()) {
-      clock.sleep(TimeUnit.SECONDS.toMillis(1));
+      clock.sleep(WAIT_TIME);
       if (clock.milliseconds() > maxWaitTime) {
         throw new ConnectException(
             String.format(


### PR DESCRIPTION
Signed-off-by: Lev Zemlyanov <lev@confluent.io>

## Problem
data sets that have frequent updates will result in slow performance because of long wait times

## Solution
reduce the wait times to 10ms to fix performance bottlenecking

remove the unique constraint by relying on `BulkItemResponse::getItemId` which returns the order of the request in the bulk request, which we can use to map the request to the `SinkRecord` it came from

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
modified a test to upsert multiple records with the same key
existing reporter tests cover the rest of the test cases

PERF TEST RESULTS:

configs
```
{
  "task.max": 1,
  "linger.ms": 1000,
  "batch.size": 2000,
  "max.buffered.records": 20000,
  "max.in.flight.requests": 5,
}
```

v10.0.2 with the same key for every single record
![Screen Shot 2021-02-08 at 4 24 40 PM](https://user-images.githubusercontent.com/14001489/107298535-76d87500-6a2a-11eb-99b0-7678dd64e83c.png)

a steady 6.7K records/s

this PR:
![Screen Shot 2021-02-08 at 4 02 20 PM](https://user-images.githubusercontent.com/14001489/107298627-8a83db80-6a2a-11eb-9704-55a153ebdc5e.png)

the first rate is a steady 32K records/s (the dip is from a rebalance) with unique keys
the second rate is a steady 6.7K records/s with identical records which is what v10.0.2 also had, therefore this PR addresses the performance regression


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [x] Manual tests - performance testing

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
backporting to `11.0.x` where this was introduced