### PR TITLE
CCMSG-965: Add necessary configs for Elasticsearch datastreams

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -798,7 +798,7 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   }
 
   public boolean isDataStream() {
-    return dataStreamType() != DataStreamType.NONE && !dataStreamDataset().equals("");
+    return dataStreamType() != DataStreamType.NONE && !dataStreamDataset().isEmpty();
   }
 
   public boolean isProxyWithAuthenticationConfigured() {

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -1004,7 +1004,7 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
 
     @Override
     public String toString() {
-      return "A valid dataset name that is all lowercase, less than 100 characters and "
+      return "A valid dataset name that is all lowercase, less than 100 characters, and "
           + "does not contain any spaces or invalid characters \\/*?\"<>|,#-:";
     }
   }

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -87,21 +87,26 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
       "Generic name describing data ingested and its structure to be written to a data stream. "
       + "Can be any arbitrary string that is no longer than 100 characters, is in all lowercase, "
       + "and does not contain spaces or any of these special characters ``/\\*\"<>|,#:-``. "
-      + "Otherwise, no value indicates the connector will write "
-      + "to regular indices instead. If filled, this configuration will be used alongside "
-      + "``data.stream.type`` to construct the index name.";
+      + "Otherwise, no value indicates the connector will write to regular indices instead. "
+      + "If specified, this configuration will be used alongside ``data.stream.type`` to "
+      + "construct the datas stream name in the form of {``data.stream.type``"
+      + "}-{" + DATA_STREAM_DATASET_CONFIG + "}-{namespace}.";
   private static final String DATA_STREAM_DATASET_DISPLAY = "Data stream dataset";
   private static final String DATA_STREAM_DATASET_DEFAULT = "";
 
   public static final String DATA_STREAM_TYPE_CONFIG = "data.stream.type";
-  private static final String DATA_STREAM_TYPE_DOC =
+  private static final String DATA_STREAM_TYPE_DOC = String.format(
       "Generic type describing the data to be written to data stream. "
-      + "Should only be ``" + DataStreamType.LOGS.name() + "`` or ``"
-      + DataStreamType.METRICS.name() + "`` if the user wants to write "
-      + "to data stream. Otherwise, the default is" + DataStreamType.NONE.name()
-      + " which indicates the connector will write to regular indices instead. "
-      + "If set, this configuration will be used alongside " + DATA_STREAM_DATASET_CONFIG
-      + " to construct the index name.";
+          + "The default is %s which indicates the connector will write "
+          + "to regular indices instead. If set, this configuration will "
+          + "be used alongside %s to construct the data stream name in the form "
+          + "{%s}-{%s}-{namespace}.",
+      DataStreamType.NONE.name(),
+      DATA_STREAM_DATASET_CONFIG,
+      DATA_STREAM_TYPE_CONFIG,
+      DATA_STREAM_DATASET_CONFIG
+  );
+
   private static final String DATA_STREAM_TYPE_DISPLAY = "Data Stream Type";
   private static final DataStreamType DATA_STREAM_TYPE_DEFAULT = DataStreamType.NONE;
 

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -84,15 +84,15 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
 
   public static final String DATA_STREAM_DATASET_CONFIG = "data.stream.dataset";
   private static final String DATA_STREAM_DATASET_DOC =
-      "Generic name describing data ingested and its structure." +
-          " The default is generic, which is the same as Elastic's default.";
+      "Generic name describing data ingested and its structure."
+      + " The default is generic, which is the same as Elastic's default.";
   private static final String DATA_STREAM_DATASET_DISPLAY = "Data stream dataset";
   private static final String DATA_STREAM_DATASET_DEFAULT = null;
 
   public static final String DATA_STREAM_TYPE_CONFIG = "data.stream.type";
   private static final String DATA_STREAM_TYPE_DOC =
-      "Generic type describing the data to be written to Elasticsearch Datastreams." +
-          " The default is logs, which is the same as Elastic's default.";
+      "Generic type describing the data to be written to Elasticsearch Datastreams."
+      + " The default is logs, which is the same as Elastic's default.";
   private static final String DATA_STREAM_TYPE_DISPLAY = "Data stream type";
   private static final DataStreamType DATA_STREAM_TYPE_DEFAULT = DataStreamType.NONE;
 
@@ -963,16 +963,28 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
       }
 
       if (((String) value).length() >= 100) {
-        throw new ConfigException(name, value, "The specified dataset must be less than 100 characters.");
+        throw new ConfigException(
+            name,
+            value,
+            "The specified dataset must be less than 100 characters."
+        );
       }
 
       if (!value.equals(((String) value).toLowerCase())) {
-        throw new ConfigException(name, value, "The specified dataset must be in lowercase.");
+        throw new ConfigException(
+            name,
+            value,
+            "The specified dataset must be in lowercase."
+        );
       }
 
       if (((String) value).matches(".*[\\\\\\/\\*\\?\\\"<>| ,#\\-:]+.*")) {
-        throw new ConfigException(name, value, "The specified dataset contains a space or at least one invalid character" +
-            "\\/*?\"<>|,#-:");
+        throw new ConfigException(
+            name,
+            value,
+            "The specified dataset contains a space or at least one invalid character"
+            + "\\/*?\"<>|,#-:"
+        );
       }
     }
 

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -968,9 +968,9 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
 
       if (!value.equals(((String) value).toLowerCase())) {
         throw new ConfigException(name, value, "The specified dataset must be in lowercase.");
-      }// can I just do warning instead???
+      }
 
-      if (((String) value).matches(".*[\\/\\\\\\*\\?\"<>| ,#-:]+.*")) {
+      if (((String) value).matches(".*[\\\\\\/\\*\\?\\\"<>| ,#\\-:]+.*")) {
         throw new ConfigException(name, value, "The specified dataset contains invalid characters.");
       }
     }

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -1001,7 +1001,8 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
 
     @Override
     public String toString() {
-      return "A valid dataset name that is less than 100 characters and does not contain any spaces or invalid characters \\/*?\"<>|,#-:";
+      return "A valid dataset name that is less than 100 characters and "
+          + "does not contain any spaces or invalid characters \\/*?\"<>|,#-:";
     }
   }
 

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -797,6 +797,10 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
     return !getString(PROXY_HOST_CONFIG).isEmpty();
   }
 
+  public boolean isDataStream() {
+    return dataStreamType() != DataStreamType.NONE && !dataStreamDataset().equals("");
+  }
+
   public boolean isProxyWithAuthenticationConfigured() {
     return isBasicProxyConfigured()
         && !getString(PROXY_USERNAME_CONFIG).isEmpty()

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -84,15 +84,24 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
 
   public static final String DATA_STREAM_DATASET_CONFIG = "data.stream.dataset";
   private static final String DATA_STREAM_DATASET_DOC =
-      "Generic name describing data ingested and its structure."
-      + " The default is generic, which is the same as Elastic's default.";
+      "Generic name describing data ingested and its structure to be written to data stream. "
+      + "Can be any arbitrary string that is less than 100 characters, is in all lowercase, "
+      + "and does not contain spaces or any of these special characters ``/\\*\"<>|,#:-``. "
+      + "Otherwise, the default is ``null`` which indicates the connector will write "
+      + "to regular indices instead. If filled, this configuration will be used alongside "
+      + "``data.stream.type`` to construct the index name.";
   private static final String DATA_STREAM_DATASET_DISPLAY = "Data stream dataset";
   private static final String DATA_STREAM_DATASET_DEFAULT = null;
 
   public static final String DATA_STREAM_TYPE_CONFIG = "data.stream.type";
   private static final String DATA_STREAM_TYPE_DOC =
-      "Generic type describing the data to be written to Elasticsearch Datastreams."
-      + " The default is logs, which is the same as Elastic's default.";
+      "Generic type describing the data to be written to data stream. "
+      + "Should only be ``" + DataStreamType.LOGS.name() + "`` or ``"
+      + DataStreamType.METRICS.name() + "`` if the user wants to write "
+      + "to data stream. Otherwise, the default is" + DataStreamType.NONE.name()
+      + " which indicates the connector will write to regular indices instead. "
+      + "If set, this configuration will be used alongside " + DATA_STREAM_DATASET_CONFIG
+      + " to construct the index name.";
   private static final String DATA_STREAM_TYPE_DISPLAY = "Data stream type";
   private static final DataStreamType DATA_STREAM_TYPE_DEFAULT = DataStreamType.NONE;
 

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -973,9 +973,7 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
 
       if (((String) value).length() >= 100) {
         throw new ConfigException(
-            name,
-            value,
-            "The specified dataset must be less than 100 characters."
+            name, value, "The specified dataset must be less than 100 characters."
         );
       }
 

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -980,18 +980,13 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
       }
 
       if (!value.equals(((String) value).toLowerCase())) {
-        throw new ConfigException(
-            name,
-            value,
-            "The specified dataset must be in lowercase."
-        );
+        throw new ConfigException(name, value, "The specified dataset must be in lowercase.");
       }
 
       if (((String) value).matches(".*[\\\\\\/\\*\\?\\\"<>| ,#\\-:]+.*")) {
         throw new ConfigException(
-            name,
-            value,
-            "The specified dataset contains a space or at least one invalid character"
+            name, value,
+            "The specified dataset contains a space or at least one invalid character "
             + "\\/*?\"<>|,#-:"
         );
       }

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -88,8 +88,8 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
       + "Can be any arbitrary string that is no longer than 100 characters, is in all lowercase, "
       + "and does not contain spaces or any of these special characters ``/\\*\"<>|,#:-``. "
       + "Otherwise, no value indicates the connector will write to regular indices instead. "
-      + "If specified, this configuration will be used alongside ``data.stream.type`` to "
-      + "construct the datas stream name in the form of {``data.stream.type``"
+      + "If set, this configuration will be used alongside ``data.stream.type`` to "
+      + "construct the data stream name in the form of {``data.stream.type``"
       + "}-{" + DATA_STREAM_DATASET_CONFIG + "}-{namespace}.";
   private static final String DATA_STREAM_DATASET_DISPLAY = "Data stream dataset";
   private static final String DATA_STREAM_DATASET_DEFAULT = "";
@@ -99,7 +99,7 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
       "Generic type describing the data to be written to data stream. "
           + "The default is %s which indicates the connector will write "
           + "to regular indices instead. If set, this configuration will "
-          + "be used alongside %s to construct the data stream name in the form "
+          + "be used alongside %s to construct the data stream name in the form of"
           + "{%s}-{%s}-{namespace}.",
       DataStreamType.NONE.name(),
       DATA_STREAM_DATASET_CONFIG,

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -971,7 +971,8 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
       }
 
       if (((String) value).matches(".*[\\\\\\/\\*\\?\\\"<>| ,#\\-:]+.*")) {
-        throw new ConfigException(name, value, "The specified dataset contains invalid characters.");
+        throw new ConfigException(name, value, "The specified dataset contains a space or at least one invalid character" +
+            "\\/*?\"<>|,#-:");
       }
     }
 

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -971,19 +971,21 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
         return;
       }
 
-      if (((String) value).length() > 100) {
+      String dataset = (String) value;
+
+      if (dataset.length() > 100) {
         throw new ConfigException(
             name, value, "The specified dataset must be no longer than 100 characters."
         );
       }
 
-      if (!value.equals(((String) value).toLowerCase())) {
+      if (!value.equals(dataset.toLowerCase())) {
         throw new ConfigException(
             name, value, "The specified dataset must be in all lowercase."
         );
       }
 
-      if (((String) value).matches(".*[\\\\\\/\\*\\?\\\"<>| ,#\\-:]+.*")) {
+      if (dataset.matches(".*[\\\\\\/\\*\\?\\\"<>| ,#\\-:]+.*")) {
         throw new ConfigException(
             name, value,
             "The specified dataset must not contain any spaces or "

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -962,7 +962,7 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
         return;
       }
 
-      if (((String) value).length() > 100) {
+      if (((String) value).length() >= 100) {
         throw new ConfigException(name, value, "The specified dataset must be less than 100 characters.");
       }
 

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -978,14 +978,16 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
       }
 
       if (!value.equals(((String) value).toLowerCase())) {
-        throw new ConfigException(name, value, "The specified dataset must be in lowercase.");
+        throw new ConfigException(
+            name, value, "The specified dataset must be in lowercase."
+        );
       }
 
       if (((String) value).matches(".*[\\\\\\/\\*\\?\\\"<>| ,#\\-:]+.*")) {
         throw new ConfigException(
             name, value,
-            "The specified dataset contains a space or at least one invalid character "
-            + "\\/*?\"<>|,#-:"
+            "The specified dataset contains a space or at least one "
+            + "invalid character \\/*?\"<>|,#-:"
         );
       }
     }

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -90,8 +90,8 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
       + "Otherwise, no value indicates the connector will write to regular indices instead. "
       + "If set, this configuration will be used alongside ``data.stream.type`` to "
       + "construct the data stream name in the form of {``data.stream.type``"
-      + "}-{" + DATA_STREAM_DATASET_CONFIG + "}-{namespace}.";
-  private static final String DATA_STREAM_DATASET_DISPLAY = "Data stream dataset";
+      + "}-{" + DATA_STREAM_DATASET_CONFIG + "}-{topic}.";
+  private static final String DATA_STREAM_DATASET_DISPLAY = "Data Stream Dataset";
   private static final String DATA_STREAM_DATASET_DEFAULT = "";
 
   public static final String DATA_STREAM_TYPE_CONFIG = "data.stream.type";
@@ -100,13 +100,12 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
           + "The default is %s which indicates the connector will write "
           + "to regular indices instead. If set, this configuration will "
           + "be used alongside %s to construct the data stream name in the form of"
-          + "{%s}-{%s}-{namespace}.",
+          + "{%s}-{%s}-{topic}.",
       DataStreamType.NONE.name(),
       DATA_STREAM_DATASET_CONFIG,
       DATA_STREAM_TYPE_CONFIG,
       DATA_STREAM_DATASET_CONFIG
   );
-
   private static final String DATA_STREAM_TYPE_DISPLAY = "Data Stream Type";
   private static final DataStreamType DATA_STREAM_TYPE_DEFAULT = DataStreamType.NONE;
 
@@ -1001,7 +1000,7 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
 
     @Override
     public String toString() {
-      return "A valid dataset name that is less than 100 characters and "
+      return "A valid dataset name that is all lowercase, less than 100 characters and "
           + "does not contain any spaces or invalid characters \\/*?\"<>|,#-:";
     }
   }

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -85,7 +85,7 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   public static final String DATA_STREAM_DATASET_CONFIG = "data.stream.dataset";
   private static final String DATA_STREAM_DATASET_DOC =
       "Generic name describing data ingested and its structure to be written to data stream. "
-      + "Can be any arbitrary string that is less than 100 characters, is in all lowercase, "
+      + "Can be any arbitrary string that is no longer than 100 characters, is in all lowercase, "
       + "and does not contain spaces or any of these special characters ``/\\*\"<>|,#:-``. "
       + "Otherwise, the default is ``null`` which indicates the connector will write "
       + "to regular indices instead. If filled, this configuration will be used alongside "
@@ -971,9 +971,9 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
         return;
       }
 
-      if (((String) value).length() >= 100) {
+      if (((String) value).length() > 100) {
         throw new ConfigException(
-            name, value, "The specified dataset must be less than 100 characters."
+            name, value, "The specified dataset must no longer than 100 characters."
         );
       }
 

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -84,14 +84,14 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
 
   public static final String DATA_STREAM_DATASET_CONFIG = "data.stream.dataset";
   private static final String DATA_STREAM_DATASET_DOC =
-      "Generic name describing data ingested and its structure to be written to data stream. "
+      "Generic name describing data ingested and its structure to be written to a data stream. "
       + "Can be any arbitrary string that is no longer than 100 characters, is in all lowercase, "
       + "and does not contain spaces or any of these special characters ``/\\*\"<>|,#:-``. "
-      + "Otherwise, the default is ``null`` which indicates the connector will write "
+      + "Otherwise, no value indicates the connector will write "
       + "to regular indices instead. If filled, this configuration will be used alongside "
       + "``data.stream.type`` to construct the index name.";
   private static final String DATA_STREAM_DATASET_DISPLAY = "Data stream dataset";
-  private static final String DATA_STREAM_DATASET_DEFAULT = null;
+  private static final String DATA_STREAM_DATASET_DEFAULT = "";
 
   public static final String DATA_STREAM_TYPE_CONFIG = "data.stream.type";
   private static final String DATA_STREAM_TYPE_DOC =
@@ -102,7 +102,7 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
       + " which indicates the connector will write to regular indices instead. "
       + "If set, this configuration will be used alongside " + DATA_STREAM_DATASET_CONFIG
       + " to construct the index name.";
-  private static final String DATA_STREAM_TYPE_DISPLAY = "Data stream type";
+  private static final String DATA_STREAM_TYPE_DISPLAY = "Data Stream Type";
   private static final DataStreamType DATA_STREAM_TYPE_DEFAULT = DataStreamType.NONE;
 
   public static final String MAX_IN_FLIGHT_REQUESTS_CONFIG = "max.in.flight.requests";
@@ -973,28 +973,28 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
 
       if (((String) value).length() > 100) {
         throw new ConfigException(
-            name, value, "The specified dataset must no longer than 100 characters."
+            name, value, "The specified dataset must be no longer than 100 characters."
         );
       }
 
       if (!value.equals(((String) value).toLowerCase())) {
         throw new ConfigException(
-            name, value, "The specified dataset must be in lowercase."
+            name, value, "The specified dataset must be in all lowercase."
         );
       }
 
       if (((String) value).matches(".*[\\\\\\/\\*\\?\\\"<>| ,#\\-:]+.*")) {
         throw new ConfigException(
             name, value,
-            "The specified dataset contains a space or at least one "
-            + "invalid character \\/*?\"<>|,#-:"
+            "The specified dataset must not contain any spaces or "
+            + "invalid characters \\/*?\"<>|,#-:"
         );
       }
     }
 
     @Override
     public String toString() {
-      return "Valid Data stream dataset name.";
+      return "A valid dataset name that is less than 100 characters and does not contain any spaces or invalid characters \\/*?\"<>|,#-:";
     }
   }
 

--- a/src/main/java/io/confluent/connect/elasticsearch/Validator.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/Validator.java
@@ -95,7 +95,7 @@ public class Validator {
 
     try (RestHighLevelClient client = clientFactory.client()) {
       validateCredentials();
-      validateDataStreamFields();
+      validateDataStreamConfigs();
       validateIgnoreConfigs();
       validateKerberos();
       validateLingerMs();
@@ -125,7 +125,7 @@ public class Validator {
     }
   }
 
-  private void validateDataStreamFields() {
+  private void validateDataStreamConfigs() {
     if (config.dataStreamType() == DataStreamType.NONE ^ config.dataStreamDataset().equals("")) {
       String errorMessage = String.format(
           "Either both or neither '%s' and '%s' must be set.",
@@ -135,10 +135,8 @@ public class Validator {
       addErrorMessage(DATA_STREAM_TYPE_CONFIG, errorMessage);
       addErrorMessage(DATA_STREAM_DATASET_CONFIG, errorMessage);
     }
-    boolean atLeastOneSet = config.dataStreamType() != DataStreamType.NONE
-        || !config.dataStreamDataset().equals("");
 
-    if (atLeastOneSet && config.writeMethod() == WriteMethod.UPSERT) {
+    if (config.isDataStream() && config.writeMethod() == WriteMethod.UPSERT) {
       String errorMessage = String.format(
           "Upserts are not supported with data streams. %s must not be %s if %s and %s are set.",
           WRITE_METHOD_CONFIG,
@@ -149,7 +147,7 @@ public class Validator {
       addErrorMessage(WRITE_METHOD_CONFIG, errorMessage);
     }
 
-    if (atLeastOneSet && config.behaviorOnNullValues() == BehaviorOnNullValues.DELETE) {
+    if (config.isDataStream() && config.behaviorOnNullValues() == BehaviorOnNullValues.DELETE) {
       String errorMessage = String.format(
           "Deletes are not supported with data streams. %s must not be %s if %s and %s are set.",
           BEHAVIOR_ON_NULL_VALUES_CONFIG,

--- a/src/main/java/io/confluent/connect/elasticsearch/Validator.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/Validator.java
@@ -124,7 +124,7 @@ public class Validator {
   private void validateDataStreamFields() {
     if (config.dataStreamType() == DataStreamType.NONE ^ config.dataStreamDataset() == null) {
       String errorMessage = String.format(
-          "'%s' must be set if '%s' is set.", DATA_STREAM_DATASET_CONFIG, DATA_STREAM_TYPE_CONFIG
+          "Either both or neither '%s' and '%s' must be set.", DATA_STREAM_DATASET_CONFIG, DATA_STREAM_TYPE_CONFIG
       );
       addErrorMessage(DATA_STREAM_TYPE_CONFIG, errorMessage);
       addErrorMessage(DATA_STREAM_DATASET_CONFIG, errorMessage);

--- a/src/main/java/io/confluent/connect/elasticsearch/Validator.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/Validator.java
@@ -140,7 +140,7 @@ public class Validator {
 
     if (atLeastOneSet && config.writeMethod() == WriteMethod.UPSERT) {
       String errorMessage = String.format(
-          "%s must not be %s if %s and %s are set.",
+          "Upserts are not supported with data streams. %s must not be %s if %s and %s are set.",
           WRITE_METHOD_CONFIG,
           WriteMethod.UPSERT,
           DATA_STREAM_TYPE_CONFIG,
@@ -151,7 +151,7 @@ public class Validator {
 
     if (atLeastOneSet && config.behaviorOnNullValues() == BehaviorOnNullValues.DELETE) {
       String errorMessage = String.format(
-          "%s must not be %s if %s and %s are set.",
+          "Deletes are not supported with data streams. %s must not be %s if %s and %s are set.",
           BEHAVIOR_ON_NULL_VALUES_CONFIG,
           BehaviorOnNullValues.DELETE,
           DATA_STREAM_TYPE_CONFIG,

--- a/src/main/java/io/confluent/connect/elasticsearch/Validator.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/Validator.java
@@ -37,6 +37,9 @@ import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfi
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_PASSWORD_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_URL_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_USERNAME_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_DATASET_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_TYPE_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DataStreamType;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.FLUSH_TIMEOUT_MS_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_KEY_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_KEY_TOPICS_CONFIG;
@@ -88,6 +91,7 @@ public class Validator {
 
     try (RestHighLevelClient client = clientFactory.client()) {
       validateCredentials();
+      validateDataStreamFields();
       validateIgnoreConfigs();
       validateKerberos();
       validateLingerMs();
@@ -114,6 +118,16 @@ public class Validator {
       );
       addErrorMessage(CONNECTION_USERNAME_CONFIG, errorMessage);
       addErrorMessage(CONNECTION_PASSWORD_CONFIG, errorMessage);
+    }
+  }
+
+  private void validateDataStreamFields() {
+    if (config.dataStreamType() == DataStreamType.NONE ^ config.dataStreamDataset() == null) {
+      String errorMessage = String.format(
+          "'%s' must be set if '%s' is set.", DATA_STREAM_DATASET_CONFIG, DATA_STREAM_TYPE_CONFIG
+      );
+      addErrorMessage(DATA_STREAM_TYPE_CONFIG, errorMessage);
+      addErrorMessage(DATA_STREAM_DATASET_CONFIG, errorMessage);
     }
   }
 

--- a/src/main/java/io/confluent/connect/elasticsearch/Validator.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/Validator.java
@@ -126,7 +126,7 @@ public class Validator {
   }
 
   private void validateDataStreamConfigs() {
-    if (config.dataStreamType() == DataStreamType.NONE ^ config.dataStreamDataset().equals("")) {
+    if (config.dataStreamType() == DataStreamType.NONE ^ config.dataStreamDataset().isEmpty()) {
       String errorMessage = String.format(
           "Either both or neither '%s' and '%s' must be set.",
           DATA_STREAM_DATASET_CONFIG,

--- a/src/main/java/io/confluent/connect/elasticsearch/Validator.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/Validator.java
@@ -33,7 +33,33 @@ import org.elasticsearch.client.RestHighLevelClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.*;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BATCH_SIZE_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BehaviorOnNullValues;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_PASSWORD_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_URL_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_USERNAME_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_DATASET_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_TYPE_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DataStreamType;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.FLUSH_TIMEOUT_MS_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_KEY_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_KEY_TOPICS_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_SCHEMA_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_SCHEMA_TOPICS_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.KERBEROS_KEYTAB_PATH_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.LINGER_MS_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.MAX_BUFFERED_RECORDS_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.MAX_IN_FLIGHT_REQUESTS_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.PROXY_HOST_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.PROXY_PASSWORD_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.PROXY_PORT_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.PROXY_USERNAME_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SECURITY_PROTOCOL_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SSL_CONFIG_PREFIX;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.KERBEROS_PRINCIPAL_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.WRITE_METHOD_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.WriteMethod;
 
 public class Validator {
 
@@ -100,7 +126,7 @@ public class Validator {
   }
 
   private void validateDataStreamFields() {
-    if (config.dataStreamType() == DataStreamType.NONE ^ config.dataStreamDataset() == null) {
+    if (config.dataStreamType() == DataStreamType.NONE ^ config.dataStreamDataset().equals("")) {
       String errorMessage = String.format(
           "Either both or neither '%s' and '%s' must be set.",
           DATA_STREAM_DATASET_CONFIG,
@@ -109,8 +135,10 @@ public class Validator {
       addErrorMessage(DATA_STREAM_TYPE_CONFIG, errorMessage);
       addErrorMessage(DATA_STREAM_DATASET_CONFIG, errorMessage);
     }
-
-    if (config.writeMethod() == WriteMethod.UPSERT) {
+    boolean atLeastOneSet = config.dataStreamType() != DataStreamType.NONE
+        || !config.dataStreamDataset().equals("");
+    System.out.println(atLeastOneSet);
+    if (atLeastOneSet && config.writeMethod() == WriteMethod.UPSERT) {
       String errorMessage = String.format(
           "%s must not be %s if %s and %s are set.",
           WRITE_METHOD_CONFIG,
@@ -121,7 +149,7 @@ public class Validator {
       addErrorMessage(WRITE_METHOD_CONFIG, errorMessage);
     }
 
-    if (config.behaviorOnNullValues() == BehaviorOnNullValues.DELETE) {
+    if (atLeastOneSet && config.behaviorOnNullValues() == BehaviorOnNullValues.DELETE) {
       String errorMessage = String.format(
           "%s must not be %s if %s and %s are set.",
           BEHAVIOR_ON_NULL_VALUES_CONFIG,

--- a/src/main/java/io/confluent/connect/elasticsearch/Validator.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/Validator.java
@@ -137,7 +137,7 @@ public class Validator {
     }
     boolean atLeastOneSet = config.dataStreamType() != DataStreamType.NONE
         || !config.dataStreamDataset().equals("");
-    System.out.println(atLeastOneSet);
+
     if (atLeastOneSet && config.writeMethod() == WriteMethod.UPSERT) {
       String errorMessage = String.format(
           "%s must not be %s if %s and %s are set.",

--- a/src/main/java/io/confluent/connect/elasticsearch/Validator.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/Validator.java
@@ -33,29 +33,7 @@ import org.elasticsearch.client.RestHighLevelClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BATCH_SIZE_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_PASSWORD_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_URL_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_USERNAME_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_DATASET_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_TYPE_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DataStreamType;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.FLUSH_TIMEOUT_MS_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_KEY_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_KEY_TOPICS_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_SCHEMA_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_SCHEMA_TOPICS_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.KERBEROS_KEYTAB_PATH_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.LINGER_MS_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.MAX_BUFFERED_RECORDS_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.MAX_IN_FLIGHT_REQUESTS_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.PROXY_HOST_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.PROXY_PASSWORD_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.PROXY_PORT_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.PROXY_USERNAME_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SECURITY_PROTOCOL_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SSL_CONFIG_PREFIX;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.KERBEROS_PRINCIPAL_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.*;
 
 public class Validator {
 
@@ -124,10 +102,34 @@ public class Validator {
   private void validateDataStreamFields() {
     if (config.dataStreamType() == DataStreamType.NONE ^ config.dataStreamDataset() == null) {
       String errorMessage = String.format(
-          "Either both or neither '%s' and '%s' must be set.", DATA_STREAM_DATASET_CONFIG, DATA_STREAM_TYPE_CONFIG
+          "Either both or neither '%s' and '%s' must be set.",
+          DATA_STREAM_DATASET_CONFIG,
+          DATA_STREAM_TYPE_CONFIG
       );
       addErrorMessage(DATA_STREAM_TYPE_CONFIG, errorMessage);
       addErrorMessage(DATA_STREAM_DATASET_CONFIG, errorMessage);
+    }
+
+    if (config.writeMethod() == WriteMethod.UPSERT) {
+      String errorMessage = String.format(
+          "%s must not be %s if %s and %s are set.",
+          WRITE_METHOD_CONFIG,
+          WriteMethod.UPSERT,
+          DATA_STREAM_TYPE_CONFIG,
+          DATA_STREAM_DATASET_CONFIG
+      );
+      addErrorMessage(WRITE_METHOD_CONFIG, errorMessage);
+    }
+
+    if (config.behaviorOnNullValues() == BehaviorOnNullValues.DELETE) {
+      String errorMessage = String.format(
+          "%s must not be %s if %s and %s are set.",
+          BEHAVIOR_ON_NULL_VALUES_CONFIG,
+          BehaviorOnNullValues.DELETE,
+          DATA_STREAM_TYPE_CONFIG,
+          DATA_STREAM_DATASET_CONFIG
+      );
+      addErrorMessage(BEHAVIOR_ON_NULL_VALUES_CONFIG, errorMessage);
     }
   }
 

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
@@ -2,6 +2,8 @@ package io.confluent.connect.elasticsearch;
 
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_TIMEOUT_MS_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_URL_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_DATASET_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_TYPE_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.KERBEROS_KEYTAB_PATH_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.PROXY_HOST_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.PROXY_PASSWORD_CONFIG;
@@ -52,6 +54,42 @@ public class ElasticsearchSinkConnectorConfigTest {
 
     assertEquals(config.readTimeoutMs(), 10000);
     assertEquals(config.connectionTimeoutMs(), 15000);
+  }
+
+  @Test
+  public void shouldAllowValidChractersDataStreamDataset() {
+    props.put(DATA_STREAM_DATASET_CONFIG, "a_valid.dataset123");
+    new ElasticsearchSinkConnectorConfig(props);
+  }
+
+  @Test
+  public void shouldAllowValidDataStreamType() {
+    props.put(DATA_STREAM_TYPE_CONFIG, "metrics");
+    new ElasticsearchSinkConnectorConfig(props);
+  }
+
+  @Test
+  public void shouldAllowValidDataStreamTypeWithWeirdCasing() {
+    props.put(DATA_STREAM_TYPE_CONFIG, "mEtRICS");
+    new ElasticsearchSinkConnectorConfig(props);
+  }
+
+  @Test(expected = ConfigException.class)
+  public void shouldNotAllowInvalidCasingDataStreamDataset() {
+    props.put(DATA_STREAM_DATASET_CONFIG, "AN_INVALID.dataset123");
+    new ElasticsearchSinkConnectorConfig(props);
+  }
+
+  @Test(expected = ConfigException.class)
+  public void shouldNotAllowInvalidCharactersDataStreamDataset() {
+    props.put(DATA_STREAM_DATASET_CONFIG, "not-valid?");
+    new ElasticsearchSinkConnectorConfig(props);
+  }
+
+  @Test(expected = ConfigException.class)
+  public void shouldNotAllowInvalidDataStreamType() {
+    props.put(DATA_STREAM_TYPE_CONFIG, "notLogOrMetrics");
+    new ElasticsearchSinkConnectorConfig(props);
   }
 
   @Test(expected = ConfigException.class)

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
@@ -69,13 +69,13 @@ public class ElasticsearchSinkConnectorConfigTest {
   }
 
   @Test
-  public void shouldAllowValidDataStreamTypeWithWeirdCasing() {
+  public void shouldAllowValidDataStreamTypeCaseInsensitive) {
     props.put(DATA_STREAM_TYPE_CONFIG, "mEtRICS");
     new ElasticsearchSinkConnectorConfig(props);
   }
 
   @Test(expected = ConfigException.class)
-  public void shouldNotAllowInvalidCasingDataStreamDataset() {
+  public void shouldNotAllowInvalidCaseDataStreamDataset() {
     props.put(DATA_STREAM_DATASET_CONFIG, "AN_INVALID.dataset123");
     new ElasticsearchSinkConnectorConfig(props);
   }
@@ -93,7 +93,7 @@ public class ElasticsearchSinkConnectorConfigTest {
   }
 
   @Test(expected = ConfigException.class)
-  public void shouldNotAllowTooLongDataStreamDataset() {
+  public void shouldNotAllowLongDataStreamDataset() {
     props.put(DATA_STREAM_DATASET_CONFIG, String.format("%d%100d", 1, 1));
     new ElasticsearchSinkConnectorConfig(props);
   }

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
@@ -93,6 +93,12 @@ public class ElasticsearchSinkConnectorConfigTest {
   }
 
   @Test(expected = ConfigException.class)
+  public void shouldNotAllowTooLongDataStreamDataset() {
+    props.put(DATA_STREAM_DATASET_CONFIG, String.format("%d%100d", 1, 1));
+    new ElasticsearchSinkConnectorConfig(props);
+  }
+
+  @Test(expected = ConfigException.class)
   public void shouldNotAllowNullUrlList(){
     props.put(CONNECTION_URL_CONFIG, null);
     new ElasticsearchSinkConnectorConfig(props);

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
@@ -69,7 +69,7 @@ public class ElasticsearchSinkConnectorConfigTest {
   }
 
   @Test
-  public void shouldAllowValidDataStreamTypeCaseInsensitive) {
+  public void shouldAllowValidDataStreamTypeCaseInsensitive() {
     props.put(DATA_STREAM_TYPE_CONFIG, "mEtRICS");
     new ElasticsearchSinkConnectorConfig(props);
   }

--- a/src/test/java/io/confluent/connect/elasticsearch/ValidatorTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ValidatorTest.java
@@ -144,8 +144,6 @@ public class ValidatorTest {
   public void testInvalidUpsertDeleteOnValidDataStreamConfigs() {
     props.put(DATA_STREAM_DATASET_CONFIG, "a_valid_dataset");
     props.put(DATA_STREAM_TYPE_CONFIG, "logs");
-    props.put(BEHAVIOR_ON_NULL_VALUES_CONFIG, "ignore");
-    props.put(WRITE_METHOD_CONFIG, "insert");
     validator = new Validator(props, () -> mockClient);
     Config result = validator.validate();
     assertNoErrors(result);

--- a/src/test/java/io/confluent/connect/elasticsearch/ValidatorTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ValidatorTest.java
@@ -116,7 +116,7 @@ public class ValidatorTest {
   }
 
   @Test
-  public void testInvalidOperationsOnValidDataStreamConfigs() {
+  public void testInvalidUpsertDeleteOnValidDataStreamConfigs() {
     props.put(DATA_STREAM_DATASET_CONFIG, "a_valid_dataset");
     props.put(DATA_STREAM_TYPE_CONFIG, "logs");
     props.put(BEHAVIOR_ON_NULL_VALUES_CONFIG, "ignore");

--- a/src/test/java/io/confluent/connect/elasticsearch/ValidatorTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ValidatorTest.java
@@ -20,6 +20,8 @@ import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfi
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_PASSWORD_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_URL_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_USERNAME_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_DATASET_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_TYPE_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.FLUSH_TIMEOUT_MS_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_KEY_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_KEY_TOPICS_CONFIG;
@@ -109,6 +111,24 @@ public class ValidatorTest {
 
     result = validator.validate();
     assertNoErrors(result);
+  }
+
+  @Test
+  public void testValidBothDataStreamConfigs() {
+    props.put(DATA_STREAM_DATASET_CONFIG, "a_valid_dataset");
+    props.put(DATA_STREAM_TYPE_CONFIG, "logs");
+    validator = new Validator(props, () -> mockClient);
+    Config result = validator.validate();
+    assertNoErrors(result);
+  }
+
+  @Test
+  public void testInvalidMissingOneDataStreamConfig() {
+    props.put(DATA_STREAM_DATASET_CONFIG, "a_valid_dataset");
+    validator = new Validator(props, () -> mockClient);
+    Config result = validator.validate();
+    assertHasErrorMessage(result, DATA_STREAM_DATASET_CONFIG, "must be set");
+    assertHasErrorMessage(result, DATA_STREAM_TYPE_CONFIG, "must be set");
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/elasticsearch/ValidatorTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ValidatorTest.java
@@ -123,6 +123,13 @@ public class ValidatorTest {
   }
 
   @Test
+  public void testValidMissingBothDataStreamConfigs() {
+    validator = new Validator(props, () -> mockClient);
+    Config result = validator.validate();
+    assertNoErrors(result);
+  }
+
+  @Test
   public void testInvalidMissingOneDataStreamConfig() {
     props.put(DATA_STREAM_DATASET_CONFIG, "a_valid_dataset");
     validator = new Validator(props, () -> mockClient);

--- a/src/test/java/io/confluent/connect/elasticsearch/ValidatorTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ValidatorTest.java
@@ -114,7 +114,7 @@ public class ValidatorTest {
   }
 
   @Test
-  public void testValidBothDataStreamConfigs() {
+  public void testValidDataStreamConfigs() {
     props.put(DATA_STREAM_DATASET_CONFIG, "a_valid_dataset");
     props.put(DATA_STREAM_TYPE_CONFIG, "logs");
     validator = new Validator(props, () -> mockClient);
@@ -123,7 +123,7 @@ public class ValidatorTest {
   }
 
   @Test
-  public void testValidMissingBothDataStreamConfigs() {
+  public void testValidDefaultConfig() {
     validator = new Validator(props, () -> mockClient);
     Config result = validator.validate();
     assertNoErrors(result);

--- a/src/test/java/io/confluent/connect/elasticsearch/ValidatorTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ValidatorTest.java
@@ -75,10 +75,26 @@ public class ValidatorTest {
   }
 
   @Test
+  public void testValidDefaultConfig() {
+    validator = new Validator(props, () -> mockClient);
+    Config result = validator.validate();
+    assertNoErrors(result);
+  }
+
+  @Test
   public void testInvalidIndividualConfigs() {
     validator = new Validator(new HashMap<>(), () -> mockClient);
     Config result = validator.validate();
     assertHasErrorMessage(result, CONNECTION_URL_CONFIG, "Missing required configuration");
+  }
+
+  @Test
+  public void testValidUpsertDeleteOnDefaultConfig() {
+    props.put(BEHAVIOR_ON_NULL_VALUES_CONFIG, "delete");
+    props.put(WRITE_METHOD_CONFIG, "upsert");
+    validator = new Validator(props, () -> mockClient);
+    Config result = validator.validate();
+    assertNoErrors(result);
   }
 
   @Test
@@ -116,6 +132,15 @@ public class ValidatorTest {
   }
 
   @Test
+  public void testInvalidMissingOneDataStreamConfig() {
+    props.put(DATA_STREAM_DATASET_CONFIG, "a_valid_dataset");
+    validator = new Validator(props, () -> mockClient);
+    Config result = validator.validate();
+    assertHasErrorMessage(result, DATA_STREAM_DATASET_CONFIG, "must be set");
+    assertHasErrorMessage(result, DATA_STREAM_TYPE_CONFIG, "must be set");
+  }
+
+  @Test
   public void testInvalidUpsertDeleteOnValidDataStreamConfigs() {
     props.put(DATA_STREAM_DATASET_CONFIG, "a_valid_dataset");
     props.put(DATA_STREAM_TYPE_CONFIG, "logs");
@@ -124,30 +149,6 @@ public class ValidatorTest {
     validator = new Validator(props, () -> mockClient);
     Config result = validator.validate();
     assertNoErrors(result);
-
-    props.put(BEHAVIOR_ON_NULL_VALUES_CONFIG, "delete");
-    props.put(WRITE_METHOD_CONFIG, "upsert");
-    validator = new Validator(props, () -> mockClient);
-
-    result = validator.validate();
-    assertHasErrorMessage(result, BEHAVIOR_ON_NULL_VALUES_CONFIG, "must not be");
-    assertHasErrorMessage(result, WRITE_METHOD_CONFIG, "must not be");
-  }
-
-  @Test
-  public void testValidDefaultConfig() {
-    validator = new Validator(props, () -> mockClient);
-    Config result = validator.validate();
-    assertNoErrors(result);
-  }
-
-  @Test
-  public void testInvalidMissingOneDataStreamConfig() {
-    props.put(DATA_STREAM_DATASET_CONFIG, "a_valid_dataset");
-    validator = new Validator(props, () -> mockClient);
-    Config result = validator.validate();
-    assertHasErrorMessage(result, DATA_STREAM_DATASET_CONFIG, "must be set");
-    assertHasErrorMessage(result, DATA_STREAM_TYPE_CONFIG, "must be set");
 
     props.put(BEHAVIOR_ON_NULL_VALUES_CONFIG, "delete");
     props.put(WRITE_METHOD_CONFIG, "upsert");


### PR DESCRIPTION
## Problem
Data streams requires configurations for the `type` and `dataset`

## Solution
Those 2 configurations were added along validation to ensure `dataset` follows the restrictions for data stream and index names specified by Elastic. 
[data stream fields restrictions](https://github.com/elastic/ecs/blob/master/rfcs/text/0009-data_stream-fields.md)
[index name restrictions](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html#indices-create-api-path-params)


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
Will be released as part of the whole datastream feature.
<!-- Are you backporting or merging to master? -->
Not backporting or merging to master.
<!-- If you are reverting or rolling back, is it safe? --> 
