### PR TITLE
CCMSG-835, CCMSG-834: Update outdated commons-codec to fix CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
             <artifactId>httpclient</artifactId>
             <version>4.5.13</version>
         </dependency>
-        <!-- force commons-codec version to address CVE CCMSG-835 -->
+        <!-- Override httpClient transitive dependency commons-codec version to address CVE CCMSG-835 -->
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
             <artifactId>httpclient</artifactId>
             <version>4.5.13</version>
         </dependency>
-        <!-- Override httpClient transitive dependency commons-codec version to address CVE CCMSG-835 -->
+        <!-- Force commons-codec (httpclient transitive dependency) version to address CVE CCMSG-835 -->
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,18 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>4.5.13</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- force commons-codec version to address CVE CCMSG-835 -->
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.15</version>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -77,12 +77,6 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>4.5.13</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-codec</groupId>
-                    <artifactId>commons-codec</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <!-- force commons-codec version to address CVE CCMSG-835 -->
         <dependency>


### PR DESCRIPTION
## Problem
Shown by the mvn dependency:tree command, the httpclient dependency drags in commons-codec to 1.11, which is marked by twistlock as a vulnerability

## Solution
Exclude the dependency from httpclient, and bump to the latest version (1.15).

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?
It also applies to 5.5.x, so but it should be fixed in the backport of this PR.

## Test Strategy
mvn verify and mvn integration-test to make sure nothing broke

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
targeting 5.4.x