### PR TITLE
CC-13829: Upgrade httpclient to 4.5.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,11 @@
             <version>${jest.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.13</version>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
             <version>${hamcrest.version}</version>


### PR DESCRIPTION
## Problem
There is a CVE in HttpClient brought in by io.searchbox:jest:jar:6.3.1. We need to upgrade it to HttpClient. 

## Solution
I am trying to add a direct dependency on HttpClient. It seems that 5.0.x and 5.1.x 's tests will not pass even without this change. 


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?


## Test Strategy
Rely on existing tests and let's discuss whether additional tests are needed.

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->

<!-- Are you backporting or merging to master? -->
Merging to master. 

<!-- If you are reverting or rolling back, is it safe? --> 
