### PR TITLE
CCMSG-201: add connection configs validator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <artifactId>mockito-inline</artifactId>
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/io/confluent/connect/elasticsearch/Validator.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/Validator.java
@@ -100,7 +100,7 @@ public class Validator {
         validateConnection(client);
       }
     } catch (IOException e) {
-      log.warn("Closing the client failed ");
+      log.warn("Closing the client failed.", e);
     }
 
     return new Config(validations);

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorTest.java
@@ -62,16 +62,6 @@ public class ElasticsearchSinkConnectorTest {
     connector.stop();
   }
 
-
-  @Test
-  public void shouldValidateConfigs() {
-    Config result = connector.validate(settings);
-    assertNotNull(result);
-    result.configValues()
-        .stream()
-        .forEach(config -> assertTrue(config.errorMessages().isEmpty()));
-  }
-
   @Test
   public void testVersion() {
     assertNotNull(connector.version());

--- a/src/test/java/io/confluent/connect/elasticsearch/ValidatorTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ValidatorTest.java
@@ -72,7 +72,7 @@ public class ValidatorTest {
 
   @Test
   public void testInvalidIndividualConfigs() {
-    validator = new Validator(new HashMap<>(), mockClient);
+    validator = new Validator(new HashMap<>(), () -> mockClient);
     Config result = validator.validate();
     assertHasErrorMessage(result, CONNECTION_URL_CONFIG, "Missing required configuration");
   }
@@ -80,7 +80,7 @@ public class ValidatorTest {
   @Test
   public void testInvalidCredentials() {
     props.put(CONNECTION_USERNAME_CONFIG, "username");
-    validator = new Validator(props, mockClient);
+    validator = new Validator(props, () -> mockClient);
 
     Config result = validator.validate();
     assertHasErrorMessage(result, CONNECTION_USERNAME_CONFIG, "must be set");
@@ -97,7 +97,7 @@ public class ValidatorTest {
   @Test
   public void testValidCredentials() {
     // username and password not set
-    validator = new Validator(props, mockClient);
+    validator = new Validator(props, () -> mockClient);
 
     Config result = validator.validate();
     assertNoErrors(result);
@@ -105,7 +105,7 @@ public class ValidatorTest {
     // both set
     props.put(CONNECTION_USERNAME_CONFIG, "username");
     props.put(CONNECTION_PASSWORD_CONFIG, "password");
-    validator = new Validator(props, mockClient);
+    validator = new Validator(props, () -> mockClient);
 
     result = validator.validate();
     assertNoErrors(result);
@@ -117,7 +117,7 @@ public class ValidatorTest {
     props.put(IGNORE_KEY_TOPICS_CONFIG, "some,topics");
     props.put(IGNORE_SCHEMA_CONFIG, "true");
     props.put(IGNORE_SCHEMA_TOPICS_CONFIG, "some,other,topics");
-    validator = new Validator(props, mockClient);
+    validator = new Validator(props, () -> mockClient);
 
     Config result = validator.validate();
     assertHasErrorMessage(result, IGNORE_KEY_CONFIG, "is true");
@@ -131,7 +131,7 @@ public class ValidatorTest {
     // topics configs not set
     props.put(IGNORE_KEY_CONFIG, "true");
     props.put(IGNORE_SCHEMA_CONFIG, "true");
-    validator = new Validator(props, mockClient);
+    validator = new Validator(props, () -> mockClient);
 
     Config result = validator.validate();
     assertNoErrors(result);
@@ -141,7 +141,7 @@ public class ValidatorTest {
     props.put(IGNORE_KEY_TOPICS_CONFIG, "some,topics");
     props.put(IGNORE_SCHEMA_CONFIG, "false");
     props.put(IGNORE_SCHEMA_TOPICS_CONFIG, "some,other,topics");
-    validator = new Validator(props, mockClient);
+    validator = new Validator(props, () -> mockClient);
 
     result = validator.validate();
     assertNoErrors(result);
@@ -150,7 +150,7 @@ public class ValidatorTest {
   @Test
   public void testInvalidKerberos() throws IOException {
     props.put(KERBEROS_PRINCIPAL_CONFIG, "principal");
-    validator = new Validator(props, mockClient);
+    validator = new Validator(props, () -> mockClient);
 
     Config result = validator.validate();
     assertHasErrorMessage(result, KERBEROS_PRINCIPAL_CONFIG, "must be set");
@@ -161,7 +161,7 @@ public class ValidatorTest {
     props.put(KERBEROS_PRINCIPAL_CONFIG, "principal");
     props.put(KERBEROS_KEYTAB_PATH_CONFIG, keytab.toString());
     props.put(PROXY_HOST_CONFIG, "proxy.com");
-    validator = new Validator(props, mockClient);
+    validator = new Validator(props, () -> mockClient);
 
     result = validator.validate();
     assertHasErrorMessage(result, KERBEROS_PRINCIPAL_CONFIG, "not supported with proxy settings");
@@ -172,7 +172,7 @@ public class ValidatorTest {
     props.remove(PROXY_HOST_CONFIG);
     props.put(CONNECTION_USERNAME_CONFIG, "username");
     props.put(CONNECTION_PASSWORD_CONFIG, "password");
-    validator = new Validator(props, mockClient);
+    validator = new Validator(props, () -> mockClient);
 
     result = validator.validate();
     assertHasErrorMessage(result, KERBEROS_PRINCIPAL_CONFIG, "Either only Kerberos");
@@ -186,7 +186,7 @@ public class ValidatorTest {
   @Test
   public void testValidKerberos() throws IOException {
     // kerberos configs not set
-    validator = new Validator(props, mockClient);
+    validator = new Validator(props, () -> mockClient);
 
     Config result = validator.validate();
     assertNoErrors(result);
@@ -195,7 +195,7 @@ public class ValidatorTest {
     Path keytab = Files.createTempFile("es", ".keytab");
     props.put(KERBEROS_PRINCIPAL_CONFIG, "principal");
     props.put(KERBEROS_KEYTAB_PATH_CONFIG, keytab.toString());
-    validator = new Validator(props, mockClient);
+    validator = new Validator(props, () -> mockClient);
 
     result = validator.validate();
     assertNoErrors(result);
@@ -206,7 +206,7 @@ public class ValidatorTest {
   public void testInvalidLingerMs() {
     props.put(LINGER_MS_CONFIG, "1001");
     props.put(FLUSH_TIMEOUT_MS_CONFIG, "1000");
-    validator = new Validator(props, mockClient);
+    validator = new Validator(props, () -> mockClient);
 
     Config result = validator.validate();
     assertHasErrorMessage(result, LINGER_MS_CONFIG, "can not be larger than");
@@ -217,7 +217,7 @@ public class ValidatorTest {
   public void testValidLingerMs() {
     props.put(LINGER_MS_CONFIG, "999");
     props.put(FLUSH_TIMEOUT_MS_CONFIG, "1000");
-    validator = new Validator(props, mockClient);
+    validator = new Validator(props, () -> mockClient);
 
     Config result = validator.validate();
     assertNoErrors(result);
@@ -228,7 +228,7 @@ public class ValidatorTest {
     props.put(MAX_BUFFERED_RECORDS_CONFIG, "1");
     props.put(BATCH_SIZE_CONFIG, "2");
     props.put(MAX_IN_FLIGHT_REQUESTS_CONFIG, "2");
-    validator = new Validator(props, mockClient);
+    validator = new Validator(props, () -> mockClient);
 
     Config result = validator.validate();
     assertHasErrorMessage(result, MAX_BUFFERED_RECORDS_CONFIG, "must be larger than or equal to");
@@ -241,7 +241,7 @@ public class ValidatorTest {
     props.put(MAX_BUFFERED_RECORDS_CONFIG, "5");
     props.put(BATCH_SIZE_CONFIG, "2");
     props.put(MAX_IN_FLIGHT_REQUESTS_CONFIG, "2");
-    validator = new Validator(props, mockClient);
+    validator = new Validator(props, () -> mockClient);
 
     Config result = validator.validate();
     assertNoErrors(result);
@@ -252,7 +252,7 @@ public class ValidatorTest {
     props.put(PROXY_HOST_CONFIG, "");
     props.put(PROXY_USERNAME_CONFIG, "username");
     props.put(PROXY_PASSWORD_CONFIG, "password");
-    validator = new Validator(props, mockClient);
+    validator = new Validator(props, () -> mockClient);
 
     Config result = validator.validate();
     assertHasErrorMessage(result, PROXY_HOST_CONFIG, " must be set to use");
@@ -263,7 +263,7 @@ public class ValidatorTest {
 
     props.put(PROXY_HOST_CONFIG, "proxy");
     props.put(PROXY_PASSWORD_CONFIG, "password");
-    validator = new Validator(props, mockClient);
+    validator = new Validator(props, () -> mockClient);
 
     result = validator.validate();
     assertHasErrorMessage(result, PROXY_USERNAME_CONFIG, "Either both or neither");
@@ -273,7 +273,7 @@ public class ValidatorTest {
   @Test
   public void testValidProxy() {
     props.put(PROXY_HOST_CONFIG, "proxy");
-    validator = new Validator(props, mockClient);
+    validator = new Validator(props, () -> mockClient);
 
     Config result = validator.validate();
     assertNoErrors(result);
@@ -281,7 +281,7 @@ public class ValidatorTest {
     props.put(PROXY_HOST_CONFIG, "proxy");
     props.put(PROXY_USERNAME_CONFIG, "password");
     props.put(PROXY_PASSWORD_CONFIG, "password");
-    validator = new Validator(props, mockClient);
+    validator = new Validator(props, () -> mockClient);
 
     result = validator.validate();
     assertNoErrors(result);
@@ -291,7 +291,7 @@ public class ValidatorTest {
   public void testInvalidSsl() {
     // no SSL
     props.put(SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SSL.name());
-    validator = new Validator(props, mockClient);
+    validator = new Validator(props, () -> mockClient);
 
     Config result = validator.validate();
     assertHasErrorMessage(result, SECURITY_PROTOCOL_CONFIG, "At least these SSL configs ");
@@ -302,7 +302,7 @@ public class ValidatorTest {
     props.put(SSL_CONFIG_PREFIX + SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, "b");
     props.put(SSL_CONFIG_PREFIX + SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, "c");
     props.put(SSL_CONFIG_PREFIX + SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, "d");
-    validator = new Validator(props, mockClient);
+    validator = new Validator(props, () -> mockClient);
 
     result = validator.validate();
     assertHasErrorMessage(result, SECURITY_PROTOCOL_CONFIG, "to use SSL configs");
@@ -312,7 +312,7 @@ public class ValidatorTest {
   public void testValidSsl() {
     // no SSL
     props.put(SECURITY_PROTOCOL_CONFIG, SecurityProtocol.PLAINTEXT.name());
-    validator = new Validator(props, mockClient);
+    validator = new Validator(props, () -> mockClient);
 
     Config result = validator.validate();
     assertNoErrors(result);
@@ -323,7 +323,7 @@ public class ValidatorTest {
     props.put(SSL_CONFIG_PREFIX + SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, "b");
     props.put(SSL_CONFIG_PREFIX + SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, "c");
     props.put(SSL_CONFIG_PREFIX + SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, "d");
-    validator = new Validator(props, mockClient);
+    validator = new Validator(props, () -> mockClient);
 
     result = validator.validate();
     assertNoErrors(result);
@@ -331,7 +331,7 @@ public class ValidatorTest {
 
   @Test
   public void testValidConnection() {
-    validator = new Validator(props, mockClient);
+    validator = new Validator(props, () -> mockClient);
 
     Config result = validator.validate();
     assertNoErrors(result);
@@ -340,10 +340,19 @@ public class ValidatorTest {
   @Test
   public void testInvalidConnection() throws IOException {
     when(mockClient.ping(eq(RequestOptions.DEFAULT))).thenReturn(false);
-    validator = new Validator(props, mockClient);
+    validator = new Validator(props, () -> mockClient);
 
     Config result = validator.validate();
-    assertHasErrorMessage(result, CONNECTION_URL_CONFIG, "Could not connect to Elasticsearch due to");
+    assertHasErrorMessage(result, CONNECTION_URL_CONFIG, "Could not connect to Elasticsearch.");
+  }
+
+  @Test
+  public void testInvalidConnectionThrows() throws IOException {
+    when(mockClient.ping(eq(RequestOptions.DEFAULT))).thenThrow(new IOException("i iz fake"));
+    validator = new Validator(props, () -> mockClient);
+
+    Config result = validator.validate();
+    assertHasErrorMessage(result, CONNECTION_URL_CONFIG, "Could not connect to Elasticsearch.");
   }
 
   private static void assertHasErrorMessage(Config config, String property, String msg) {


### PR DESCRIPTION
Signed-off-by: Lev Zemlyanov <lev@confluent.io>

## Problem
we are missing a validator whether the ES service is available

## Solution
add a validator by pinging ES

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
add unit tests testing the validator, existing ITs also run the added code

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
backport to `11.0.x` where this validaator should be added