### PR TITLE
CCMSG-836: Connector does not set 'read.timeout.ms' correctly

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ConfigCallbackHandler.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ConfigCallbackHandler.java
@@ -126,7 +126,8 @@ public class ConfigCallbackHandler implements HttpClientConfigCallback, RequestC
     return builder
         .setContentCompressionEnabled(config.compression())
         .setConnectTimeout(config.connectionTimeoutMs())
-        .setConnectionRequestTimeout(config.readTimeoutMs());
+        .setConnectionRequestTimeout(config.readTimeoutMs())
+        .setSocketTimeout(config.readTimeoutMs());
   }
 
   /**


### PR DESCRIPTION
Signed-off-by: Lev Zemlyanov <lev@confluent.io>

## Problem
the connector does not set the `read.timeout.ms` config correctly for socket timeouts

## Solution
set the socket timeout correctly with the config

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
backport to `11.0.x` where this bug was introduced