### PR TITLE
CCMSG-920: add retries to bulk requests

### DIFF
--- a/src/test/java/io/confluent/connect/elasticsearch/helper/NetworkErrorContainer.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/helper/NetworkErrorContainer.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.elasticsearch.helper;
+
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+public class NetworkErrorContainer extends GenericContainer<NetworkErrorContainer> {
+
+  private static final String DEFAULT_DOCKER_IMAGE = "gaiaadm/pumba:latest";
+
+  private static final String PUMBA_PAUSE_COMMAND = "--log-level info --interval 120s pause --duration 10s ";
+  private static final String DOCKER_SOCK = "/var/run/docker.sock";
+
+  public NetworkErrorContainer(String containerToInterrupt) {
+    this(DEFAULT_DOCKER_IMAGE, containerToInterrupt);
+  }
+
+  public NetworkErrorContainer(
+      String dockerImageName,
+      String containerToInterrupt
+  ) {
+    super(dockerImageName);
+
+    setCommand(PUMBA_PAUSE_COMMAND + containerToInterrupt);
+    addFileSystemBind(DOCKER_SOCK, DOCKER_SOCK, BindMode.READ_WRITE);
+    setWaitStrategy(Wait.forLogMessage(".*pausing container.*", 1));
+    withLogConsumer(l -> System.out.print(l.getUtf8String()));
+  }
+}

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorKerberosWithSslIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorKerberosWithSslIT.java
@@ -1,11 +1,8 @@
 package io.confluent.connect.elasticsearch.integration;
 
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_PASSWORD_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_URL_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_USERNAME_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SECURITY_PROTOCOL_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SSL_CONFIG_PREFIX;
-import static io.confluent.connect.elasticsearch.helper.ElasticsearchContainer.ELASTIC_PASSWORD;
 
 import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig;
 import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SecurityProtocol;


### PR DESCRIPTION
Signed-off-by: Lev Zemlyanov <lev@confluent.io>

## Problem
the retries provided by Elasticsearch client are not adequate enough to cover network errors
https://github.com/elastic/elasticsearch/issues/71159

## Solution
implement retries for network errors
if a bulkrequest fails, then retry it in the same request thread 

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
add a test that adds a network delay to the ES container and make sure the client is still able to write

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
backport to `11.0.x` since this is a regression