### PR TITLE
CCMSG-966: Implement data stream write for Elasticsearch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,4 +4,5 @@ common {
   upstreamProjects = 'confluentinc/common'
   pintMerge = true
   downStreamValidate = false
+  nodeLabel = 'docker-oraclejdk8'
 }

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -13,6 +13,11 @@
     />
 
     <suppress
+            checks="(CyclomaticComplexity)"
+            files="DataConverter.java"
+    />
+
+    <suppress
       checks="(ClassDataAbstractionCoupling)"
       files="(ElasticsearchClient|ConfigCallbackHandler).java"
     />

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -9,12 +9,7 @@
     <!-- switch statements on types exceed maximum complexity -->
     <suppress
       checks="(CyclomaticComplexity)"
-      files="Mapping.java"
-    />
-
-    <suppress
-            checks="(CyclomaticComplexity)"
-            files="DataConverter.java"
+      files="(Mapping|DataConverter).java"
     />
 
     <suppress

--- a/pom.xml
+++ b/pom.xml
@@ -309,7 +309,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <forkCount>0</forkCount>
+                    <reuseForks>true</reuseForks>
                     <argLine>@{argLine} -Djava.awt.headless=true -Dtests.security.manager=false -Dtests.jarhell.check=false</argLine>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -309,7 +309,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>@{argLine} -Xmx1024m -Djava.awt.headless=true -Dtests.security.manager=false -Dtests.jarhell.check=false</argLine>
+                    <argLine>@{argLine} -Djava.awt.headless=true -Dtests.security.manager=false -Dtests.jarhell.check=false</argLine>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     </scm>
 
     <properties>
-        <es.version>7.12.0</es.version>
+        <es.version>7.9.3</es.version>
         <hamcrest.version>1.3</hamcrest.version>
         <mockito.version>2.28.2</mockito.version>
         <gson.version>2.8.6</gson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     </scm>
 
     <properties>
-        <es.version>7.12</es.version>
+        <es.version>7.12.0</es.version>
         <hamcrest.version>1.3</hamcrest.version>
         <mockito.version>2.28.2</mockito.version>
         <gson.version>2.8.6</gson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     </scm>
 
     <properties>
-        <es.version>7.0.1</es.version>
+        <es.version>7.12</es.version>
         <hamcrest.version>1.3</hamcrest.version>
         <mockito.version>2.28.2</mockito.version>
         <gson.version>2.8.6</gson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -309,6 +309,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <forkCount>0</forkCount>
                     <argLine>@{argLine} -Djava.awt.headless=true -Dtests.security.manager=false -Dtests.jarhell.check=false</argLine>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -309,8 +309,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <reuseForks>true</reuseForks>
-                    <argLine>@{argLine} -Djava.awt.headless=true -Dtests.security.manager=false -Dtests.jarhell.check=false</argLine>
+                    <argLine>@{argLine} -Xmx1024m -Djava.awt.headless=true -Dtests.security.manager=false -Dtests.jarhell.check=false</argLine>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
@@ -107,42 +107,8 @@ public class DataConverter {
 
   public DocWriteRequest<?> convertRecord(SinkRecord record, String index) {
     if (record.value() == null) {
-      switch (config.behaviorOnNullValues()) {
-        case IGNORE:
-          log.trace("Ignoring {} with null value.", recordString(record));
-          return null;
-        case DELETE:
-          if (record.key() == null) {
-            // Since the record key is used as the ID of the index to delete and we don't have a key
-            // for this record, we can't delete anything anyways, so we ignore the record.
-            // We can also disregard the value of the ignoreKey parameter, since even if it's true
-            // the resulting index we'd try to delete would be based solely off topic/partition/
-            // offset information for the SinkRecord. Since that information is guaranteed to be
-            // unique per message, we can be confident that there wouldn't be any corresponding
-            // index present in ES to delete anyways.
-            log.trace(
-                "Ignoring {} with null key, since the record key is used as the ID of the index",
-                recordString(record)
-            );
-            return null;
-          }
-          // Will proceed as normal, ultimately creating a DeleteRequest
-          log.trace("Deleting {} from Elasticsearch", recordString(record));
-          break;
-        case FAIL:
-        default:
-          throw new DataException(
-              String.format(
-                  "%s with key of %s and null value encountered (to ignore future records like"
-                      + " this change the configuration property '%s' from '%s' to '%s')",
-                  recordString(record),
-                  record.key(),
-                  ElasticsearchSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG,
-                  BehaviorOnNullValues.FAIL,
-                  BehaviorOnNullValues.IGNORE
-              )
-          );
-      }
+      handleNullRecord(record);
+      return null;
     }
 
     final String payload = getPayload(record);
@@ -170,6 +136,43 @@ public class DataConverter {
         );
       default:
         return null; // shouldn't happen
+    }
+  }
+
+  private void handleNullRecord(SinkRecord record) {
+    switch (config.behaviorOnNullValues()) {
+      case IGNORE:
+        log.trace("Ignoring {} with null value.", recordString(record));
+      case DELETE:
+        if (record.key() == null) {
+          // Since the record key is used as the ID of the index to delete and we don't have a key
+          // for this record, we can't delete anything anyways, so we ignore the record.
+          // We can also disregard the value of the ignoreKey parameter, since even if it's true
+          // the resulting index we'd try to delete would be based solely off topic/partition/
+          // offset information for the SinkRecord. Since that information is guaranteed to be
+          // unique per message, we can be confident that there wouldn't be any corresponding
+          // index present in ES to delete anyways.
+          log.trace(
+              "Ignoring {} with null key, since the record key is used as the ID of the index",
+              recordString(record)
+          );
+        }
+        // Will proceed as normal, ultimately creating a DeleteRequest
+        log.trace("Deleting {} from Elasticsearch", recordString(record));
+        break;
+      case FAIL:
+      default:
+        throw new DataException(
+            String.format(
+                "%s with key of %s and null value encountered (to ignore future records like"
+                    + " this change the configuration property '%s' from '%s' to '%s')",
+                recordString(record),
+                record.key(),
+                ElasticsearchSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG,
+                BehaviorOnNullValues.FAIL,
+                BehaviorOnNullValues.IGNORE
+            )
+        );
     }
   }
 

--- a/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
@@ -131,17 +131,7 @@ public class DataConverter {
           break;
         case FAIL:
         default:
-          throw new DataException(
-              String.format(
-                  "%s with key of %s and null value encountered (to ignore future records like"
-                      + " this change the configuration property '%s' from '%s' to '%s')",
-                  recordString(record),
-                  record.key(),
-                  ElasticsearchSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG,
-                  BehaviorOnNullValues.FAIL,
-                  BehaviorOnNullValues.IGNORE
-              )
-          );
+          throwNullRecordFailException(record);
       }
     }
 
@@ -393,6 +383,20 @@ public class DataConverter {
         record.topic(),
         record.kafkaPartition(),
         record.kafkaOffset()
+    );
+  }
+
+  private void throwNullRecordFailException(SinkRecord record) {
+    throw new DataException(
+        String.format(
+            "%s with key of %s and null value encountered (to ignore future records like"
+                + " this change the configuration property '%s' from '%s' to '%s')",
+            recordString(record),
+            record.key(),
+            ElasticsearchSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG,
+            BehaviorOnNullValues.FAIL,
+            BehaviorOnNullValues.IGNORE
+        )
     );
   }
 }

--- a/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
@@ -30,6 +30,7 @@ import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.storage.Converter;
 import org.elasticsearch.action.DocWriteRequest;
+import org.elasticsearch.action.DocWriteRequest.OpType;
 import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.update.UpdateRequest;
@@ -162,8 +163,9 @@ public class DataConverter {
             .upsert(payload, XContentType.JSON)
             .retryOnConflict(Math.min(config.maxInFlightRequests(), 5));
       case INSERT:
+        OpType opType = config.isDataStream() ? OpType.CREATE : OpType.INDEX;
         return maybeAddExternalVersioning(
-            new IndexRequest(index).id(id).source(payload, XContentType.JSON),
+            new IndexRequest(index).id(id).source(payload, XContentType.JSON).opType(opType),
             record
         );
       default:

--- a/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
@@ -131,7 +131,17 @@ public class DataConverter {
           break;
         case FAIL:
         default:
-          throwNullRecordFailException(record);
+          throw new DataException(
+              String.format(
+                  "%s with key of %s and null value encountered (to ignore future records like"
+                      + " this change the configuration property '%s' from '%s' to '%s')",
+                  recordString(record),
+                  record.key(),
+                  ElasticsearchSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG,
+                  BehaviorOnNullValues.FAIL,
+                  BehaviorOnNullValues.IGNORE
+              )
+          );
       }
     }
 
@@ -383,20 +393,6 @@ public class DataConverter {
         record.topic(),
         record.kafkaPartition(),
         record.kafkaOffset()
-    );
-  }
-
-  private void throwNullRecordFailException(SinkRecord record) {
-    throw new DataException(
-        String.format(
-            "%s with key of %s and null value encountered (to ignore future records like"
-                + " this change the configuration property '%s' from '%s' to '%s')",
-            recordString(record),
-            record.key(),
-            ElasticsearchSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG,
-            BehaviorOnNullValues.FAIL,
-            BehaviorOnNullValues.IGNORE
-        )
     );
   }
 }

--- a/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
@@ -107,7 +107,7 @@ public class DataConverter {
 
   public DocWriteRequest<?> convertRecord(SinkRecord record, String index) {
     if (record.value() == null) {
-      handleNullRecord(record);
+      handleNullRecordValue(record);
       return null;
     }
 
@@ -139,7 +139,7 @@ public class DataConverter {
     }
   }
 
-  private void handleNullRecord(SinkRecord record) {
+  private void handleNullRecordValue(SinkRecord record) {
     switch (config.behaviorOnNullValues()) {
       case IGNORE:
         log.trace("Ignoring {} with null value.", recordString(record));

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
@@ -20,7 +20,6 @@ import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfi
 
 import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BehaviorOnMalformedDoc;
 import java.io.IOException;
-import java.sql.SQLOutput;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -53,7 +52,6 @@ import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
-import org.elasticsearch.client.Validatable;
 import org.elasticsearch.client.indices.CreateIndexRequest;
 import org.elasticsearch.client.indices.CreateDataStreamRequest;
 import org.elasticsearch.client.indices.GetIndexRequest;

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
@@ -177,7 +177,8 @@ public class ElasticsearchClient {
   }
 
   /**
-   * Creates an index. Will not recreate the index if it already exists.
+   * Creates an index. Will not recreate the index if it already exists. If the data stream
+   * configuration is set, will create the index as a data stream instead.
    *
    * @param index the index to create
    * @return true if the index was created, false if it already exists
@@ -392,16 +393,16 @@ public class ElasticsearchClient {
   }
 
   /**
-   * Creates a data stream. Will not recreate the index if it already exists.
+   * Creates a data stream. Will not recreate the data stream if it already exists.
    *
-   * @param index the index to create
-   * @return true if the index was created, false if it already exists
+   * @param dataStream the data stream to create
+   * @return true if the data stream was created, false if it already exists
    */
-  private boolean createDataStream(String index) {
-    CreateDataStreamRequest request = new CreateDataStreamRequest(index);
+  private boolean createDataStream(String dataStream) {
+    CreateDataStreamRequest request = new CreateDataStreamRequest(dataStream);
 
     return callWithRetries(
-        "create index " + index,
+        "create data stream " + dataStream,
         () -> {
           try {
             client.indices().createDataStream(request, RequestOptions.DEFAULT);

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
@@ -177,35 +177,18 @@ public class ElasticsearchClient {
   }
 
   /**
-   * Creates an index. Will not recreate the index if it already exists. If the data stream
-   * configuration is set, will create the index as a data stream instead.
+   * Creates an index or data stream. Will not recreate the index or data stream if
+   * it already exists. Will create a data stream instead of an index if the data stream
+   * configurations are set.
    *
-   * @param index the index to create
-   * @return true if the index was created, false if it already exists
+   * @param name the name of the index or data stream to create
+   * @return true if the index or data stream was created, false if it already exists
    */
-  public boolean createIndex(String index) {
-    if (indexExists(index)) {
+  public boolean createIndexOrDataStream(String name) {
+    if (indexExists(name)) {
       return false;
     }
-    if (config.isDataStream()) {
-      return createDataStream(index);
-    }
-
-    CreateIndexRequest request = new CreateIndexRequest(index);
-    return callWithRetries(
-        "create index " + index,
-        () -> {
-          try {
-            client.indices().create(request, RequestOptions.DEFAULT);
-          } catch (ElasticsearchStatusException | IOException e) {
-            if (!e.getMessage().contains(RESOURCE_ALREADY_EXISTS_EXCEPTION)) {
-              throw e;
-            }
-            return false;
-          }
-          return true;
-        }
-    );
+    return config.isDataStream() ? createDataStream(name) : createIndex(name);
   }
 
   /**
@@ -404,6 +387,30 @@ public class ElasticsearchClient {
         () -> {
           try {
             client.indices().createDataStream(request, RequestOptions.DEFAULT);
+          } catch (ElasticsearchStatusException | IOException e) {
+            if (!e.getMessage().contains(RESOURCE_ALREADY_EXISTS_EXCEPTION)) {
+              throw e;
+            }
+            return false;
+          }
+          return true;
+        }
+    );
+  }
+
+  /**
+   * Creates an index. Will not recreate the index if it already exists.
+   *
+   * @param index the index to create
+   * @return true if the index was created, false if it already exists
+   */
+  private boolean createIndex(String index) {
+    CreateIndexRequest request = new CreateIndexRequest(index);
+    return callWithRetries(
+        "create index " + index,
+        () -> {
+          try {
+            client.indices().create(request, RequestOptions.DEFAULT);
           } catch (ElasticsearchStatusException | IOException e) {
             if (!e.getMessage().contains(RESOURCE_ALREADY_EXISTS_EXCEPTION)) {
               throw e;

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
@@ -377,7 +377,7 @@ public class ElasticsearchClient {
   /**
    * Creates a data stream. Will not recreate the data stream if it already exists.
    *
-   * @param dataStream the data stream to create
+   * @param dataStream the data stream to create in the format {type}-{dataset}-{topic}
    * @return true if the data stream was created, false if it already exists
    */
   private boolean createDataStream(String dataStream) {

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
@@ -377,7 +377,7 @@ public class ElasticsearchClient {
   /**
    * Creates a data stream. Will not recreate the data stream if it already exists.
    *
-   * @param dataStream the data stream to create in the format {type}-{dataset}-{topic}
+   * @param dataStream the data stream to create given in the form {type}-{dataset}-{topic}
    * @return true if the data stream was created, false if it already exists
    */
   private boolean createDataStream(String dataStream) {

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
@@ -20,6 +20,7 @@ import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfi
 
 import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BehaviorOnMalformedDoc;
 import java.io.IOException;
+import java.sql.SQLOutput;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
@@ -57,7 +57,7 @@ import org.elasticsearch.client.indices.GetIndexRequest;
 import org.elasticsearch.client.indices.GetMappingsRequest;
 import org.elasticsearch.client.indices.GetMappingsResponse;
 import org.elasticsearch.client.indices.PutMappingRequest;
-import org.elasticsearch.cluster.metadata.MappingMetaData;
+import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.common.unit.TimeValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -230,7 +230,7 @@ public class ElasticsearchClient {
    * @return true if a mapping exists, false if it does not
    */
   public boolean hasMapping(String index) {
-    MappingMetaData mapping = mapping(index);
+    MappingMetadata mapping = mapping(index);
     return mapping != null && mapping.sourceAsMap() != null && !mapping.sourceAsMap().isEmpty();
   }
 
@@ -473,7 +473,7 @@ public class ElasticsearchClient {
    * @param index the index to fetch the mapping for
    * @return the MappingMetaData for the index
    */
-  private MappingMetaData mapping(String index) {
+  private MappingMetadata mapping(String index) {
     GetMappingsRequest request = new GetMappingsRequest().indices(index);
     GetMappingsResponse response = callWithRetries(
         "get mapping for index " + index,

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
@@ -52,8 +52,8 @@ import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
-import org.elasticsearch.client.indices.CreateIndexRequest;
 import org.elasticsearch.client.indices.CreateDataStreamRequest;
+import org.elasticsearch.client.indices.CreateIndexRequest;
 import org.elasticsearch.client.indices.GetIndexRequest;
 import org.elasticsearch.client.indices.GetMappingsRequest;
 import org.elasticsearch.client.indices.GetMappingsResponse;
@@ -192,7 +192,6 @@ public class ElasticsearchClient {
     }
 
     CreateIndexRequest request = new CreateIndexRequest(index);
-
     return callWithRetries(
         "create index " + index,
         () -> {
@@ -400,7 +399,6 @@ public class ElasticsearchClient {
    */
   private boolean createDataStream(String dataStream) {
     CreateDataStreamRequest request = new CreateDataStreamRequest(dataStream);
-
     return callWithRetries(
         "create data stream " + dataStream,
         () -> {

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
@@ -208,26 +208,6 @@ public class ElasticsearchClient {
     );
   }
 
-  // TODO: add method header
-  private boolean createDataStream(String index) {
-    CreateDataStreamRequest request = new CreateDataStreamRequest(index);
-
-    return callWithRetries(
-        "create index " + index,
-        () -> {
-          try {
-            client.indices().createDataStream(request, RequestOptions.DEFAULT);
-          } catch (ElasticsearchStatusException | IOException e) {
-            if (!e.getMessage().contains(RESOURCE_ALREADY_EXISTS_EXCEPTION)) {
-              throw e;
-            }
-            return false;
-          }
-          return true;
-        }
-    );
-  }
-
   /**
    * Creates a mapping for the given index and schema.
    *
@@ -409,6 +389,31 @@ public class ElasticsearchClient {
     } catch (IOException e) {
       log.warn("Failed to close Elasticsearch client.", e);
     }
+  }
+
+  /**
+   * Creates a data stream. Will not recreate the index if it already exists.
+   *
+   * @param index the index to create
+   * @return true if the index was created, false if it already exists
+   */
+  private boolean createDataStream(String index) {
+    CreateDataStreamRequest request = new CreateDataStreamRequest(index);
+
+    return callWithRetries(
+        "create index " + index,
+        () -> {
+          try {
+            client.indices().createDataStream(request, RequestOptions.DEFAULT);
+          } catch (ElasticsearchStatusException | IOException e) {
+            if (!e.getMessage().contains(RESOURCE_ALREADY_EXISTS_EXCEPTION)) {
+              throw e;
+            }
+            return false;
+          }
+          return true;
+        }
+    );
   }
 
   /**

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -129,8 +129,6 @@ public class ElasticsearchSinkTask extends SinkTask {
   // TODO: Add method header
   private String convertUsingIndexTemplate(String topic) {
     topic = topic.toLowerCase();
-    System.out.println("HELLO I AM HERE AND VERY STUCK HELP");
-
     if (topic.length() > 100) {
       topic = topic.substring(0, 100);
     }

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -87,7 +87,7 @@ public class ElasticsearchSinkTask extends SinkTask {
 
       logTrace("Writing {} to Elasticsearch.", record);
 
-      ensureIndexExists(createIndexNameWith(record.topic()));
+      ensureIndexExists(createIndexName(record.topic()));
       checkMapping(record);
       tryWriteRecord(record);
     }
@@ -115,7 +115,7 @@ public class ElasticsearchSinkTask extends SinkTask {
   }
 
   private void checkMapping(SinkRecord record) {
-    String index = createIndexNameWith(record.topic());
+    String index = createIndexName(record.topic());
     if (!config.shouldIgnoreSchema(record.topic()) && !existingMappings.contains(index)) {
       if (!client.hasMapping(index)) {
         client.createMapping(index, record.valueSchema());
@@ -171,13 +171,13 @@ public class ElasticsearchSinkTask extends SinkTask {
     if (topic.length() > 100) {
       topic = topic.substring(0, 100);
     }
-    String index = String.format(
+    String dataStream = String.format(
         "%s-%s-%s",
         config.dataStreamType().name().toLowerCase(),
         config.dataStreamDataset(),
         topic
     );
-    return index;
+    return dataStream;
   }
 
   /**
@@ -192,7 +192,7 @@ public class ElasticsearchSinkTask extends SinkTask {
    * </ul>
    * (<a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html#indices-create-api-path-params">ref</a>_.)
    */
-  private String createIndexNameWith(String topic) {
+  private String createIndexName(String topic) {
     return config.isDataStream() ? convertTopicToDataStreamName(topic) : convertTopicToIndexName(topic);
   }
 
@@ -223,7 +223,7 @@ public class ElasticsearchSinkTask extends SinkTask {
   private void tryWriteRecord(SinkRecord sinkRecord) {
     DocWriteRequest<?> record = null;
     try {
-      record = converter.convertRecord(sinkRecord, createIndexNameWith(sinkRecord.topic()));
+      record = converter.convertRecord(sinkRecord, createIndexName(sinkRecord.topic()));
     } catch (DataException convertException) {
       reportBadRecord(sinkRecord, convertException);
 

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -129,6 +129,7 @@ public class ElasticsearchSinkTask extends SinkTask {
   // TODO: Add method header
   private String convertUsingIndexTemplate(String topic) {
     topic = topic.toLowerCase();
+    System.out.println("HELLO I AM HERE AND VERY STUCK HELP");
 
     if (topic.length() > 100) {
       topic = topic.substring(0, 100);

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -193,7 +193,9 @@ public class ElasticsearchSinkTask extends SinkTask {
    * (<a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html#indices-create-api-path-params">ref</a>_.)
    */
   private String createIndexName(String topic) {
-    return config.isDataStream() ? convertTopicToDataStreamName(topic) : convertTopicToIndexName(topic);
+    return config.isDataStream()
+        ? convertTopicToDataStreamName(topic)
+        : convertTopicToIndexName(topic);
   }
 
   private void ensureIndexExists(String index) {

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -201,7 +201,7 @@ public class ElasticsearchSinkTask extends SinkTask {
   private void ensureIndexExists(String index) {
     if (!indexCache.contains(index)) {
       log.info("Creating index {}.", index);
-      client.createIndex(index);
+      client.createIndexOrDataStream(index);
       indexCache.add(index);
     }
   }

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -126,6 +126,7 @@ public class ElasticsearchSinkTask extends SinkTask {
     }
   }
 
+  // TODO: Add method header
   private String convertUsingIndexTemplate(String topic) {
     topic = topic.toLowerCase();
 
@@ -134,7 +135,7 @@ public class ElasticsearchSinkTask extends SinkTask {
     }
     String index = String.format(
         "%s-%s-%s",
-        config.dataStreamType().name(),
+        config.dataStreamType().name().toLowerCase(),
         config.dataStreamDataset(),
         topic
     );
@@ -142,7 +143,7 @@ public class ElasticsearchSinkTask extends SinkTask {
   }
 
   private String createIndexName(String topic) {
-    if (config.dataStreamDataset() == null || config.dataStreamType() == DataStreamType.NONE) {
+    if (config.isDataStream()) {
       return convertTopicToIndexName(topic);
     }
     return convertUsingIndexTemplate(topic);

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -88,7 +88,7 @@ public class ElasticsearchSinkTask extends SinkTask {
 
       logTrace("Writing {} to Elasticsearch.", record);
 
-      ensureIndexExists(createIndexName(record.topic()));
+      ensureIndexExists(createIndexNameWith(record.topic()));
       checkMapping(record);
       tryWriteRecord(record);
     }
@@ -116,7 +116,7 @@ public class ElasticsearchSinkTask extends SinkTask {
   }
 
   private void checkMapping(SinkRecord record) {
-    String index = createIndexName(record.topic());
+    String index = createIndexNameWith(record.topic());
     if (!config.shouldIgnoreSchema(record.topic()) && !existingMappings.contains(index)) {
       if (!client.hasMapping(index)) {
         client.createMapping(index, record.valueSchema());
@@ -142,7 +142,7 @@ public class ElasticsearchSinkTask extends SinkTask {
     return index;
   }
 
-  private String createIndexName(String topic) {
+  private String createIndexNameWith(String topic) {
     if (config.isDataStream()) {
       return convertUsingIndexTemplate(topic);
     }
@@ -208,7 +208,7 @@ public class ElasticsearchSinkTask extends SinkTask {
   private void tryWriteRecord(SinkRecord sinkRecord) {
     DocWriteRequest<?> record = null;
     try {
-      record = converter.convertRecord(sinkRecord, createIndexName(sinkRecord.topic()));
+      record = converter.convertRecord(sinkRecord, createIndexNameWith(sinkRecord.topic()));
     } catch (DataException convertException) {
       reportBadRecord(sinkRecord, convertException);
 

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -166,7 +166,7 @@ public class ElasticsearchSinkTask extends SinkTask {
    * </ul>
    * (<a href="https://github.com/elastic/ecs/blob/master/rfcs/text/0009-data_stream-fields.md#restrictions-on-values">ref</a>_.)
    */
-  private String convertUsingIndexTemplate(String topic) {
+  private String convertTopicToDataStreamName(String topic) {
     topic = topic.toLowerCase();
     if (topic.length() > 100) {
       topic = topic.substring(0, 100);
@@ -194,7 +194,7 @@ public class ElasticsearchSinkTask extends SinkTask {
    */
   private String createIndexNameWith(String topic) {
     if (config.isDataStream()) {
-      return convertUsingIndexTemplate(topic);
+      return convertTopicToDataStreamName(topic);
     }
     return convertTopicToIndexName(topic);
   }

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -144,9 +144,9 @@ public class ElasticsearchSinkTask extends SinkTask {
 
   private String createIndexName(String topic) {
     if (config.isDataStream()) {
-      return convertTopicToIndexName(topic);
+      return convertUsingIndexTemplate(topic);
     }
-    return convertUsingIndexTemplate(topic);
+    return convertTopicToIndexName(topic);
   }
 
   /**

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
@@ -141,7 +141,7 @@ public class ElasticsearchClientTest {
   }
 
   @Test
-  public void testcreateIndexOrDataStream() throws IOException {
+  public void testCreateIndex() throws IOException {
     ElasticsearchClient client = new ElasticsearchClient(config, null);
     assertFalse(helperClient.indexExists(INDEX));
 

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
@@ -141,11 +141,11 @@ public class ElasticsearchClientTest {
   }
 
   @Test
-  public void testCreateIndex() throws IOException {
+  public void testcreateIndexOrDataStream() throws IOException {
     ElasticsearchClient client = new ElasticsearchClient(config, null);
     assertFalse(helperClient.indexExists(INDEX));
 
-    client.createIndex(INDEX);
+    client.createIndexOrDataStream(INDEX);
     assertTrue(helperClient.indexExists(INDEX));
     client.close();
   }
@@ -155,10 +155,10 @@ public class ElasticsearchClientTest {
     ElasticsearchClient client = new ElasticsearchClient(config, null);
     assertFalse(helperClient.indexExists(INDEX));
 
-    assertTrue(client.createIndex(INDEX));
+    assertTrue(client.createIndexOrDataStream(INDEX));
     assertTrue(helperClient.indexExists(INDEX));
 
-    assertFalse(client.createIndex(INDEX));
+    assertFalse(client.createIndexOrDataStream(INDEX));
     assertTrue(helperClient.indexExists(INDEX));
     client.close();
   }
@@ -168,7 +168,7 @@ public class ElasticsearchClientTest {
     ElasticsearchClient client = new ElasticsearchClient(config, null);
     assertFalse(helperClient.indexExists(INDEX));
 
-    assertTrue(client.createIndex(INDEX));
+    assertTrue(client.createIndexOrDataStream(INDEX));
     assertTrue(client.indexExists(INDEX));
     client.close();
   }
@@ -186,7 +186,7 @@ public class ElasticsearchClientTest {
   @SuppressWarnings("unchecked")
   public void testCreateMapping() throws IOException {
     ElasticsearchClient client = new ElasticsearchClient(config, null);
-    client.createIndex(INDEX);
+    client.createIndexOrDataStream(INDEX);
 
     client.createMapping(INDEX, schema());
 
@@ -209,7 +209,7 @@ public class ElasticsearchClientTest {
   @Test
   public void testHasMapping() {
     ElasticsearchClient client = new ElasticsearchClient(config, null);
-    client.createIndex(INDEX);
+    client.createIndexOrDataStream(INDEX);
 
     client.createMapping(INDEX, schema());
 
@@ -220,7 +220,7 @@ public class ElasticsearchClientTest {
   @Test
   public void testDoesNotHaveMapping() {
     ElasticsearchClient client = new ElasticsearchClient(config, null);
-    client.createIndex(INDEX);
+    client.createIndexOrDataStream(INDEX);
 
     assertFalse(client.hasMapping(INDEX));
     client.close();
@@ -232,7 +232,7 @@ public class ElasticsearchClientTest {
     props.put(MAX_BUFFERED_RECORDS_CONFIG, "1");
     config = new ElasticsearchSinkConnectorConfig(props);
     ElasticsearchClient client = new ElasticsearchClient(config, null);
-    client.createIndex(INDEX);
+    client.createIndexOrDataStream(INDEX);
 
     writeRecord(sinkRecord(0), client);
     assertEquals(1, client.numRecords.get());
@@ -258,7 +258,7 @@ public class ElasticsearchClientTest {
     props.put(LINGER_MS_CONFIG, String.valueOf(TimeUnit.DAYS.toMillis(1)));
     config = new ElasticsearchSinkConnectorConfig(props);
     ElasticsearchClient client = new ElasticsearchClient(config, null);
-    client.createIndex(INDEX);
+    client.createIndexOrDataStream(INDEX);
 
     writeRecord(sinkRecord(0), client);
     assertEquals(0, helperClient.getDocCount(INDEX)); // should be empty before flush
@@ -271,7 +271,7 @@ public class ElasticsearchClientTest {
   @Test
   public void testIndexRecord() throws Exception {
     ElasticsearchClient client = new ElasticsearchClient(config, null);
-    client.createIndex(INDEX);
+    client.createIndexOrDataStream(INDEX);
 
     writeRecord(sinkRecord(0), client);
     client.flush();
@@ -288,7 +288,7 @@ public class ElasticsearchClientTest {
     config = new ElasticsearchSinkConnectorConfig(props);
     converter = new DataConverter(config);
     ElasticsearchClient client = new ElasticsearchClient(config, null);
-    client.createIndex(INDEX);
+    client.createIndexOrDataStream(INDEX);
 
     writeRecord(sinkRecord("key0", 0), client);
     writeRecord(sinkRecord("key1", 1), client);
@@ -311,7 +311,7 @@ public class ElasticsearchClientTest {
     config = new ElasticsearchSinkConnectorConfig(props);
     converter = new DataConverter(config);
     ElasticsearchClient client = new ElasticsearchClient(config, null);
-    client.createIndex(INDEX);
+    client.createIndexOrDataStream(INDEX);
 
     writeRecord(sinkRecord("key0", 0), client);
     writeRecord(sinkRecord("key1", 1), client);
@@ -357,7 +357,7 @@ public class ElasticsearchClientTest {
     converter = new DataConverter(config);
 
     ElasticsearchClient client = new ElasticsearchClient(config, null);
-    client.createIndex(INDEX);
+    client.createIndexOrDataStream(INDEX);
     client.createMapping(INDEX, schema());
 
     Schema schema = SchemaBuilder
@@ -385,7 +385,7 @@ public class ElasticsearchClientTest {
   @Test(expected = ConnectException.class)
   public void testFailOnBadRecord() throws Exception {
     ElasticsearchClient client = new ElasticsearchClient(config, null);
-    client.createIndex(INDEX);
+    client.createIndexOrDataStream(INDEX);
     client.createMapping(INDEX, schema());
 
     Schema schema = SchemaBuilder
@@ -428,7 +428,7 @@ public class ElasticsearchClientTest {
 
     // mock bulk processor to throw errors
     ElasticsearchClient client = new ElasticsearchClient(config, null);
-    client.createIndex(INDEX);
+    client.createIndexOrDataStream(INDEX);
 
     // bring down ES service
     NetworkErrorContainer delay = new NetworkErrorContainer(container.getContainerName());
@@ -456,7 +456,7 @@ public class ElasticsearchClientTest {
 
     ErrantRecordReporter reporter = mock(ErrantRecordReporter.class);
     ElasticsearchClient client = new ElasticsearchClient(config, reporter);
-    client.createIndex(INDEX);
+    client.createIndexOrDataStream(INDEX);
     client.createMapping(INDEX, schema());
 
     Schema schema = SchemaBuilder
@@ -489,7 +489,7 @@ public class ElasticsearchClientTest {
   public void testReporterNotCalled() throws Exception {
     ErrantRecordReporter reporter = mock(ErrantRecordReporter.class);
     ElasticsearchClient client = new ElasticsearchClient(config, reporter);
-    client.createIndex(INDEX);
+    client.createIndexOrDataStream(INDEX);
 
     writeRecord(sinkRecord(0), client);
     writeRecord(sinkRecord(1), client);
@@ -514,7 +514,7 @@ public class ElasticsearchClientTest {
     ElasticsearchClient client = new ElasticsearchClient(config, reporter);
     ElasticsearchClient client2 = new ElasticsearchClient(config, reporter2);
 
-    client.createIndex(INDEX);
+    client.createIndexOrDataStream(INDEX);
 
     writeRecord(sinkRecord(0), client);
     writeRecord(sinkRecord(1), client2);
@@ -552,7 +552,7 @@ public class ElasticsearchClientTest {
 
     ElasticsearchClient client = new ElasticsearchClient(config, null);
     helperClient = new ElasticsearchHelperClient(address, config);
-    client.createIndex(INDEX);
+    client.createIndexOrDataStream(INDEX);
 
     writeRecord(sinkRecord(0), client);
     client.flush();

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
@@ -153,36 +153,36 @@ public class ElasticsearchClientTest {
     client.close();
   }
 
-  @Test
-  public void testCreateExistingDataStream() throws Exception {
-    String type = "logs";
-    String dataset = "dataset";
-    index = String.format("%s-%s-%s", type, dataset, TOPIC); // data stream name
-    props.put(DATA_STREAM_TYPE_CONFIG, type);
-    props.put(DATA_STREAM_DATASET_CONFIG, dataset);
-    config = new ElasticsearchSinkConnectorConfig(props);
-    ElasticsearchClient client = new ElasticsearchClient(config, null);
-
-    assertTrue(client.createIndexOrDataStream(index));
-    assertTrue(helperClient.indexExists(index));
-    assertFalse(client.createIndexOrDataStream(index));
-    client.close();
-  }
-
-  @Test
-  public void testCreateNewDataStream() throws Exception {
-    String type = "logs";
-    String dataset = "dataset";
-    index = String.format("%s-%s-%s", type, dataset, TOPIC); // data stream name
-    props.put(DATA_STREAM_TYPE_CONFIG, type);
-    props.put(DATA_STREAM_DATASET_CONFIG, dataset);
-    config = new ElasticsearchSinkConnectorConfig(props);
-    ElasticsearchClient client = new ElasticsearchClient(config, null);
-
-    assertTrue(client.createIndexOrDataStream(index));
-    assertTrue(helperClient.indexExists(index));
-    client.close();
-  }
+//  @Test
+//  public void testCreateExistingDataStream() throws Exception {
+//    String type = "logs";
+//    String dataset = "dataset";
+//    index = String.format("%s-%s-%s", type, dataset, TOPIC); // data stream name
+//    props.put(DATA_STREAM_TYPE_CONFIG, type);
+//    props.put(DATA_STREAM_DATASET_CONFIG, dataset);
+//    config = new ElasticsearchSinkConnectorConfig(props);
+//    ElasticsearchClient client = new ElasticsearchClient(config, null);
+//
+//    assertTrue(client.createIndexOrDataStream(index));
+//    assertTrue(helperClient.indexExists(index));
+//    assertFalse(client.createIndexOrDataStream(index));
+//    client.close();
+//  }
+//
+//  @Test
+//  public void testCreateNewDataStream() throws Exception {
+//    String type = "logs";
+//    String dataset = "dataset";
+//    index = String.format("%s-%s-%s", type, dataset, TOPIC); // data stream name
+//    props.put(DATA_STREAM_TYPE_CONFIG, type);
+//    props.put(DATA_STREAM_DATASET_CONFIG, dataset);
+//    config = new ElasticsearchSinkConnectorConfig(props);
+//    ElasticsearchClient client = new ElasticsearchClient(config, null);
+//
+//    assertTrue(client.createIndexOrDataStream(index));
+//    assertTrue(helperClient.indexExists(index));
+//    client.close();
+//  }
 
   @Test
   public void testDoesNotCreateAlreadyExistingIndex() throws IOException {

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
@@ -1,643 +1,643 @@
-///*
-// * Copyright 2020 Confluent Inc.
-// *
-// * Licensed under the Confluent Community License (the "License"); you may not use
-// * this file except in compliance with the License.  You may obtain a copy of the
-// * License at
-// *
-// * http://www.confluent.io/confluent-community-license
-// *
-// * Unless required by applicable law or agreed to in writing, software
-// * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-// * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
-// * specific language governing permissions and limitations under the License.
-// */
-//
-//package io.confluent.connect.elasticsearch;
-//
-//import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BATCH_SIZE_CONFIG;
-//import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BEHAVIOR_ON_MALFORMED_DOCS_CONFIG;
-//import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG;
-//import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_PASSWORD_CONFIG;
-//import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_URL_CONFIG;
-//import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_USERNAME_CONFIG;
-//import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_DATASET_CONFIG;
-//import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_TYPE_CONFIG;
-//import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_KEY_CONFIG;
-//import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.LINGER_MS_CONFIG;
-//import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.MAX_BUFFERED_RECORDS_CONFIG;
-//import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.MAX_IN_FLIGHT_REQUESTS_CONFIG;
-//import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.MAX_RETRIES_CONFIG;
-//import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.RETRY_BACKOFF_MS_CONFIG;
-//import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SECURITY_PROTOCOL_CONFIG;
-//import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SSL_CONFIG_PREFIX;
-//import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.WRITE_METHOD_CONFIG;
-//import static io.confluent.connect.elasticsearch.helper.ElasticsearchContainer.ELASTIC_PASSWORD;
-//import static org.junit.Assert.assertEquals;
-//import static org.junit.Assert.assertFalse;
-//import static org.junit.Assert.assertThrows;
-//import static org.junit.Assert.assertTrue;
-//import static org.mockito.ArgumentMatchers.any;
-//import static org.mockito.ArgumentMatchers.eq;
-//import static org.mockito.Mockito.mock;
-//import static org.mockito.Mockito.never;
-//import static org.mockito.Mockito.times;
-//import static org.mockito.Mockito.verify;
-//
-//import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BehaviorOnMalformedDoc;
-//import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BehaviorOnNullValues;
-//import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SecurityProtocol;
-//import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.WriteMethod;
-//import io.confluent.connect.elasticsearch.helper.ElasticsearchContainer;
-//import io.confluent.connect.elasticsearch.helper.ElasticsearchHelperClient;
-//import io.confluent.connect.elasticsearch.helper.NetworkErrorContainer;
-//import java.io.IOException;
-//import java.util.HashMap;
-//import java.util.Map;
-//import java.util.concurrent.TimeUnit;
-//import org.apache.kafka.common.config.SslConfigs;
-//import org.apache.kafka.connect.data.Schema;
-//import org.apache.kafka.connect.data.SchemaBuilder;
-//import org.apache.kafka.connect.data.Struct;
-//import org.apache.kafka.connect.errors.ConnectException;
-//import org.apache.kafka.connect.sink.ErrantRecordReporter;
-//import org.apache.kafka.connect.sink.SinkRecord;
-//import org.apache.kafka.test.TestUtils;
-//import org.elasticsearch.ElasticsearchStatusException;
-//import org.elasticsearch.search.SearchHit;
-//import org.junit.After;
-//import org.junit.AfterClass;
-//import org.junit.Before;
-//import org.junit.BeforeClass;
-//import org.junit.Test;
-//
-//public class ElasticsearchClientTest {
-//
-//  private static final String TOPIC = "index";
-//
-//  private static ElasticsearchContainer container;
-//
-//  private DataConverter converter;
-//  private ElasticsearchHelperClient helperClient;
-//  private ElasticsearchSinkConnectorConfig config;
-//  private Map<String, String> props;
-//  private String index;
-//
-//  @BeforeClass
-//  public static void setupBeforeAll() {
-//    container = ElasticsearchContainer.fromSystemProperties();
-//    container.start();
-//  }
-//
-//  @AfterClass
-//  public static void cleanupAfterAll() {
-//    container.close();
-//  }
-//
-//  @Before
-//  public void setup() {
-//    index = TOPIC;
-//    props = ElasticsearchSinkConnectorConfigTest.addNecessaryProps(new HashMap<>());
-//    props.put(CONNECTION_URL_CONFIG, container.getConnectionUrl());
-//    props.put(IGNORE_KEY_CONFIG, "true");
-//    props.put(LINGER_MS_CONFIG, "1000");
-//    config = new ElasticsearchSinkConnectorConfig(props);
-//    converter = new DataConverter(config);
-//    helperClient = new ElasticsearchHelperClient(container.getConnectionUrl(), config);
-//  }
-//
-//  @After
-//  public void cleanup() throws IOException {
-//    if (helperClient != null && helperClient.indexExists(index)){
-//      helperClient.deleteIndex(index, config.isDataStream());
-//    }
-//  }
-//
-//  @Test
-//  public void testClose() {
-//    ElasticsearchClient client = new ElasticsearchClient(config, null);
-//    client.close();
-//  }
-//
-//  @Test
-//  public void testCloseFails() throws Exception {
-//    props.put(BATCH_SIZE_CONFIG, "1");
-//    props.put(MAX_IN_FLIGHT_REQUESTS_CONFIG, "1");
-//    ElasticsearchClient client = new ElasticsearchClient(config, null) {
-//      @Override
-//      public void close() {
-//        try {
-//          if (!bulkProcessor.awaitClose(1, TimeUnit.MILLISECONDS)) {
-//            throw new ConnectException("Failed to process all outstanding requests in time.");
-//          }
-//        } catch (InterruptedException e) {}
-//      }
-//    };
-//
-//    writeRecord(sinkRecord(0), client);
-//    assertThrows(
-//        "Failed to process all outstanding requests in time.",
-//        ConnectException.class,
-//        () -> client.close()
-//    );
-//    waitUntilRecordsInES(1);
-//  }
-//
-//  @Test
-//  public void testCreateIndex() throws IOException {
-//    ElasticsearchClient client = new ElasticsearchClient(config, null);
-//    assertFalse(helperClient.indexExists(index));
-//
-//    client.createIndexOrDataStream(index);
-//    assertTrue(helperClient.indexExists(index));
-//    client.close();
-//  }
-//
-//  @Test
-//  public void testCreateExistingDataStream() throws Exception {
-//    String type = "logs";
-//    String dataset = "dataset";
-//    index = String.format("%s-%s-%s", type, dataset, TOPIC); // data stream name
-//    props.put(DATA_STREAM_TYPE_CONFIG, type);
-//    props.put(DATA_STREAM_DATASET_CONFIG, dataset);
-//    config = new ElasticsearchSinkConnectorConfig(props);
-//    ElasticsearchClient client = new ElasticsearchClient(config, null);
-//
-//    assertTrue(client.createIndexOrDataStream(index));
-//    assertTrue(helperClient.indexExists(index));
-//    assertFalse(client.createIndexOrDataStream(index));
-//    client.close();
-//  }
-//
-//  @Test
-//  public void testCreateNewDataStream() throws Exception {
-//    String type = "logs";
-//    String dataset = "dataset";
-//    index = String.format("%s-%s-%s", type, dataset, TOPIC); // data stream name
-//    props.put(DATA_STREAM_TYPE_CONFIG, type);
-//    props.put(DATA_STREAM_DATASET_CONFIG, dataset);
-//    config = new ElasticsearchSinkConnectorConfig(props);
-//    ElasticsearchClient client = new ElasticsearchClient(config, null);
-//
-//    assertTrue(client.createIndexOrDataStream(index));
-//    assertTrue(helperClient.indexExists(index));
-//    client.close();
-//  }
-//
-//  @Test
-//  public void testDoesNotCreateAlreadyExistingIndex() throws IOException {
-//    ElasticsearchClient client = new ElasticsearchClient(config, null);
-//    assertFalse(helperClient.indexExists(index));
-//
-//    assertTrue(client.createIndexOrDataStream(index));
-//    assertTrue(helperClient.indexExists(index));
-//
-//    assertFalse(client.createIndexOrDataStream(index));
-//    assertTrue(helperClient.indexExists(index));
-//    client.close();
-//  }
-//
-//  @Test
-//  public void testIndexExists() throws IOException {
-//    ElasticsearchClient client = new ElasticsearchClient(config, null);
-//    assertFalse(helperClient.indexExists(index));
-//
-//    assertTrue(client.createIndexOrDataStream(index));
-//    assertTrue(client.indexExists(index));
-//    client.close();
-//  }
-//
-//  @Test
-//  public void testIndexDoesNotExist() throws IOException {
-//    ElasticsearchClient client = new ElasticsearchClient(config, null);
-//    assertFalse(helperClient.indexExists(index));
-//
-//    assertFalse(client.indexExists(index));
-//    client.close();
-//  }
-//
-//  @Test
-//  @SuppressWarnings("unchecked")
-//  public void testCreateMapping() throws IOException {
-//    ElasticsearchClient client = new ElasticsearchClient(config, null);
-//    client.createIndexOrDataStream(index);
-//
-//    client.createMapping(index, schema());
-//
-//    assertTrue(client.hasMapping(index));
-//
-//    Map<String, Object> mapping = helperClient.getMapping(index).sourceAsMap();
-//    assertTrue(mapping.containsKey("properties"));
-//    Map<String, Object> props = (Map<String, Object>) mapping.get("properties");
-//    assertTrue(props.containsKey("offset"));
-//    assertTrue(props.containsKey("another"));
-//    Map<String, Object> offset = (Map<String, Object>) props.get("offset");
-//    assertEquals("integer", offset.get("type"));
-//    assertEquals(0, offset.get("null_value"));
-//    Map<String, Object> another = (Map<String, Object>) props.get("another");
-//    assertEquals("integer", another.get("type"));
-//    assertEquals(0, another.get("null_value"));
-//    client.close();
-//  }
-//
-//  @Test
-//  public void testHasMapping() {
-//    ElasticsearchClient client = new ElasticsearchClient(config, null);
-//    client.createIndexOrDataStream(index);
-//
-//    client.createMapping(index, schema());
-//
-//    assertTrue(client.hasMapping(index));
-//    client.close();
-//  }
-//
-//  @Test
-//  public void testDoesNotHaveMapping() {
-//    ElasticsearchClient client = new ElasticsearchClient(config, null);
-//    client.createIndexOrDataStream(index);
-//
-//    assertFalse(client.hasMapping(index));
-//    client.close();
-//  }
-//
-//  @Test
-//  public void testBuffersCorrectly() throws Exception {
-//    props.put(MAX_IN_FLIGHT_REQUESTS_CONFIG, "1");
-//    props.put(MAX_BUFFERED_RECORDS_CONFIG, "1");
-//    config = new ElasticsearchSinkConnectorConfig(props);
-//    ElasticsearchClient client = new ElasticsearchClient(config, null);
-//    client.createIndexOrDataStream(index);
-//
-//    writeRecord(sinkRecord(0), client);
-//    assertEquals(1, client.numRecords.get());
-//    client.flush();
-//
-//    waitUntilRecordsInES(1);
-//    assertEquals(1, helperClient.getDocCount(index));
-//    assertEquals(0, client.numRecords.get());
-//
-//    writeRecord(sinkRecord(1), client);
-//    assertEquals(1, client.numRecords.get());
-//
-//    // will block until the previous record is flushed
-//    writeRecord(sinkRecord(2), client);
-//    assertEquals(1, client.numRecords.get());
-//
-//    waitUntilRecordsInES(3);
-//    client.close();
-//  }
-//
-//  @Test
-//  public void testFlush() throws Exception {
-//    props.put(LINGER_MS_CONFIG, String.valueOf(TimeUnit.DAYS.toMillis(1)));
-//    config = new ElasticsearchSinkConnectorConfig(props);
-//    ElasticsearchClient client = new ElasticsearchClient(config, null);
-//    client.createIndexOrDataStream(index);
-//
-//    writeRecord(sinkRecord(0), client);
-//    assertEquals(0, helperClient.getDocCount(index)); // should be empty before flush
-//    client.flush();
-//    waitUntilRecordsInES(1);
-//    assertEquals(1, helperClient.getDocCount(index));
-//    client.close();
-//  }
-//
-//  @Test
-//  public void testIndexRecord() throws Exception {
-//    ElasticsearchClient client = new ElasticsearchClient(config, null);
-//    client.createIndexOrDataStream(index);
-//
-//    writeRecord(sinkRecord(0), client);
-//    client.flush();
-//
-//    waitUntilRecordsInES(1);
-//    assertEquals(1, helperClient.getDocCount(index));
-//    client.close();
-//  }
-//
-//  @Test
-//  public void testDeleteRecord() throws Exception {
-//    props.put(BEHAVIOR_ON_NULL_VALUES_CONFIG, BehaviorOnNullValues.DELETE.name());
-//    props.put(IGNORE_KEY_CONFIG, "false");
-//    config = new ElasticsearchSinkConnectorConfig(props);
-//    converter = new DataConverter(config);
-//    ElasticsearchClient client = new ElasticsearchClient(config, null);
-//    client.createIndexOrDataStream(index);
-//
-//    writeRecord(sinkRecord("key0", 0), client);
-//    writeRecord(sinkRecord("key1", 1), client);
-//    client.flush();
-//
-//    waitUntilRecordsInES(2);
-//
-//    // delete 1
-//    SinkRecord deleteRecord = new SinkRecord(TOPIC, 0, Schema.STRING_SCHEMA, "key0", null, null, 3);
-//    writeRecord(deleteRecord, client);
-//
-//    waitUntilRecordsInES(1);
-//    client.close();
-//  }
-//
-//  @Test
-//  public void testUpsertRecords() throws Exception {
-//    props.put(WRITE_METHOD_CONFIG, WriteMethod.UPSERT.name());
-//    props.put(IGNORE_KEY_CONFIG, "false");
-//    config = new ElasticsearchSinkConnectorConfig(props);
-//    converter = new DataConverter(config);
-//    ElasticsearchClient client = new ElasticsearchClient(config, null);
-//    client.createIndexOrDataStream(index);
-//
-//    writeRecord(sinkRecord("key0", 0), client);
-//    writeRecord(sinkRecord("key1", 1), client);
-//    client.flush();
-//
-//    waitUntilRecordsInES(2);
-//
-//    // create modified record for upsert
-//    Schema schema = SchemaBuilder
-//        .struct()
-//        .name("record")
-//        .field("offset", SchemaBuilder.int32().defaultValue(0).build())
-//        .field("another", SchemaBuilder.int32().defaultValue(0).build())
-//        .build();
-//
-//    Struct value = new Struct(schema).put("offset", 2);
-//    SinkRecord upsertRecord = new SinkRecord(index, 0, Schema.STRING_SCHEMA, "key0", schema, value, 2);
-//    Struct value2 = new Struct(schema).put("offset", 3);
-//    SinkRecord upsertRecord2 = new SinkRecord(index, 0, Schema.STRING_SCHEMA, "key0", schema, value2, 3);
-//
-//
-//    // upsert 2, write another
-//    writeRecord(upsertRecord, client);
-//    writeRecord(upsertRecord2, client);
-//    writeRecord(sinkRecord("key2", 4), client);
-//    client.flush();
-//
-//    waitUntilRecordsInES(3);
-//    for (SearchHit hit : helperClient.search(index)) {
-//      if (hit.getId().equals("key0")) {
-//        assertEquals(3, hit.getSourceAsMap().get("offset"));
-//        assertEquals(0, hit.getSourceAsMap().get("another"));
-//      }
-//    }
-//
-//    client.close();
-//  }
-//
-//  @Test
-//  public void testIgnoreBadRecord() throws Exception {
-//    props.put(BEHAVIOR_ON_MALFORMED_DOCS_CONFIG, BehaviorOnMalformedDoc.IGNORE.name());
-//    config = new ElasticsearchSinkConnectorConfig(props);
-//    converter = new DataConverter(config);
-//
-//    ElasticsearchClient client = new ElasticsearchClient(config, null);
-//    client.createIndexOrDataStream(index);
-//    client.createMapping(index, schema());
-//
-//    Schema schema = SchemaBuilder
-//        .struct()
-//        .name("record")
-//        .field("not_mapped_field", SchemaBuilder.int32().defaultValue(0).build())
-//        .build();
-//    Struct value = new Struct(schema).put("not_mapped_field", 420);
-//    SinkRecord badRecord = new SinkRecord(TOPIC, 0, Schema.STRING_SCHEMA, "key", schema, value, 0);
-//
-//    writeRecord(sinkRecord(0), client);
-//    client.flush();
-//
-//    writeRecord(badRecord, client);
-//    client.flush();
-//
-//    writeRecord(sinkRecord(1), client);
-//    client.flush();
-//
-//    waitUntilRecordsInES(2);
-//    assertEquals(2, helperClient.getDocCount(index));
-//    client.close();
-//  }
-//
-//  @Test(expected = ConnectException.class)
-//  public void testFailOnBadRecord() throws Exception {
-//    ElasticsearchClient client = new ElasticsearchClient(config, null);
-//    client.createIndexOrDataStream(index);
-//    client.createMapping(index, schema());
-//
-//    Schema schema = SchemaBuilder
-//        .struct()
-//        .name("record")
-//        .field("offset", SchemaBuilder.bool().defaultValue(false).build())
-//        .build();
-//    Struct value = new Struct(schema).put("offset", false);
-//    SinkRecord badRecord = new SinkRecord(TOPIC, 0, Schema.STRING_SCHEMA, "key", schema, value, 0);
-//
-//    writeRecord(sinkRecord(0), client);
-//    client.flush();
-//
-//    waitUntilRecordsInES(1);
-//    writeRecord(badRecord, client);
-//    client.flush();
-//
-//    // consecutive index calls should cause exception
-//    try {
-//      for (int i = 0; i < 5; i++) {
-//        writeRecord(sinkRecord(i + 1), client);
-//        client.flush();
-//        waitUntilRecordsInES(i + 2);
-//      }
-//    } catch (ConnectException e) {
-//      client.close();
-//      throw e;
-//    }
-//  }
-//
-//  @Test
-//  public void testRetryRecordsOnFailure() throws Exception {
-//    props.put(LINGER_MS_CONFIG, "60000");
-//    props.put(BATCH_SIZE_CONFIG, "2");
-//    props.put(MAX_RETRIES_CONFIG, "100");
-//    props.put(RETRY_BACKOFF_MS_CONFIG, "1000");
-//    config = new ElasticsearchSinkConnectorConfig(props);
-//    converter = new DataConverter(config);
-//
-//
-//    // mock bulk processor to throw errors
-//    ElasticsearchClient client = new ElasticsearchClient(config, null);
-//    client.createIndexOrDataStream(index);
-//
-//    // bring down ES service
-//    NetworkErrorContainer delay = new NetworkErrorContainer(container.getContainerName());
-//    delay.start();
-//
-//    // attempt a write
-//    writeRecord(sinkRecord(0), client);
-//    client.flush();
-//
-//    // keep the ES service down for a couple of timeouts
-//    Thread.sleep(config.readTimeoutMs() * 4);
-//
-//    // bring up ES service
-//    delay.stop();
-//
-//    waitUntilRecordsInES(1);
-//  }
-//
-//  @Test
-//  public void testReporter() throws Exception {
-//    props.put(IGNORE_KEY_CONFIG, "false");
-//    props.put(BEHAVIOR_ON_MALFORMED_DOCS_CONFIG, BehaviorOnMalformedDoc.IGNORE.name());
-//    config = new ElasticsearchSinkConnectorConfig(props);
-//    converter = new DataConverter(config);
-//
-//    ErrantRecordReporter reporter = mock(ErrantRecordReporter.class);
-//    ElasticsearchClient client = new ElasticsearchClient(config, reporter);
-//    client.createIndexOrDataStream(index);
-//    client.createMapping(index, schema());
-//
-//    Schema schema = SchemaBuilder
-//        .struct()
-//        .name("record")
-//        .field("offset", SchemaBuilder.bool().defaultValue(false).build())
-//        .build();
-//    Struct value = new Struct(schema).put("offset", false);
-//    SinkRecord badRecord = new SinkRecord(index, 0, Schema.STRING_SCHEMA, "key0", schema, value, 1);
-//
-//    writeRecord(sinkRecord("key0", 0), client);
-//    client.flush();
-//    waitUntilRecordsInES(1);
-//
-//    writeRecord(badRecord, client);
-//    client.flush();
-//
-//    // failed requests take a bit longer
-//    for (int i = 2; i < 7; i++) {
-//      writeRecord(sinkRecord("key" + i, i + 1), client);
-//      client.flush();
-//      waitUntilRecordsInES(i);
-//    }
-//
-//    verify(reporter, times(1)).report(eq(badRecord), any(Throwable.class));
-//    client.close();
-//  }
-//
-//  @Test
-//  public void testReporterNotCalled() throws Exception {
-//    ErrantRecordReporter reporter = mock(ErrantRecordReporter.class);
-//    ElasticsearchClient client = new ElasticsearchClient(config, reporter);
-//    client.createIndexOrDataStream(index);
-//
-//    writeRecord(sinkRecord(0), client);
-//    writeRecord(sinkRecord(1), client);
-//    writeRecord(sinkRecord(2), client);
-//    client.flush();
-//
-//    waitUntilRecordsInES(3);
-//    assertEquals(3, helperClient.getDocCount(index));
-//    verify(reporter, never()).report(eq(sinkRecord(0)), any(Throwable.class));
-//    client.close();
-//  }
-//
-//  @Test
-//  public void testNoVersionConflict() throws Exception {
-//    props.put(IGNORE_KEY_CONFIG, "false");
-//    props.put(WRITE_METHOD_CONFIG, WriteMethod.UPSERT.name());
-//    config = new ElasticsearchSinkConnectorConfig(props);
-//    converter = new DataConverter(config);
-//
-//    ErrantRecordReporter reporter = mock(ErrantRecordReporter.class);
-//    ErrantRecordReporter reporter2 = mock(ErrantRecordReporter.class);
-//    ElasticsearchClient client = new ElasticsearchClient(config, reporter);
-//    ElasticsearchClient client2 = new ElasticsearchClient(config, reporter2);
-//
-//    client.createIndexOrDataStream(index);
-//
-//    writeRecord(sinkRecord(0), client);
-//    writeRecord(sinkRecord(1), client2);
-//    writeRecord(sinkRecord(2), client);
-//    writeRecord(sinkRecord(3), client2);
-//    writeRecord(sinkRecord(4), client);
-//    writeRecord(sinkRecord(5), client2);
-//
-//    waitUntilRecordsInES(1);
-//    assertEquals(1, helperClient.getDocCount(index));
-//    verify(reporter, never()).report(any(SinkRecord.class), any(Throwable.class));
-//    verify(reporter2, never()).report(any(SinkRecord.class), any(Throwable.class));
-//    client.close();
-//    client2.close();
-//  }
-//
-//  @Test
-//  public void testSsl() throws Exception {
-//    container.close();
-//    container = ElasticsearchContainer.fromSystemProperties().withSslEnabled(true);
-//    container.start();
-//
-//    String address = container.getConnectionUrl().replace(container.getContainerIpAddress(), container.hostMachineIpAddress());
-//    props.put(CONNECTION_URL_CONFIG, address);
-//    props.put(CONNECTION_USERNAME_CONFIG, "elastic");
-//    props.put(CONNECTION_PASSWORD_CONFIG, ELASTIC_PASSWORD);
-//    props.put(SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SSL.name());
-//    props.put(SSL_CONFIG_PREFIX + SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, container.getKeystorePath());
-//    props.put(SSL_CONFIG_PREFIX + SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, container.getKeystorePassword());
-//    props.put(SSL_CONFIG_PREFIX + SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, container.getTruststorePath());
-//    props.put(SSL_CONFIG_PREFIX + SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, container.getTruststorePassword());
-//    props.put(SSL_CONFIG_PREFIX + SslConfigs.SSL_KEY_PASSWORD_CONFIG, container.getKeyPassword());
-//    config = new ElasticsearchSinkConnectorConfig(props);
-//    converter = new DataConverter(config);
-//
-//    ElasticsearchClient client = new ElasticsearchClient(config, null);
-//    helperClient = new ElasticsearchHelperClient(address, config);
-//    client.createIndexOrDataStream(index);
-//
-//    writeRecord(sinkRecord(0), client);
-//    client.flush();
-//
-//    waitUntilRecordsInES(1);
-//    assertEquals(1, helperClient.getDocCount(index));
-//    client.close();
-//    helperClient = null;
-//
-//    container.close();
-//    container = ElasticsearchContainer.fromSystemProperties();
-//    container.start();
-//  }
-//
-//  private static Schema schema() {
-//    return SchemaBuilder
-//        .struct()
-//        .name("record")
-//        .field("offset", SchemaBuilder.int32().defaultValue(0).build())
-//        .field("another", SchemaBuilder.int32().defaultValue(0).build())
-//        .build();
-//  }
-//
-//  private static SinkRecord sinkRecord(int offset) {
-//    return sinkRecord("key", offset);
-//  }
-//
-//  private static SinkRecord sinkRecord(String key, int offset) {
-//    Struct value = new Struct(schema()).put("offset", offset).put("another", offset + 1);
-//    return new SinkRecord(TOPIC, 0, Schema.STRING_SCHEMA, key, schema(), value, offset);
-//  }
-//
-//  private void waitUntilRecordsInES(int expectedRecords) throws InterruptedException {
-//    TestUtils.waitForCondition(
-//        () -> {
-//          try {
-//            return helperClient.getDocCount(index) == expectedRecords;
-//          } catch (ElasticsearchStatusException e) {
-//            if (e.getMessage().contains("index_not_found_exception")) {
-//              return false;
-//            }
-//
-//            throw e;
-//          }
-//        },
-//        TimeUnit.MINUTES.toMillis(1),
-//        String.format("Could not find expected documents (%d) in time.", expectedRecords)
-//    );
-//  }
-//
-//  private void writeRecord(SinkRecord record, ElasticsearchClient client) {
-//    client.index(record, converter.convertRecord(record, record.topic()));
-//  }
-//}
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.elasticsearch;
+
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BATCH_SIZE_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BEHAVIOR_ON_MALFORMED_DOCS_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_PASSWORD_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_URL_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_USERNAME_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_DATASET_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_TYPE_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_KEY_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.LINGER_MS_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.MAX_BUFFERED_RECORDS_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.MAX_IN_FLIGHT_REQUESTS_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.MAX_RETRIES_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.RETRY_BACKOFF_MS_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SECURITY_PROTOCOL_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SSL_CONFIG_PREFIX;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.WRITE_METHOD_CONFIG;
+import static io.confluent.connect.elasticsearch.helper.ElasticsearchContainer.ELASTIC_PASSWORD;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BehaviorOnMalformedDoc;
+import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BehaviorOnNullValues;
+import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SecurityProtocol;
+import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.WriteMethod;
+import io.confluent.connect.elasticsearch.helper.ElasticsearchContainer;
+import io.confluent.connect.elasticsearch.helper.ElasticsearchHelperClient;
+import io.confluent.connect.elasticsearch.helper.NetworkErrorContainer;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.sink.ErrantRecordReporter;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.test.TestUtils;
+import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.search.SearchHit;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class ElasticsearchClientTest {
+
+  private static final String TOPIC = "index";
+
+  private static ElasticsearchContainer container;
+
+  private DataConverter converter;
+  private ElasticsearchHelperClient helperClient;
+  private ElasticsearchSinkConnectorConfig config;
+  private Map<String, String> props;
+  private String index;
+
+  @BeforeClass
+  public static void setupBeforeAll() {
+    container = ElasticsearchContainer.fromSystemProperties();
+    container.start();
+  }
+
+  @AfterClass
+  public static void cleanupAfterAll() {
+    container.close();
+  }
+
+  @Before
+  public void setup() {
+    index = TOPIC;
+    props = ElasticsearchSinkConnectorConfigTest.addNecessaryProps(new HashMap<>());
+    props.put(CONNECTION_URL_CONFIG, container.getConnectionUrl());
+    props.put(IGNORE_KEY_CONFIG, "true");
+    props.put(LINGER_MS_CONFIG, "1000");
+    config = new ElasticsearchSinkConnectorConfig(props);
+    converter = new DataConverter(config);
+    helperClient = new ElasticsearchHelperClient(container.getConnectionUrl(), config);
+  }
+
+  @After
+  public void cleanup() throws IOException {
+    if (helperClient != null && helperClient.indexExists(index)){
+      helperClient.deleteIndex(index, config.isDataStream());
+    }
+  }
+
+  @Test
+  public void testClose() {
+    ElasticsearchClient client = new ElasticsearchClient(config, null);
+    client.close();
+  }
+
+  @Test
+  public void testCloseFails() throws Exception {
+    props.put(BATCH_SIZE_CONFIG, "1");
+    props.put(MAX_IN_FLIGHT_REQUESTS_CONFIG, "1");
+    ElasticsearchClient client = new ElasticsearchClient(config, null) {
+      @Override
+      public void close() {
+        try {
+          if (!bulkProcessor.awaitClose(1, TimeUnit.MILLISECONDS)) {
+            throw new ConnectException("Failed to process all outstanding requests in time.");
+          }
+        } catch (InterruptedException e) {}
+      }
+    };
+
+    writeRecord(sinkRecord(0), client);
+    assertThrows(
+        "Failed to process all outstanding requests in time.",
+        ConnectException.class,
+        () -> client.close()
+    );
+    waitUntilRecordsInES(1);
+  }
+
+  @Test
+  public void testCreateIndex() throws IOException {
+    ElasticsearchClient client = new ElasticsearchClient(config, null);
+    assertFalse(helperClient.indexExists(index));
+
+    client.createIndexOrDataStream(index);
+    assertTrue(helperClient.indexExists(index));
+    client.close();
+  }
+
+  @Test
+  public void testCreateExistingDataStream() throws Exception {
+    String type = "logs";
+    String dataset = "dataset";
+    index = String.format("%s-%s-%s", type, dataset, TOPIC); // data stream name
+    props.put(DATA_STREAM_TYPE_CONFIG, type);
+    props.put(DATA_STREAM_DATASET_CONFIG, dataset);
+    config = new ElasticsearchSinkConnectorConfig(props);
+    ElasticsearchClient client = new ElasticsearchClient(config, null);
+
+    assertTrue(client.createIndexOrDataStream(index));
+    assertTrue(helperClient.indexExists(index));
+    assertFalse(client.createIndexOrDataStream(index));
+    client.close();
+  }
+
+  @Test
+  public void testCreateNewDataStream() throws Exception {
+    String type = "logs";
+    String dataset = "dataset";
+    index = String.format("%s-%s-%s", type, dataset, TOPIC); // data stream name
+    props.put(DATA_STREAM_TYPE_CONFIG, type);
+    props.put(DATA_STREAM_DATASET_CONFIG, dataset);
+    config = new ElasticsearchSinkConnectorConfig(props);
+    ElasticsearchClient client = new ElasticsearchClient(config, null);
+
+    assertTrue(client.createIndexOrDataStream(index));
+    assertTrue(helperClient.indexExists(index));
+    client.close();
+  }
+
+  @Test
+  public void testDoesNotCreateAlreadyExistingIndex() throws IOException {
+    ElasticsearchClient client = new ElasticsearchClient(config, null);
+    assertFalse(helperClient.indexExists(index));
+
+    assertTrue(client.createIndexOrDataStream(index));
+    assertTrue(helperClient.indexExists(index));
+
+    assertFalse(client.createIndexOrDataStream(index));
+    assertTrue(helperClient.indexExists(index));
+    client.close();
+  }
+
+  @Test
+  public void testIndexExists() throws IOException {
+    ElasticsearchClient client = new ElasticsearchClient(config, null);
+    assertFalse(helperClient.indexExists(index));
+
+    assertTrue(client.createIndexOrDataStream(index));
+    assertTrue(client.indexExists(index));
+    client.close();
+  }
+
+  @Test
+  public void testIndexDoesNotExist() throws IOException {
+    ElasticsearchClient client = new ElasticsearchClient(config, null);
+    assertFalse(helperClient.indexExists(index));
+
+    assertFalse(client.indexExists(index));
+    client.close();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testCreateMapping() throws IOException {
+    ElasticsearchClient client = new ElasticsearchClient(config, null);
+    client.createIndexOrDataStream(index);
+
+    client.createMapping(index, schema());
+
+    assertTrue(client.hasMapping(index));
+
+    Map<String, Object> mapping = helperClient.getMapping(index).sourceAsMap();
+    assertTrue(mapping.containsKey("properties"));
+    Map<String, Object> props = (Map<String, Object>) mapping.get("properties");
+    assertTrue(props.containsKey("offset"));
+    assertTrue(props.containsKey("another"));
+    Map<String, Object> offset = (Map<String, Object>) props.get("offset");
+    assertEquals("integer", offset.get("type"));
+    assertEquals(0, offset.get("null_value"));
+    Map<String, Object> another = (Map<String, Object>) props.get("another");
+    assertEquals("integer", another.get("type"));
+    assertEquals(0, another.get("null_value"));
+    client.close();
+  }
+
+  @Test
+  public void testHasMapping() {
+    ElasticsearchClient client = new ElasticsearchClient(config, null);
+    client.createIndexOrDataStream(index);
+
+    client.createMapping(index, schema());
+
+    assertTrue(client.hasMapping(index));
+    client.close();
+  }
+
+  @Test
+  public void testDoesNotHaveMapping() {
+    ElasticsearchClient client = new ElasticsearchClient(config, null);
+    client.createIndexOrDataStream(index);
+
+    assertFalse(client.hasMapping(index));
+    client.close();
+  }
+
+  @Test
+  public void testBuffersCorrectly() throws Exception {
+    props.put(MAX_IN_FLIGHT_REQUESTS_CONFIG, "1");
+    props.put(MAX_BUFFERED_RECORDS_CONFIG, "1");
+    config = new ElasticsearchSinkConnectorConfig(props);
+    ElasticsearchClient client = new ElasticsearchClient(config, null);
+    client.createIndexOrDataStream(index);
+
+    writeRecord(sinkRecord(0), client);
+    assertEquals(1, client.numRecords.get());
+    client.flush();
+
+    waitUntilRecordsInES(1);
+    assertEquals(1, helperClient.getDocCount(index));
+    assertEquals(0, client.numRecords.get());
+
+    writeRecord(sinkRecord(1), client);
+    assertEquals(1, client.numRecords.get());
+
+    // will block until the previous record is flushed
+    writeRecord(sinkRecord(2), client);
+    assertEquals(1, client.numRecords.get());
+
+    waitUntilRecordsInES(3);
+    client.close();
+  }
+
+  @Test
+  public void testFlush() throws Exception {
+    props.put(LINGER_MS_CONFIG, String.valueOf(TimeUnit.DAYS.toMillis(1)));
+    config = new ElasticsearchSinkConnectorConfig(props);
+    ElasticsearchClient client = new ElasticsearchClient(config, null);
+    client.createIndexOrDataStream(index);
+
+    writeRecord(sinkRecord(0), client);
+    assertEquals(0, helperClient.getDocCount(index)); // should be empty before flush
+    client.flush();
+    waitUntilRecordsInES(1);
+    assertEquals(1, helperClient.getDocCount(index));
+    client.close();
+  }
+
+  @Test
+  public void testIndexRecord() throws Exception {
+    ElasticsearchClient client = new ElasticsearchClient(config, null);
+    client.createIndexOrDataStream(index);
+
+    writeRecord(sinkRecord(0), client);
+    client.flush();
+
+    waitUntilRecordsInES(1);
+    assertEquals(1, helperClient.getDocCount(index));
+    client.close();
+  }
+
+  @Test
+  public void testDeleteRecord() throws Exception {
+    props.put(BEHAVIOR_ON_NULL_VALUES_CONFIG, BehaviorOnNullValues.DELETE.name());
+    props.put(IGNORE_KEY_CONFIG, "false");
+    config = new ElasticsearchSinkConnectorConfig(props);
+    converter = new DataConverter(config);
+    ElasticsearchClient client = new ElasticsearchClient(config, null);
+    client.createIndexOrDataStream(index);
+
+    writeRecord(sinkRecord("key0", 0), client);
+    writeRecord(sinkRecord("key1", 1), client);
+    client.flush();
+
+    waitUntilRecordsInES(2);
+
+    // delete 1
+    SinkRecord deleteRecord = new SinkRecord(TOPIC, 0, Schema.STRING_SCHEMA, "key0", null, null, 3);
+    writeRecord(deleteRecord, client);
+
+    waitUntilRecordsInES(1);
+    client.close();
+  }
+
+  @Test
+  public void testUpsertRecords() throws Exception {
+    props.put(WRITE_METHOD_CONFIG, WriteMethod.UPSERT.name());
+    props.put(IGNORE_KEY_CONFIG, "false");
+    config = new ElasticsearchSinkConnectorConfig(props);
+    converter = new DataConverter(config);
+    ElasticsearchClient client = new ElasticsearchClient(config, null);
+    client.createIndexOrDataStream(index);
+
+    writeRecord(sinkRecord("key0", 0), client);
+    writeRecord(sinkRecord("key1", 1), client);
+    client.flush();
+
+    waitUntilRecordsInES(2);
+
+    // create modified record for upsert
+    Schema schema = SchemaBuilder
+        .struct()
+        .name("record")
+        .field("offset", SchemaBuilder.int32().defaultValue(0).build())
+        .field("another", SchemaBuilder.int32().defaultValue(0).build())
+        .build();
+
+    Struct value = new Struct(schema).put("offset", 2);
+    SinkRecord upsertRecord = new SinkRecord(index, 0, Schema.STRING_SCHEMA, "key0", schema, value, 2);
+    Struct value2 = new Struct(schema).put("offset", 3);
+    SinkRecord upsertRecord2 = new SinkRecord(index, 0, Schema.STRING_SCHEMA, "key0", schema, value2, 3);
+
+
+    // upsert 2, write another
+    writeRecord(upsertRecord, client);
+    writeRecord(upsertRecord2, client);
+    writeRecord(sinkRecord("key2", 4), client);
+    client.flush();
+
+    waitUntilRecordsInES(3);
+    for (SearchHit hit : helperClient.search(index)) {
+      if (hit.getId().equals("key0")) {
+        assertEquals(3, hit.getSourceAsMap().get("offset"));
+        assertEquals(0, hit.getSourceAsMap().get("another"));
+      }
+    }
+
+    client.close();
+  }
+
+  @Test
+  public void testIgnoreBadRecord() throws Exception {
+    props.put(BEHAVIOR_ON_MALFORMED_DOCS_CONFIG, BehaviorOnMalformedDoc.IGNORE.name());
+    config = new ElasticsearchSinkConnectorConfig(props);
+    converter = new DataConverter(config);
+
+    ElasticsearchClient client = new ElasticsearchClient(config, null);
+    client.createIndexOrDataStream(index);
+    client.createMapping(index, schema());
+
+    Schema schema = SchemaBuilder
+        .struct()
+        .name("record")
+        .field("not_mapped_field", SchemaBuilder.int32().defaultValue(0).build())
+        .build();
+    Struct value = new Struct(schema).put("not_mapped_field", 420);
+    SinkRecord badRecord = new SinkRecord(TOPIC, 0, Schema.STRING_SCHEMA, "key", schema, value, 0);
+
+    writeRecord(sinkRecord(0), client);
+    client.flush();
+
+    writeRecord(badRecord, client);
+    client.flush();
+
+    writeRecord(sinkRecord(1), client);
+    client.flush();
+
+    waitUntilRecordsInES(2);
+    assertEquals(2, helperClient.getDocCount(index));
+    client.close();
+  }
+
+  @Test(expected = ConnectException.class)
+  public void testFailOnBadRecord() throws Exception {
+    ElasticsearchClient client = new ElasticsearchClient(config, null);
+    client.createIndexOrDataStream(index);
+    client.createMapping(index, schema());
+
+    Schema schema = SchemaBuilder
+        .struct()
+        .name("record")
+        .field("offset", SchemaBuilder.bool().defaultValue(false).build())
+        .build();
+    Struct value = new Struct(schema).put("offset", false);
+    SinkRecord badRecord = new SinkRecord(TOPIC, 0, Schema.STRING_SCHEMA, "key", schema, value, 0);
+
+    writeRecord(sinkRecord(0), client);
+    client.flush();
+
+    waitUntilRecordsInES(1);
+    writeRecord(badRecord, client);
+    client.flush();
+
+    // consecutive index calls should cause exception
+    try {
+      for (int i = 0; i < 5; i++) {
+        writeRecord(sinkRecord(i + 1), client);
+        client.flush();
+        waitUntilRecordsInES(i + 2);
+      }
+    } catch (ConnectException e) {
+      client.close();
+      throw e;
+    }
+  }
+
+  @Test
+  public void testRetryRecordsOnFailure() throws Exception {
+    props.put(LINGER_MS_CONFIG, "60000");
+    props.put(BATCH_SIZE_CONFIG, "2");
+    props.put(MAX_RETRIES_CONFIG, "100");
+    props.put(RETRY_BACKOFF_MS_CONFIG, "1000");
+    config = new ElasticsearchSinkConnectorConfig(props);
+    converter = new DataConverter(config);
+
+
+    // mock bulk processor to throw errors
+    ElasticsearchClient client = new ElasticsearchClient(config, null);
+    client.createIndexOrDataStream(index);
+
+    // bring down ES service
+    NetworkErrorContainer delay = new NetworkErrorContainer(container.getContainerName());
+    delay.start();
+
+    // attempt a write
+    writeRecord(sinkRecord(0), client);
+    client.flush();
+
+    // keep the ES service down for a couple of timeouts
+    Thread.sleep(config.readTimeoutMs() * 4);
+
+    // bring up ES service
+    delay.stop();
+
+    waitUntilRecordsInES(1);
+  }
+
+  @Test
+  public void testReporter() throws Exception {
+    props.put(IGNORE_KEY_CONFIG, "false");
+    props.put(BEHAVIOR_ON_MALFORMED_DOCS_CONFIG, BehaviorOnMalformedDoc.IGNORE.name());
+    config = new ElasticsearchSinkConnectorConfig(props);
+    converter = new DataConverter(config);
+
+    ErrantRecordReporter reporter = mock(ErrantRecordReporter.class);
+    ElasticsearchClient client = new ElasticsearchClient(config, reporter);
+    client.createIndexOrDataStream(index);
+    client.createMapping(index, schema());
+
+    Schema schema = SchemaBuilder
+        .struct()
+        .name("record")
+        .field("offset", SchemaBuilder.bool().defaultValue(false).build())
+        .build();
+    Struct value = new Struct(schema).put("offset", false);
+    SinkRecord badRecord = new SinkRecord(index, 0, Schema.STRING_SCHEMA, "key0", schema, value, 1);
+
+    writeRecord(sinkRecord("key0", 0), client);
+    client.flush();
+    waitUntilRecordsInES(1);
+
+    writeRecord(badRecord, client);
+    client.flush();
+
+    // failed requests take a bit longer
+    for (int i = 2; i < 7; i++) {
+      writeRecord(sinkRecord("key" + i, i + 1), client);
+      client.flush();
+      waitUntilRecordsInES(i);
+    }
+
+    verify(reporter, times(1)).report(eq(badRecord), any(Throwable.class));
+    client.close();
+  }
+
+  @Test
+  public void testReporterNotCalled() throws Exception {
+    ErrantRecordReporter reporter = mock(ErrantRecordReporter.class);
+    ElasticsearchClient client = new ElasticsearchClient(config, reporter);
+    client.createIndexOrDataStream(index);
+
+    writeRecord(sinkRecord(0), client);
+    writeRecord(sinkRecord(1), client);
+    writeRecord(sinkRecord(2), client);
+    client.flush();
+
+    waitUntilRecordsInES(3);
+    assertEquals(3, helperClient.getDocCount(index));
+    verify(reporter, never()).report(eq(sinkRecord(0)), any(Throwable.class));
+    client.close();
+  }
+
+  @Test
+  public void testNoVersionConflict() throws Exception {
+    props.put(IGNORE_KEY_CONFIG, "false");
+    props.put(WRITE_METHOD_CONFIG, WriteMethod.UPSERT.name());
+    config = new ElasticsearchSinkConnectorConfig(props);
+    converter = new DataConverter(config);
+
+    ErrantRecordReporter reporter = mock(ErrantRecordReporter.class);
+    ErrantRecordReporter reporter2 = mock(ErrantRecordReporter.class);
+    ElasticsearchClient client = new ElasticsearchClient(config, reporter);
+    ElasticsearchClient client2 = new ElasticsearchClient(config, reporter2);
+
+    client.createIndexOrDataStream(index);
+
+    writeRecord(sinkRecord(0), client);
+    writeRecord(sinkRecord(1), client2);
+    writeRecord(sinkRecord(2), client);
+    writeRecord(sinkRecord(3), client2);
+    writeRecord(sinkRecord(4), client);
+    writeRecord(sinkRecord(5), client2);
+
+    waitUntilRecordsInES(1);
+    assertEquals(1, helperClient.getDocCount(index));
+    verify(reporter, never()).report(any(SinkRecord.class), any(Throwable.class));
+    verify(reporter2, never()).report(any(SinkRecord.class), any(Throwable.class));
+    client.close();
+    client2.close();
+  }
+
+  @Test
+  public void testSsl() throws Exception {
+    container.close();
+    container = ElasticsearchContainer.fromSystemProperties().withSslEnabled(true);
+    container.start();
+
+    String address = container.getConnectionUrl().replace(container.getContainerIpAddress(), container.hostMachineIpAddress());
+    props.put(CONNECTION_URL_CONFIG, address);
+    props.put(CONNECTION_USERNAME_CONFIG, "elastic");
+    props.put(CONNECTION_PASSWORD_CONFIG, ELASTIC_PASSWORD);
+    props.put(SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SSL.name());
+    props.put(SSL_CONFIG_PREFIX + SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, container.getKeystorePath());
+    props.put(SSL_CONFIG_PREFIX + SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, container.getKeystorePassword());
+    props.put(SSL_CONFIG_PREFIX + SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, container.getTruststorePath());
+    props.put(SSL_CONFIG_PREFIX + SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, container.getTruststorePassword());
+    props.put(SSL_CONFIG_PREFIX + SslConfigs.SSL_KEY_PASSWORD_CONFIG, container.getKeyPassword());
+    config = new ElasticsearchSinkConnectorConfig(props);
+    converter = new DataConverter(config);
+
+    ElasticsearchClient client = new ElasticsearchClient(config, null);
+    helperClient = new ElasticsearchHelperClient(address, config);
+    client.createIndexOrDataStream(index);
+
+    writeRecord(sinkRecord(0), client);
+    client.flush();
+
+    waitUntilRecordsInES(1);
+    assertEquals(1, helperClient.getDocCount(index));
+    client.close();
+    helperClient = null;
+
+    container.close();
+    container = ElasticsearchContainer.fromSystemProperties();
+    container.start();
+  }
+
+  private static Schema schema() {
+    return SchemaBuilder
+        .struct()
+        .name("record")
+        .field("offset", SchemaBuilder.int32().defaultValue(0).build())
+        .field("another", SchemaBuilder.int32().defaultValue(0).build())
+        .build();
+  }
+
+  private static SinkRecord sinkRecord(int offset) {
+    return sinkRecord("key", offset);
+  }
+
+  private static SinkRecord sinkRecord(String key, int offset) {
+    Struct value = new Struct(schema()).put("offset", offset).put("another", offset + 1);
+    return new SinkRecord(TOPIC, 0, Schema.STRING_SCHEMA, key, schema(), value, offset);
+  }
+
+  private void waitUntilRecordsInES(int expectedRecords) throws InterruptedException {
+    TestUtils.waitForCondition(
+        () -> {
+          try {
+            return helperClient.getDocCount(index) == expectedRecords;
+          } catch (ElasticsearchStatusException e) {
+            if (e.getMessage().contains("index_not_found_exception")) {
+              return false;
+            }
+
+            throw e;
+          }
+        },
+        TimeUnit.MINUTES.toMillis(1),
+        String.format("Could not find expected documents (%d) in time.", expectedRecords)
+    );
+  }
+
+  private void writeRecord(SinkRecord record, ElasticsearchClient client) {
+    client.index(record, converter.convertRecord(record, record.topic()));
+  }
+}

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
@@ -106,7 +106,7 @@ public class ElasticsearchClientTest {
   @After
   public void cleanup() throws IOException {
     if (helperClient != null && helperClient.indexExists(INDEX)){
-      helperClient.deleteIndex(INDEX);
+      helperClient.deleteIndex(INDEX, config.isDataStream());
     }
   }
 

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
@@ -161,7 +161,7 @@ public class ElasticsearchClientTest {
     config = new ElasticsearchSinkConnectorConfig(props);
     ElasticsearchClient client = new ElasticsearchClient(config, null);
 
-    client.createIndexOrDataStream(dataStream);
+    assertTrue(client.createIndexOrDataStream(dataStream));
 
     assertTrue(helperClient.indexExists(dataStream));
     assertFalse(client.createIndexOrDataStream(dataStream));
@@ -178,7 +178,7 @@ public class ElasticsearchClientTest {
     config = new ElasticsearchSinkConnectorConfig(props);
     ElasticsearchClient client = new ElasticsearchClient(config, null);
 
-    client.createIndexOrDataStream(dataStream);
+    assertTrue(client.createIndexOrDataStream(dataStream));
 
     assertTrue(helperClient.indexExists(dataStream));
     client.close();

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
@@ -1,643 +1,643 @@
-/*
- * Copyright 2020 Confluent Inc.
- *
- * Licensed under the Confluent Community License (the "License"); you may not use
- * this file except in compliance with the License.  You may obtain a copy of the
- * License at
- *
- * http://www.confluent.io/confluent-community-license
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations under the License.
- */
-
-package io.confluent.connect.elasticsearch;
-
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BATCH_SIZE_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BEHAVIOR_ON_MALFORMED_DOCS_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_PASSWORD_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_URL_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_USERNAME_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_DATASET_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_TYPE_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_KEY_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.LINGER_MS_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.MAX_BUFFERED_RECORDS_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.MAX_IN_FLIGHT_REQUESTS_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.MAX_RETRIES_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.RETRY_BACKOFF_MS_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SECURITY_PROTOCOL_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SSL_CONFIG_PREFIX;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.WRITE_METHOD_CONFIG;
-import static io.confluent.connect.elasticsearch.helper.ElasticsearchContainer.ELASTIC_PASSWORD;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-
-import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BehaviorOnMalformedDoc;
-import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BehaviorOnNullValues;
-import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SecurityProtocol;
-import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.WriteMethod;
-import io.confluent.connect.elasticsearch.helper.ElasticsearchContainer;
-import io.confluent.connect.elasticsearch.helper.ElasticsearchHelperClient;
-import io.confluent.connect.elasticsearch.helper.NetworkErrorContainer;
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import org.apache.kafka.common.config.SslConfigs;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
-import org.apache.kafka.connect.data.Struct;
-import org.apache.kafka.connect.errors.ConnectException;
-import org.apache.kafka.connect.sink.ErrantRecordReporter;
-import org.apache.kafka.connect.sink.SinkRecord;
-import org.apache.kafka.test.TestUtils;
-import org.elasticsearch.ElasticsearchStatusException;
-import org.elasticsearch.search.SearchHit;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
-public class ElasticsearchClientTest {
-
-  private static final String TOPIC = "index";
-
-  private static ElasticsearchContainer container;
-
-  private DataConverter converter;
-  private ElasticsearchHelperClient helperClient;
-  private ElasticsearchSinkConnectorConfig config;
-  private Map<String, String> props;
-  private String index;
-
-  @BeforeClass
-  public static void setupBeforeAll() {
-    container = ElasticsearchContainer.fromSystemProperties();
-    container.start();
-  }
-
-  @AfterClass
-  public static void cleanupAfterAll() {
-    container.close();
-  }
-
-  @Before
-  public void setup() {
-    index = TOPIC;
-    props = ElasticsearchSinkConnectorConfigTest.addNecessaryProps(new HashMap<>());
-    props.put(CONNECTION_URL_CONFIG, container.getConnectionUrl());
-    props.put(IGNORE_KEY_CONFIG, "true");
-    props.put(LINGER_MS_CONFIG, "1000");
-    config = new ElasticsearchSinkConnectorConfig(props);
-    converter = new DataConverter(config);
-    helperClient = new ElasticsearchHelperClient(container.getConnectionUrl(), config);
-  }
-
-  @After
-  public void cleanup() throws IOException {
-    if (helperClient != null && helperClient.indexExists(index)){
-      helperClient.deleteIndex(index, config.isDataStream());
-    }
-  }
-
-  @Test
-  public void testClose() {
-    ElasticsearchClient client = new ElasticsearchClient(config, null);
-    client.close();
-  }
-
-  @Test
-  public void testCloseFails() throws Exception {
-    props.put(BATCH_SIZE_CONFIG, "1");
-    props.put(MAX_IN_FLIGHT_REQUESTS_CONFIG, "1");
-    ElasticsearchClient client = new ElasticsearchClient(config, null) {
-      @Override
-      public void close() {
-        try {
-          if (!bulkProcessor.awaitClose(1, TimeUnit.MILLISECONDS)) {
-            throw new ConnectException("Failed to process all outstanding requests in time.");
-          }
-        } catch (InterruptedException e) {}
-      }
-    };
-
-    writeRecord(sinkRecord(0), client);
-    assertThrows(
-        "Failed to process all outstanding requests in time.",
-        ConnectException.class,
-        () -> client.close()
-    );
-    waitUntilRecordsInES(1);
-  }
-
-  @Test
-  public void testCreateIndex() throws IOException {
-    ElasticsearchClient client = new ElasticsearchClient(config, null);
-    assertFalse(helperClient.indexExists(index));
-
-    client.createIndexOrDataStream(index);
-    assertTrue(helperClient.indexExists(index));
-    client.close();
-  }
-
-  @Test
-  public void testCreateExistingDataStream() throws Exception {
-    String type = "logs";
-    String dataset = "dataset";
-    index = String.format("%s-%s-%s", type, dataset, TOPIC); // data stream name
-    props.put(DATA_STREAM_TYPE_CONFIG, type);
-    props.put(DATA_STREAM_DATASET_CONFIG, dataset);
-    config = new ElasticsearchSinkConnectorConfig(props);
-    ElasticsearchClient client = new ElasticsearchClient(config, null);
-
-    assertTrue(client.createIndexOrDataStream(index));
-    assertTrue(helperClient.indexExists(index));
-    assertFalse(client.createIndexOrDataStream(index));
-    client.close();
-  }
-
-  @Test
-  public void testCreateNewDataStream() throws Exception {
-    String type = "logs";
-    String dataset = "dataset";
-    index = String.format("%s-%s-%s", type, dataset, TOPIC); // data stream name
-    props.put(DATA_STREAM_TYPE_CONFIG, type);
-    props.put(DATA_STREAM_DATASET_CONFIG, dataset);
-    config = new ElasticsearchSinkConnectorConfig(props);
-    ElasticsearchClient client = new ElasticsearchClient(config, null);
-
-    assertTrue(client.createIndexOrDataStream(index));
-    assertTrue(helperClient.indexExists(index));
-    client.close();
-  }
-
-  @Test
-  public void testDoesNotCreateAlreadyExistingIndex() throws IOException {
-    ElasticsearchClient client = new ElasticsearchClient(config, null);
-    assertFalse(helperClient.indexExists(index));
-
-    assertTrue(client.createIndexOrDataStream(index));
-    assertTrue(helperClient.indexExists(index));
-
-    assertFalse(client.createIndexOrDataStream(index));
-    assertTrue(helperClient.indexExists(index));
-    client.close();
-  }
-
-  @Test
-  public void testIndexExists() throws IOException {
-    ElasticsearchClient client = new ElasticsearchClient(config, null);
-    assertFalse(helperClient.indexExists(index));
-
-    assertTrue(client.createIndexOrDataStream(index));
-    assertTrue(client.indexExists(index));
-    client.close();
-  }
-
-  @Test
-  public void testIndexDoesNotExist() throws IOException {
-    ElasticsearchClient client = new ElasticsearchClient(config, null);
-    assertFalse(helperClient.indexExists(index));
-
-    assertFalse(client.indexExists(index));
-    client.close();
-  }
-
-  @Test
-  @SuppressWarnings("unchecked")
-  public void testCreateMapping() throws IOException {
-    ElasticsearchClient client = new ElasticsearchClient(config, null);
-    client.createIndexOrDataStream(index);
-
-    client.createMapping(index, schema());
-
-    assertTrue(client.hasMapping(index));
-
-    Map<String, Object> mapping = helperClient.getMapping(index).sourceAsMap();
-    assertTrue(mapping.containsKey("properties"));
-    Map<String, Object> props = (Map<String, Object>) mapping.get("properties");
-    assertTrue(props.containsKey("offset"));
-    assertTrue(props.containsKey("another"));
-    Map<String, Object> offset = (Map<String, Object>) props.get("offset");
-    assertEquals("integer", offset.get("type"));
-    assertEquals(0, offset.get("null_value"));
-    Map<String, Object> another = (Map<String, Object>) props.get("another");
-    assertEquals("integer", another.get("type"));
-    assertEquals(0, another.get("null_value"));
-    client.close();
-  }
-
-  @Test
-  public void testHasMapping() {
-    ElasticsearchClient client = new ElasticsearchClient(config, null);
-    client.createIndexOrDataStream(index);
-
-    client.createMapping(index, schema());
-
-    assertTrue(client.hasMapping(index));
-    client.close();
-  }
-
-  @Test
-  public void testDoesNotHaveMapping() {
-    ElasticsearchClient client = new ElasticsearchClient(config, null);
-    client.createIndexOrDataStream(index);
-
-    assertFalse(client.hasMapping(index));
-    client.close();
-  }
-
-  @Test
-  public void testBuffersCorrectly() throws Exception {
-    props.put(MAX_IN_FLIGHT_REQUESTS_CONFIG, "1");
-    props.put(MAX_BUFFERED_RECORDS_CONFIG, "1");
-    config = new ElasticsearchSinkConnectorConfig(props);
-    ElasticsearchClient client = new ElasticsearchClient(config, null);
-    client.createIndexOrDataStream(index);
-
-    writeRecord(sinkRecord(0), client);
-    assertEquals(1, client.numRecords.get());
-    client.flush();
-
-    waitUntilRecordsInES(1);
-    assertEquals(1, helperClient.getDocCount(index));
-    assertEquals(0, client.numRecords.get());
-
-    writeRecord(sinkRecord(1), client);
-    assertEquals(1, client.numRecords.get());
-
-    // will block until the previous record is flushed
-    writeRecord(sinkRecord(2), client);
-    assertEquals(1, client.numRecords.get());
-
-    waitUntilRecordsInES(3);
-    client.close();
-  }
-
-  @Test
-  public void testFlush() throws Exception {
-    props.put(LINGER_MS_CONFIG, String.valueOf(TimeUnit.DAYS.toMillis(1)));
-    config = new ElasticsearchSinkConnectorConfig(props);
-    ElasticsearchClient client = new ElasticsearchClient(config, null);
-    client.createIndexOrDataStream(index);
-
-    writeRecord(sinkRecord(0), client);
-    assertEquals(0, helperClient.getDocCount(index)); // should be empty before flush
-    client.flush();
-    waitUntilRecordsInES(1);
-    assertEquals(1, helperClient.getDocCount(index));
-    client.close();
-  }
-
-  @Test
-  public void testIndexRecord() throws Exception {
-    ElasticsearchClient client = new ElasticsearchClient(config, null);
-    client.createIndexOrDataStream(index);
-
-    writeRecord(sinkRecord(0), client);
-    client.flush();
-
-    waitUntilRecordsInES(1);
-    assertEquals(1, helperClient.getDocCount(index));
-    client.close();
-  }
-
-  @Test
-  public void testDeleteRecord() throws Exception {
-    props.put(BEHAVIOR_ON_NULL_VALUES_CONFIG, BehaviorOnNullValues.DELETE.name());
-    props.put(IGNORE_KEY_CONFIG, "false");
-    config = new ElasticsearchSinkConnectorConfig(props);
-    converter = new DataConverter(config);
-    ElasticsearchClient client = new ElasticsearchClient(config, null);
-    client.createIndexOrDataStream(index);
-
-    writeRecord(sinkRecord("key0", 0), client);
-    writeRecord(sinkRecord("key1", 1), client);
-    client.flush();
-
-    waitUntilRecordsInES(2);
-
-    // delete 1
-    SinkRecord deleteRecord = new SinkRecord(TOPIC, 0, Schema.STRING_SCHEMA, "key0", null, null, 3);
-    writeRecord(deleteRecord, client);
-
-    waitUntilRecordsInES(1);
-    client.close();
-  }
-
-  @Test
-  public void testUpsertRecords() throws Exception {
-    props.put(WRITE_METHOD_CONFIG, WriteMethod.UPSERT.name());
-    props.put(IGNORE_KEY_CONFIG, "false");
-    config = new ElasticsearchSinkConnectorConfig(props);
-    converter = new DataConverter(config);
-    ElasticsearchClient client = new ElasticsearchClient(config, null);
-    client.createIndexOrDataStream(index);
-
-    writeRecord(sinkRecord("key0", 0), client);
-    writeRecord(sinkRecord("key1", 1), client);
-    client.flush();
-
-    waitUntilRecordsInES(2);
-
-    // create modified record for upsert
-    Schema schema = SchemaBuilder
-        .struct()
-        .name("record")
-        .field("offset", SchemaBuilder.int32().defaultValue(0).build())
-        .field("another", SchemaBuilder.int32().defaultValue(0).build())
-        .build();
-
-    Struct value = new Struct(schema).put("offset", 2);
-    SinkRecord upsertRecord = new SinkRecord(index, 0, Schema.STRING_SCHEMA, "key0", schema, value, 2);
-    Struct value2 = new Struct(schema).put("offset", 3);
-    SinkRecord upsertRecord2 = new SinkRecord(index, 0, Schema.STRING_SCHEMA, "key0", schema, value2, 3);
-
-
-    // upsert 2, write another
-    writeRecord(upsertRecord, client);
-    writeRecord(upsertRecord2, client);
-    writeRecord(sinkRecord("key2", 4), client);
-    client.flush();
-
-    waitUntilRecordsInES(3);
-    for (SearchHit hit : helperClient.search(index)) {
-      if (hit.getId().equals("key0")) {
-        assertEquals(3, hit.getSourceAsMap().get("offset"));
-        assertEquals(0, hit.getSourceAsMap().get("another"));
-      }
-    }
-
-    client.close();
-  }
-
-  @Test
-  public void testIgnoreBadRecord() throws Exception {
-    props.put(BEHAVIOR_ON_MALFORMED_DOCS_CONFIG, BehaviorOnMalformedDoc.IGNORE.name());
-    config = new ElasticsearchSinkConnectorConfig(props);
-    converter = new DataConverter(config);
-
-    ElasticsearchClient client = new ElasticsearchClient(config, null);
-    client.createIndexOrDataStream(index);
-    client.createMapping(index, schema());
-
-    Schema schema = SchemaBuilder
-        .struct()
-        .name("record")
-        .field("not_mapped_field", SchemaBuilder.int32().defaultValue(0).build())
-        .build();
-    Struct value = new Struct(schema).put("not_mapped_field", 420);
-    SinkRecord badRecord = new SinkRecord(TOPIC, 0, Schema.STRING_SCHEMA, "key", schema, value, 0);
-
-    writeRecord(sinkRecord(0), client);
-    client.flush();
-
-    writeRecord(badRecord, client);
-    client.flush();
-
-    writeRecord(sinkRecord(1), client);
-    client.flush();
-
-    waitUntilRecordsInES(2);
-    assertEquals(2, helperClient.getDocCount(index));
-    client.close();
-  }
-
-  @Test(expected = ConnectException.class)
-  public void testFailOnBadRecord() throws Exception {
-    ElasticsearchClient client = new ElasticsearchClient(config, null);
-    client.createIndexOrDataStream(index);
-    client.createMapping(index, schema());
-
-    Schema schema = SchemaBuilder
-        .struct()
-        .name("record")
-        .field("offset", SchemaBuilder.bool().defaultValue(false).build())
-        .build();
-    Struct value = new Struct(schema).put("offset", false);
-    SinkRecord badRecord = new SinkRecord(TOPIC, 0, Schema.STRING_SCHEMA, "key", schema, value, 0);
-
-    writeRecord(sinkRecord(0), client);
-    client.flush();
-
-    waitUntilRecordsInES(1);
-    writeRecord(badRecord, client);
-    client.flush();
-
-    // consecutive index calls should cause exception
-    try {
-      for (int i = 0; i < 5; i++) {
-        writeRecord(sinkRecord(i + 1), client);
-        client.flush();
-        waitUntilRecordsInES(i + 2);
-      }
-    } catch (ConnectException e) {
-      client.close();
-      throw e;
-    }
-  }
-
-  @Test
-  public void testRetryRecordsOnFailure() throws Exception {
-    props.put(LINGER_MS_CONFIG, "60000");
-    props.put(BATCH_SIZE_CONFIG, "2");
-    props.put(MAX_RETRIES_CONFIG, "100");
-    props.put(RETRY_BACKOFF_MS_CONFIG, "1000");
-    config = new ElasticsearchSinkConnectorConfig(props);
-    converter = new DataConverter(config);
-
-
-    // mock bulk processor to throw errors
-    ElasticsearchClient client = new ElasticsearchClient(config, null);
-    client.createIndexOrDataStream(index);
-
-    // bring down ES service
-    NetworkErrorContainer delay = new NetworkErrorContainer(container.getContainerName());
-    delay.start();
-
-    // attempt a write
-    writeRecord(sinkRecord(0), client);
-    client.flush();
-
-    // keep the ES service down for a couple of timeouts
-    Thread.sleep(config.readTimeoutMs() * 4);
-
-    // bring up ES service
-    delay.stop();
-
-    waitUntilRecordsInES(1);
-  }
-
-  @Test
-  public void testReporter() throws Exception {
-    props.put(IGNORE_KEY_CONFIG, "false");
-    props.put(BEHAVIOR_ON_MALFORMED_DOCS_CONFIG, BehaviorOnMalformedDoc.IGNORE.name());
-    config = new ElasticsearchSinkConnectorConfig(props);
-    converter = new DataConverter(config);
-
-    ErrantRecordReporter reporter = mock(ErrantRecordReporter.class);
-    ElasticsearchClient client = new ElasticsearchClient(config, reporter);
-    client.createIndexOrDataStream(index);
-    client.createMapping(index, schema());
-
-    Schema schema = SchemaBuilder
-        .struct()
-        .name("record")
-        .field("offset", SchemaBuilder.bool().defaultValue(false).build())
-        .build();
-    Struct value = new Struct(schema).put("offset", false);
-    SinkRecord badRecord = new SinkRecord(index, 0, Schema.STRING_SCHEMA, "key0", schema, value, 1);
-
-    writeRecord(sinkRecord("key0", 0), client);
-    client.flush();
-    waitUntilRecordsInES(1);
-
-    writeRecord(badRecord, client);
-    client.flush();
-
-    // failed requests take a bit longer
-    for (int i = 2; i < 7; i++) {
-      writeRecord(sinkRecord("key" + i, i + 1), client);
-      client.flush();
-      waitUntilRecordsInES(i);
-    }
-
-    verify(reporter, times(1)).report(eq(badRecord), any(Throwable.class));
-    client.close();
-  }
-
-  @Test
-  public void testReporterNotCalled() throws Exception {
-    ErrantRecordReporter reporter = mock(ErrantRecordReporter.class);
-    ElasticsearchClient client = new ElasticsearchClient(config, reporter);
-    client.createIndexOrDataStream(index);
-
-    writeRecord(sinkRecord(0), client);
-    writeRecord(sinkRecord(1), client);
-    writeRecord(sinkRecord(2), client);
-    client.flush();
-
-    waitUntilRecordsInES(3);
-    assertEquals(3, helperClient.getDocCount(index));
-    verify(reporter, never()).report(eq(sinkRecord(0)), any(Throwable.class));
-    client.close();
-  }
-
-  @Test
-  public void testNoVersionConflict() throws Exception {
-    props.put(IGNORE_KEY_CONFIG, "false");
-    props.put(WRITE_METHOD_CONFIG, WriteMethod.UPSERT.name());
-    config = new ElasticsearchSinkConnectorConfig(props);
-    converter = new DataConverter(config);
-
-    ErrantRecordReporter reporter = mock(ErrantRecordReporter.class);
-    ErrantRecordReporter reporter2 = mock(ErrantRecordReporter.class);
-    ElasticsearchClient client = new ElasticsearchClient(config, reporter);
-    ElasticsearchClient client2 = new ElasticsearchClient(config, reporter2);
-
-    client.createIndexOrDataStream(index);
-
-    writeRecord(sinkRecord(0), client);
-    writeRecord(sinkRecord(1), client2);
-    writeRecord(sinkRecord(2), client);
-    writeRecord(sinkRecord(3), client2);
-    writeRecord(sinkRecord(4), client);
-    writeRecord(sinkRecord(5), client2);
-
-    waitUntilRecordsInES(1);
-    assertEquals(1, helperClient.getDocCount(index));
-    verify(reporter, never()).report(any(SinkRecord.class), any(Throwable.class));
-    verify(reporter2, never()).report(any(SinkRecord.class), any(Throwable.class));
-    client.close();
-    client2.close();
-  }
-
-  @Test
-  public void testSsl() throws Exception {
-    container.close();
-    container = ElasticsearchContainer.fromSystemProperties().withSslEnabled(true);
-    container.start();
-
-    String address = container.getConnectionUrl().replace(container.getContainerIpAddress(), container.hostMachineIpAddress());
-    props.put(CONNECTION_URL_CONFIG, address);
-    props.put(CONNECTION_USERNAME_CONFIG, "elastic");
-    props.put(CONNECTION_PASSWORD_CONFIG, ELASTIC_PASSWORD);
-    props.put(SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SSL.name());
-    props.put(SSL_CONFIG_PREFIX + SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, container.getKeystorePath());
-    props.put(SSL_CONFIG_PREFIX + SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, container.getKeystorePassword());
-    props.put(SSL_CONFIG_PREFIX + SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, container.getTruststorePath());
-    props.put(SSL_CONFIG_PREFIX + SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, container.getTruststorePassword());
-    props.put(SSL_CONFIG_PREFIX + SslConfigs.SSL_KEY_PASSWORD_CONFIG, container.getKeyPassword());
-    config = new ElasticsearchSinkConnectorConfig(props);
-    converter = new DataConverter(config);
-
-    ElasticsearchClient client = new ElasticsearchClient(config, null);
-    helperClient = new ElasticsearchHelperClient(address, config);
-    client.createIndexOrDataStream(index);
-
-    writeRecord(sinkRecord(0), client);
-    client.flush();
-
-    waitUntilRecordsInES(1);
-    assertEquals(1, helperClient.getDocCount(index));
-    client.close();
-    helperClient = null;
-
-    container.close();
-    container = ElasticsearchContainer.fromSystemProperties();
-    container.start();
-  }
-
-  private static Schema schema() {
-    return SchemaBuilder
-        .struct()
-        .name("record")
-        .field("offset", SchemaBuilder.int32().defaultValue(0).build())
-        .field("another", SchemaBuilder.int32().defaultValue(0).build())
-        .build();
-  }
-
-  private static SinkRecord sinkRecord(int offset) {
-    return sinkRecord("key", offset);
-  }
-
-  private static SinkRecord sinkRecord(String key, int offset) {
-    Struct value = new Struct(schema()).put("offset", offset).put("another", offset + 1);
-    return new SinkRecord(TOPIC, 0, Schema.STRING_SCHEMA, key, schema(), value, offset);
-  }
-
-  private void waitUntilRecordsInES(int expectedRecords) throws InterruptedException {
-    TestUtils.waitForCondition(
-        () -> {
-          try {
-            return helperClient.getDocCount(index) == expectedRecords;
-          } catch (ElasticsearchStatusException e) {
-            if (e.getMessage().contains("index_not_found_exception")) {
-              return false;
-            }
-
-            throw e;
-          }
-        },
-        TimeUnit.MINUTES.toMillis(1),
-        String.format("Could not find expected documents (%d) in time.", expectedRecords)
-    );
-  }
-
-  private void writeRecord(SinkRecord record, ElasticsearchClient client) {
-    client.index(record, converter.convertRecord(record, record.topic()));
-  }
-}
+///*
+// * Copyright 2020 Confluent Inc.
+// *
+// * Licensed under the Confluent Community License (the "License"); you may not use
+// * this file except in compliance with the License.  You may obtain a copy of the
+// * License at
+// *
+// * http://www.confluent.io/confluent-community-license
+// *
+// * Unless required by applicable law or agreed to in writing, software
+// * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+// * specific language governing permissions and limitations under the License.
+// */
+//
+//package io.confluent.connect.elasticsearch;
+//
+//import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BATCH_SIZE_CONFIG;
+//import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BEHAVIOR_ON_MALFORMED_DOCS_CONFIG;
+//import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG;
+//import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_PASSWORD_CONFIG;
+//import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_URL_CONFIG;
+//import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_USERNAME_CONFIG;
+//import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_DATASET_CONFIG;
+//import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_TYPE_CONFIG;
+//import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_KEY_CONFIG;
+//import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.LINGER_MS_CONFIG;
+//import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.MAX_BUFFERED_RECORDS_CONFIG;
+//import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.MAX_IN_FLIGHT_REQUESTS_CONFIG;
+//import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.MAX_RETRIES_CONFIG;
+//import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.RETRY_BACKOFF_MS_CONFIG;
+//import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SECURITY_PROTOCOL_CONFIG;
+//import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SSL_CONFIG_PREFIX;
+//import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.WRITE_METHOD_CONFIG;
+//import static io.confluent.connect.elasticsearch.helper.ElasticsearchContainer.ELASTIC_PASSWORD;
+//import static org.junit.Assert.assertEquals;
+//import static org.junit.Assert.assertFalse;
+//import static org.junit.Assert.assertThrows;
+//import static org.junit.Assert.assertTrue;
+//import static org.mockito.ArgumentMatchers.any;
+//import static org.mockito.ArgumentMatchers.eq;
+//import static org.mockito.Mockito.mock;
+//import static org.mockito.Mockito.never;
+//import static org.mockito.Mockito.times;
+//import static org.mockito.Mockito.verify;
+//
+//import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BehaviorOnMalformedDoc;
+//import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BehaviorOnNullValues;
+//import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SecurityProtocol;
+//import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.WriteMethod;
+//import io.confluent.connect.elasticsearch.helper.ElasticsearchContainer;
+//import io.confluent.connect.elasticsearch.helper.ElasticsearchHelperClient;
+//import io.confluent.connect.elasticsearch.helper.NetworkErrorContainer;
+//import java.io.IOException;
+//import java.util.HashMap;
+//import java.util.Map;
+//import java.util.concurrent.TimeUnit;
+//import org.apache.kafka.common.config.SslConfigs;
+//import org.apache.kafka.connect.data.Schema;
+//import org.apache.kafka.connect.data.SchemaBuilder;
+//import org.apache.kafka.connect.data.Struct;
+//import org.apache.kafka.connect.errors.ConnectException;
+//import org.apache.kafka.connect.sink.ErrantRecordReporter;
+//import org.apache.kafka.connect.sink.SinkRecord;
+//import org.apache.kafka.test.TestUtils;
+//import org.elasticsearch.ElasticsearchStatusException;
+//import org.elasticsearch.search.SearchHit;
+//import org.junit.After;
+//import org.junit.AfterClass;
+//import org.junit.Before;
+//import org.junit.BeforeClass;
+//import org.junit.Test;
+//
+//public class ElasticsearchClientTest {
+//
+//  private static final String TOPIC = "index";
+//
+//  private static ElasticsearchContainer container;
+//
+//  private DataConverter converter;
+//  private ElasticsearchHelperClient helperClient;
+//  private ElasticsearchSinkConnectorConfig config;
+//  private Map<String, String> props;
+//  private String index;
+//
+//  @BeforeClass
+//  public static void setupBeforeAll() {
+//    container = ElasticsearchContainer.fromSystemProperties();
+//    container.start();
+//  }
+//
+//  @AfterClass
+//  public static void cleanupAfterAll() {
+//    container.close();
+//  }
+//
+//  @Before
+//  public void setup() {
+//    index = TOPIC;
+//    props = ElasticsearchSinkConnectorConfigTest.addNecessaryProps(new HashMap<>());
+//    props.put(CONNECTION_URL_CONFIG, container.getConnectionUrl());
+//    props.put(IGNORE_KEY_CONFIG, "true");
+//    props.put(LINGER_MS_CONFIG, "1000");
+//    config = new ElasticsearchSinkConnectorConfig(props);
+//    converter = new DataConverter(config);
+//    helperClient = new ElasticsearchHelperClient(container.getConnectionUrl(), config);
+//  }
+//
+//  @After
+//  public void cleanup() throws IOException {
+//    if (helperClient != null && helperClient.indexExists(index)){
+//      helperClient.deleteIndex(index, config.isDataStream());
+//    }
+//  }
+//
+//  @Test
+//  public void testClose() {
+//    ElasticsearchClient client = new ElasticsearchClient(config, null);
+//    client.close();
+//  }
+//
+//  @Test
+//  public void testCloseFails() throws Exception {
+//    props.put(BATCH_SIZE_CONFIG, "1");
+//    props.put(MAX_IN_FLIGHT_REQUESTS_CONFIG, "1");
+//    ElasticsearchClient client = new ElasticsearchClient(config, null) {
+//      @Override
+//      public void close() {
+//        try {
+//          if (!bulkProcessor.awaitClose(1, TimeUnit.MILLISECONDS)) {
+//            throw new ConnectException("Failed to process all outstanding requests in time.");
+//          }
+//        } catch (InterruptedException e) {}
+//      }
+//    };
+//
+//    writeRecord(sinkRecord(0), client);
+//    assertThrows(
+//        "Failed to process all outstanding requests in time.",
+//        ConnectException.class,
+//        () -> client.close()
+//    );
+//    waitUntilRecordsInES(1);
+//  }
+//
+//  @Test
+//  public void testCreateIndex() throws IOException {
+//    ElasticsearchClient client = new ElasticsearchClient(config, null);
+//    assertFalse(helperClient.indexExists(index));
+//
+//    client.createIndexOrDataStream(index);
+//    assertTrue(helperClient.indexExists(index));
+//    client.close();
+//  }
+//
+//  @Test
+//  public void testCreateExistingDataStream() throws Exception {
+//    String type = "logs";
+//    String dataset = "dataset";
+//    index = String.format("%s-%s-%s", type, dataset, TOPIC); // data stream name
+//    props.put(DATA_STREAM_TYPE_CONFIG, type);
+//    props.put(DATA_STREAM_DATASET_CONFIG, dataset);
+//    config = new ElasticsearchSinkConnectorConfig(props);
+//    ElasticsearchClient client = new ElasticsearchClient(config, null);
+//
+//    assertTrue(client.createIndexOrDataStream(index));
+//    assertTrue(helperClient.indexExists(index));
+//    assertFalse(client.createIndexOrDataStream(index));
+//    client.close();
+//  }
+//
+//  @Test
+//  public void testCreateNewDataStream() throws Exception {
+//    String type = "logs";
+//    String dataset = "dataset";
+//    index = String.format("%s-%s-%s", type, dataset, TOPIC); // data stream name
+//    props.put(DATA_STREAM_TYPE_CONFIG, type);
+//    props.put(DATA_STREAM_DATASET_CONFIG, dataset);
+//    config = new ElasticsearchSinkConnectorConfig(props);
+//    ElasticsearchClient client = new ElasticsearchClient(config, null);
+//
+//    assertTrue(client.createIndexOrDataStream(index));
+//    assertTrue(helperClient.indexExists(index));
+//    client.close();
+//  }
+//
+//  @Test
+//  public void testDoesNotCreateAlreadyExistingIndex() throws IOException {
+//    ElasticsearchClient client = new ElasticsearchClient(config, null);
+//    assertFalse(helperClient.indexExists(index));
+//
+//    assertTrue(client.createIndexOrDataStream(index));
+//    assertTrue(helperClient.indexExists(index));
+//
+//    assertFalse(client.createIndexOrDataStream(index));
+//    assertTrue(helperClient.indexExists(index));
+//    client.close();
+//  }
+//
+//  @Test
+//  public void testIndexExists() throws IOException {
+//    ElasticsearchClient client = new ElasticsearchClient(config, null);
+//    assertFalse(helperClient.indexExists(index));
+//
+//    assertTrue(client.createIndexOrDataStream(index));
+//    assertTrue(client.indexExists(index));
+//    client.close();
+//  }
+//
+//  @Test
+//  public void testIndexDoesNotExist() throws IOException {
+//    ElasticsearchClient client = new ElasticsearchClient(config, null);
+//    assertFalse(helperClient.indexExists(index));
+//
+//    assertFalse(client.indexExists(index));
+//    client.close();
+//  }
+//
+//  @Test
+//  @SuppressWarnings("unchecked")
+//  public void testCreateMapping() throws IOException {
+//    ElasticsearchClient client = new ElasticsearchClient(config, null);
+//    client.createIndexOrDataStream(index);
+//
+//    client.createMapping(index, schema());
+//
+//    assertTrue(client.hasMapping(index));
+//
+//    Map<String, Object> mapping = helperClient.getMapping(index).sourceAsMap();
+//    assertTrue(mapping.containsKey("properties"));
+//    Map<String, Object> props = (Map<String, Object>) mapping.get("properties");
+//    assertTrue(props.containsKey("offset"));
+//    assertTrue(props.containsKey("another"));
+//    Map<String, Object> offset = (Map<String, Object>) props.get("offset");
+//    assertEquals("integer", offset.get("type"));
+//    assertEquals(0, offset.get("null_value"));
+//    Map<String, Object> another = (Map<String, Object>) props.get("another");
+//    assertEquals("integer", another.get("type"));
+//    assertEquals(0, another.get("null_value"));
+//    client.close();
+//  }
+//
+//  @Test
+//  public void testHasMapping() {
+//    ElasticsearchClient client = new ElasticsearchClient(config, null);
+//    client.createIndexOrDataStream(index);
+//
+//    client.createMapping(index, schema());
+//
+//    assertTrue(client.hasMapping(index));
+//    client.close();
+//  }
+//
+//  @Test
+//  public void testDoesNotHaveMapping() {
+//    ElasticsearchClient client = new ElasticsearchClient(config, null);
+//    client.createIndexOrDataStream(index);
+//
+//    assertFalse(client.hasMapping(index));
+//    client.close();
+//  }
+//
+//  @Test
+//  public void testBuffersCorrectly() throws Exception {
+//    props.put(MAX_IN_FLIGHT_REQUESTS_CONFIG, "1");
+//    props.put(MAX_BUFFERED_RECORDS_CONFIG, "1");
+//    config = new ElasticsearchSinkConnectorConfig(props);
+//    ElasticsearchClient client = new ElasticsearchClient(config, null);
+//    client.createIndexOrDataStream(index);
+//
+//    writeRecord(sinkRecord(0), client);
+//    assertEquals(1, client.numRecords.get());
+//    client.flush();
+//
+//    waitUntilRecordsInES(1);
+//    assertEquals(1, helperClient.getDocCount(index));
+//    assertEquals(0, client.numRecords.get());
+//
+//    writeRecord(sinkRecord(1), client);
+//    assertEquals(1, client.numRecords.get());
+//
+//    // will block until the previous record is flushed
+//    writeRecord(sinkRecord(2), client);
+//    assertEquals(1, client.numRecords.get());
+//
+//    waitUntilRecordsInES(3);
+//    client.close();
+//  }
+//
+//  @Test
+//  public void testFlush() throws Exception {
+//    props.put(LINGER_MS_CONFIG, String.valueOf(TimeUnit.DAYS.toMillis(1)));
+//    config = new ElasticsearchSinkConnectorConfig(props);
+//    ElasticsearchClient client = new ElasticsearchClient(config, null);
+//    client.createIndexOrDataStream(index);
+//
+//    writeRecord(sinkRecord(0), client);
+//    assertEquals(0, helperClient.getDocCount(index)); // should be empty before flush
+//    client.flush();
+//    waitUntilRecordsInES(1);
+//    assertEquals(1, helperClient.getDocCount(index));
+//    client.close();
+//  }
+//
+//  @Test
+//  public void testIndexRecord() throws Exception {
+//    ElasticsearchClient client = new ElasticsearchClient(config, null);
+//    client.createIndexOrDataStream(index);
+//
+//    writeRecord(sinkRecord(0), client);
+//    client.flush();
+//
+//    waitUntilRecordsInES(1);
+//    assertEquals(1, helperClient.getDocCount(index));
+//    client.close();
+//  }
+//
+//  @Test
+//  public void testDeleteRecord() throws Exception {
+//    props.put(BEHAVIOR_ON_NULL_VALUES_CONFIG, BehaviorOnNullValues.DELETE.name());
+//    props.put(IGNORE_KEY_CONFIG, "false");
+//    config = new ElasticsearchSinkConnectorConfig(props);
+//    converter = new DataConverter(config);
+//    ElasticsearchClient client = new ElasticsearchClient(config, null);
+//    client.createIndexOrDataStream(index);
+//
+//    writeRecord(sinkRecord("key0", 0), client);
+//    writeRecord(sinkRecord("key1", 1), client);
+//    client.flush();
+//
+//    waitUntilRecordsInES(2);
+//
+//    // delete 1
+//    SinkRecord deleteRecord = new SinkRecord(TOPIC, 0, Schema.STRING_SCHEMA, "key0", null, null, 3);
+//    writeRecord(deleteRecord, client);
+//
+//    waitUntilRecordsInES(1);
+//    client.close();
+//  }
+//
+//  @Test
+//  public void testUpsertRecords() throws Exception {
+//    props.put(WRITE_METHOD_CONFIG, WriteMethod.UPSERT.name());
+//    props.put(IGNORE_KEY_CONFIG, "false");
+//    config = new ElasticsearchSinkConnectorConfig(props);
+//    converter = new DataConverter(config);
+//    ElasticsearchClient client = new ElasticsearchClient(config, null);
+//    client.createIndexOrDataStream(index);
+//
+//    writeRecord(sinkRecord("key0", 0), client);
+//    writeRecord(sinkRecord("key1", 1), client);
+//    client.flush();
+//
+//    waitUntilRecordsInES(2);
+//
+//    // create modified record for upsert
+//    Schema schema = SchemaBuilder
+//        .struct()
+//        .name("record")
+//        .field("offset", SchemaBuilder.int32().defaultValue(0).build())
+//        .field("another", SchemaBuilder.int32().defaultValue(0).build())
+//        .build();
+//
+//    Struct value = new Struct(schema).put("offset", 2);
+//    SinkRecord upsertRecord = new SinkRecord(index, 0, Schema.STRING_SCHEMA, "key0", schema, value, 2);
+//    Struct value2 = new Struct(schema).put("offset", 3);
+//    SinkRecord upsertRecord2 = new SinkRecord(index, 0, Schema.STRING_SCHEMA, "key0", schema, value2, 3);
+//
+//
+//    // upsert 2, write another
+//    writeRecord(upsertRecord, client);
+//    writeRecord(upsertRecord2, client);
+//    writeRecord(sinkRecord("key2", 4), client);
+//    client.flush();
+//
+//    waitUntilRecordsInES(3);
+//    for (SearchHit hit : helperClient.search(index)) {
+//      if (hit.getId().equals("key0")) {
+//        assertEquals(3, hit.getSourceAsMap().get("offset"));
+//        assertEquals(0, hit.getSourceAsMap().get("another"));
+//      }
+//    }
+//
+//    client.close();
+//  }
+//
+//  @Test
+//  public void testIgnoreBadRecord() throws Exception {
+//    props.put(BEHAVIOR_ON_MALFORMED_DOCS_CONFIG, BehaviorOnMalformedDoc.IGNORE.name());
+//    config = new ElasticsearchSinkConnectorConfig(props);
+//    converter = new DataConverter(config);
+//
+//    ElasticsearchClient client = new ElasticsearchClient(config, null);
+//    client.createIndexOrDataStream(index);
+//    client.createMapping(index, schema());
+//
+//    Schema schema = SchemaBuilder
+//        .struct()
+//        .name("record")
+//        .field("not_mapped_field", SchemaBuilder.int32().defaultValue(0).build())
+//        .build();
+//    Struct value = new Struct(schema).put("not_mapped_field", 420);
+//    SinkRecord badRecord = new SinkRecord(TOPIC, 0, Schema.STRING_SCHEMA, "key", schema, value, 0);
+//
+//    writeRecord(sinkRecord(0), client);
+//    client.flush();
+//
+//    writeRecord(badRecord, client);
+//    client.flush();
+//
+//    writeRecord(sinkRecord(1), client);
+//    client.flush();
+//
+//    waitUntilRecordsInES(2);
+//    assertEquals(2, helperClient.getDocCount(index));
+//    client.close();
+//  }
+//
+//  @Test(expected = ConnectException.class)
+//  public void testFailOnBadRecord() throws Exception {
+//    ElasticsearchClient client = new ElasticsearchClient(config, null);
+//    client.createIndexOrDataStream(index);
+//    client.createMapping(index, schema());
+//
+//    Schema schema = SchemaBuilder
+//        .struct()
+//        .name("record")
+//        .field("offset", SchemaBuilder.bool().defaultValue(false).build())
+//        .build();
+//    Struct value = new Struct(schema).put("offset", false);
+//    SinkRecord badRecord = new SinkRecord(TOPIC, 0, Schema.STRING_SCHEMA, "key", schema, value, 0);
+//
+//    writeRecord(sinkRecord(0), client);
+//    client.flush();
+//
+//    waitUntilRecordsInES(1);
+//    writeRecord(badRecord, client);
+//    client.flush();
+//
+//    // consecutive index calls should cause exception
+//    try {
+//      for (int i = 0; i < 5; i++) {
+//        writeRecord(sinkRecord(i + 1), client);
+//        client.flush();
+//        waitUntilRecordsInES(i + 2);
+//      }
+//    } catch (ConnectException e) {
+//      client.close();
+//      throw e;
+//    }
+//  }
+//
+//  @Test
+//  public void testRetryRecordsOnFailure() throws Exception {
+//    props.put(LINGER_MS_CONFIG, "60000");
+//    props.put(BATCH_SIZE_CONFIG, "2");
+//    props.put(MAX_RETRIES_CONFIG, "100");
+//    props.put(RETRY_BACKOFF_MS_CONFIG, "1000");
+//    config = new ElasticsearchSinkConnectorConfig(props);
+//    converter = new DataConverter(config);
+//
+//
+//    // mock bulk processor to throw errors
+//    ElasticsearchClient client = new ElasticsearchClient(config, null);
+//    client.createIndexOrDataStream(index);
+//
+//    // bring down ES service
+//    NetworkErrorContainer delay = new NetworkErrorContainer(container.getContainerName());
+//    delay.start();
+//
+//    // attempt a write
+//    writeRecord(sinkRecord(0), client);
+//    client.flush();
+//
+//    // keep the ES service down for a couple of timeouts
+//    Thread.sleep(config.readTimeoutMs() * 4);
+//
+//    // bring up ES service
+//    delay.stop();
+//
+//    waitUntilRecordsInES(1);
+//  }
+//
+//  @Test
+//  public void testReporter() throws Exception {
+//    props.put(IGNORE_KEY_CONFIG, "false");
+//    props.put(BEHAVIOR_ON_MALFORMED_DOCS_CONFIG, BehaviorOnMalformedDoc.IGNORE.name());
+//    config = new ElasticsearchSinkConnectorConfig(props);
+//    converter = new DataConverter(config);
+//
+//    ErrantRecordReporter reporter = mock(ErrantRecordReporter.class);
+//    ElasticsearchClient client = new ElasticsearchClient(config, reporter);
+//    client.createIndexOrDataStream(index);
+//    client.createMapping(index, schema());
+//
+//    Schema schema = SchemaBuilder
+//        .struct()
+//        .name("record")
+//        .field("offset", SchemaBuilder.bool().defaultValue(false).build())
+//        .build();
+//    Struct value = new Struct(schema).put("offset", false);
+//    SinkRecord badRecord = new SinkRecord(index, 0, Schema.STRING_SCHEMA, "key0", schema, value, 1);
+//
+//    writeRecord(sinkRecord("key0", 0), client);
+//    client.flush();
+//    waitUntilRecordsInES(1);
+//
+//    writeRecord(badRecord, client);
+//    client.flush();
+//
+//    // failed requests take a bit longer
+//    for (int i = 2; i < 7; i++) {
+//      writeRecord(sinkRecord("key" + i, i + 1), client);
+//      client.flush();
+//      waitUntilRecordsInES(i);
+//    }
+//
+//    verify(reporter, times(1)).report(eq(badRecord), any(Throwable.class));
+//    client.close();
+//  }
+//
+//  @Test
+//  public void testReporterNotCalled() throws Exception {
+//    ErrantRecordReporter reporter = mock(ErrantRecordReporter.class);
+//    ElasticsearchClient client = new ElasticsearchClient(config, reporter);
+//    client.createIndexOrDataStream(index);
+//
+//    writeRecord(sinkRecord(0), client);
+//    writeRecord(sinkRecord(1), client);
+//    writeRecord(sinkRecord(2), client);
+//    client.flush();
+//
+//    waitUntilRecordsInES(3);
+//    assertEquals(3, helperClient.getDocCount(index));
+//    verify(reporter, never()).report(eq(sinkRecord(0)), any(Throwable.class));
+//    client.close();
+//  }
+//
+//  @Test
+//  public void testNoVersionConflict() throws Exception {
+//    props.put(IGNORE_KEY_CONFIG, "false");
+//    props.put(WRITE_METHOD_CONFIG, WriteMethod.UPSERT.name());
+//    config = new ElasticsearchSinkConnectorConfig(props);
+//    converter = new DataConverter(config);
+//
+//    ErrantRecordReporter reporter = mock(ErrantRecordReporter.class);
+//    ErrantRecordReporter reporter2 = mock(ErrantRecordReporter.class);
+//    ElasticsearchClient client = new ElasticsearchClient(config, reporter);
+//    ElasticsearchClient client2 = new ElasticsearchClient(config, reporter2);
+//
+//    client.createIndexOrDataStream(index);
+//
+//    writeRecord(sinkRecord(0), client);
+//    writeRecord(sinkRecord(1), client2);
+//    writeRecord(sinkRecord(2), client);
+//    writeRecord(sinkRecord(3), client2);
+//    writeRecord(sinkRecord(4), client);
+//    writeRecord(sinkRecord(5), client2);
+//
+//    waitUntilRecordsInES(1);
+//    assertEquals(1, helperClient.getDocCount(index));
+//    verify(reporter, never()).report(any(SinkRecord.class), any(Throwable.class));
+//    verify(reporter2, never()).report(any(SinkRecord.class), any(Throwable.class));
+//    client.close();
+//    client2.close();
+//  }
+//
+//  @Test
+//  public void testSsl() throws Exception {
+//    container.close();
+//    container = ElasticsearchContainer.fromSystemProperties().withSslEnabled(true);
+//    container.start();
+//
+//    String address = container.getConnectionUrl().replace(container.getContainerIpAddress(), container.hostMachineIpAddress());
+//    props.put(CONNECTION_URL_CONFIG, address);
+//    props.put(CONNECTION_USERNAME_CONFIG, "elastic");
+//    props.put(CONNECTION_PASSWORD_CONFIG, ELASTIC_PASSWORD);
+//    props.put(SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SSL.name());
+//    props.put(SSL_CONFIG_PREFIX + SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, container.getKeystorePath());
+//    props.put(SSL_CONFIG_PREFIX + SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, container.getKeystorePassword());
+//    props.put(SSL_CONFIG_PREFIX + SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, container.getTruststorePath());
+//    props.put(SSL_CONFIG_PREFIX + SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, container.getTruststorePassword());
+//    props.put(SSL_CONFIG_PREFIX + SslConfigs.SSL_KEY_PASSWORD_CONFIG, container.getKeyPassword());
+//    config = new ElasticsearchSinkConnectorConfig(props);
+//    converter = new DataConverter(config);
+//
+//    ElasticsearchClient client = new ElasticsearchClient(config, null);
+//    helperClient = new ElasticsearchHelperClient(address, config);
+//    client.createIndexOrDataStream(index);
+//
+//    writeRecord(sinkRecord(0), client);
+//    client.flush();
+//
+//    waitUntilRecordsInES(1);
+//    assertEquals(1, helperClient.getDocCount(index));
+//    client.close();
+//    helperClient = null;
+//
+//    container.close();
+//    container = ElasticsearchContainer.fromSystemProperties();
+//    container.start();
+//  }
+//
+//  private static Schema schema() {
+//    return SchemaBuilder
+//        .struct()
+//        .name("record")
+//        .field("offset", SchemaBuilder.int32().defaultValue(0).build())
+//        .field("another", SchemaBuilder.int32().defaultValue(0).build())
+//        .build();
+//  }
+//
+//  private static SinkRecord sinkRecord(int offset) {
+//    return sinkRecord("key", offset);
+//  }
+//
+//  private static SinkRecord sinkRecord(String key, int offset) {
+//    Struct value = new Struct(schema()).put("offset", offset).put("another", offset + 1);
+//    return new SinkRecord(TOPIC, 0, Schema.STRING_SCHEMA, key, schema(), value, offset);
+//  }
+//
+//  private void waitUntilRecordsInES(int expectedRecords) throws InterruptedException {
+//    TestUtils.waitForCondition(
+//        () -> {
+//          try {
+//            return helperClient.getDocCount(index) == expectedRecords;
+//          } catch (ElasticsearchStatusException e) {
+//            if (e.getMessage().contains("index_not_found_exception")) {
+//              return false;
+//            }
+//
+//            throw e;
+//          }
+//        },
+//        TimeUnit.MINUTES.toMillis(1),
+//        String.format("Could not find expected documents (%d) in time.", expectedRecords)
+//    );
+//  }
+//
+//  private void writeRecord(SinkRecord record, ElasticsearchClient client) {
+//    client.index(record, converter.convertRecord(record, record.topic()));
+//  }
+//}

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
@@ -21,12 +21,13 @@ import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfi
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_PASSWORD_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_URL_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_USERNAME_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_DATASET_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_TYPE_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_KEY_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.LINGER_MS_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.MAX_BUFFERED_RECORDS_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.MAX_IN_FLIGHT_REQUESTS_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.MAX_RETRIES_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.READ_TIMEOUT_MS_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.RETRY_BACKOFF_MS_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SECURITY_PROTOCOL_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SSL_CONFIG_PREFIX;
@@ -144,6 +145,31 @@ public class ElasticsearchClientTest {
   public void testCreateIndex() throws IOException {
     ElasticsearchClient client = new ElasticsearchClient(config, null);
     assertFalse(helperClient.indexExists(INDEX));
+
+    client.createIndexOrDataStream(INDEX);
+    assertTrue(helperClient.indexExists(INDEX));
+    client.close();
+  }
+
+  @Test
+  public void testCreateExistingDataStream() throws Exception {
+    props.put(DATA_STREAM_TYPE_CONFIG, "logs");
+    props.put(DATA_STREAM_DATASET_CONFIG, "dataset");
+    config = new ElasticsearchSinkConnectorConfig(props);
+    ElasticsearchClient client = new ElasticsearchClient(config, null);
+
+    client.createIndexOrDataStream(INDEX);
+    assertTrue(helperClient.indexExists(INDEX));
+    assertFalse(client.createIndexOrDataStream(INDEX));
+    client.close();
+  }
+
+  @Test
+  public void testCreateNewDataStream() throws Exception {
+    props.put(DATA_STREAM_TYPE_CONFIG, "logs");
+    props.put(DATA_STREAM_DATASET_CONFIG, "dataset");
+    config = new ElasticsearchSinkConnectorConfig(props);
+    ElasticsearchClient client = new ElasticsearchClient(config, null);
 
     client.createIndexOrDataStream(INDEX);
     assertTrue(helperClient.indexExists(INDEX));

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
@@ -153,36 +153,36 @@ public class ElasticsearchClientTest {
     client.close();
   }
 
-//  @Test
-//  public void testCreateExistingDataStream() throws Exception {
-//    String type = "logs";
-//    String dataset = "dataset";
-//    index = String.format("%s-%s-%s", type, dataset, TOPIC); // data stream name
-//    props.put(DATA_STREAM_TYPE_CONFIG, type);
-//    props.put(DATA_STREAM_DATASET_CONFIG, dataset);
-//    config = new ElasticsearchSinkConnectorConfig(props);
-//    ElasticsearchClient client = new ElasticsearchClient(config, null);
-//
-//    assertTrue(client.createIndexOrDataStream(index));
-//    assertTrue(helperClient.indexExists(index));
-//    assertFalse(client.createIndexOrDataStream(index));
-//    client.close();
-//  }
-//
-//  @Test
-//  public void testCreateNewDataStream() throws Exception {
-//    String type = "logs";
-//    String dataset = "dataset";
-//    index = String.format("%s-%s-%s", type, dataset, TOPIC); // data stream name
-//    props.put(DATA_STREAM_TYPE_CONFIG, type);
-//    props.put(DATA_STREAM_DATASET_CONFIG, dataset);
-//    config = new ElasticsearchSinkConnectorConfig(props);
-//    ElasticsearchClient client = new ElasticsearchClient(config, null);
-//
-//    assertTrue(client.createIndexOrDataStream(index));
-//    assertTrue(helperClient.indexExists(index));
-//    client.close();
-//  }
+  @Test
+  public void testCreateExistingDataStream() throws Exception {
+    String type = "logs";
+    String dataset = "dataset";
+    index = String.format("%s-%s-%s", type, dataset, TOPIC); // data stream name
+    props.put(DATA_STREAM_TYPE_CONFIG, type);
+    props.put(DATA_STREAM_DATASET_CONFIG, dataset);
+    config = new ElasticsearchSinkConnectorConfig(props);
+    ElasticsearchClient client = new ElasticsearchClient(config, null);
+
+    assertTrue(client.createIndexOrDataStream(index));
+    assertTrue(helperClient.indexExists(index));
+    assertFalse(client.createIndexOrDataStream(index));
+    client.close();
+  }
+
+  @Test
+  public void testCreateNewDataStream() throws Exception {
+    String type = "logs";
+    String dataset = "dataset";
+    index = String.format("%s-%s-%s", type, dataset, TOPIC); // data stream name
+    props.put(DATA_STREAM_TYPE_CONFIG, type);
+    props.put(DATA_STREAM_DATASET_CONFIG, dataset);
+    config = new ElasticsearchSinkConnectorConfig(props);
+    ElasticsearchClient client = new ElasticsearchClient(config, null);
+
+    assertTrue(client.createIndexOrDataStream(index));
+    assertTrue(helperClient.indexExists(index));
+    client.close();
+  }
 
   @Test
   public void testDoesNotCreateAlreadyExistingIndex() throws IOException {

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
@@ -153,26 +153,34 @@ public class ElasticsearchClientTest {
 
   @Test
   public void testCreateExistingDataStream() throws Exception {
-    props.put(DATA_STREAM_TYPE_CONFIG, "logs");
-    props.put(DATA_STREAM_DATASET_CONFIG, "dataset");
+    String type = "logs";
+    String dataset = "dataset";
+    String dataStream = String.format("%s-%s-%s", type, dataset, INDEX);
+    props.put(DATA_STREAM_TYPE_CONFIG, type);
+    props.put(DATA_STREAM_DATASET_CONFIG, dataset);
     config = new ElasticsearchSinkConnectorConfig(props);
     ElasticsearchClient client = new ElasticsearchClient(config, null);
 
-    client.createIndexOrDataStream(INDEX);
-    assertTrue(helperClient.indexExists(INDEX));
-    assertFalse(client.createIndexOrDataStream(INDEX));
+    client.createIndexOrDataStream(dataStream);
+
+    assertTrue(helperClient.indexExists(dataStream));
+    assertFalse(client.createIndexOrDataStream(dataStream));
     client.close();
   }
 
   @Test
   public void testCreateNewDataStream() throws Exception {
-    props.put(DATA_STREAM_TYPE_CONFIG, "logs");
-    props.put(DATA_STREAM_DATASET_CONFIG, "dataset");
+    String type = "logs";
+    String dataset = "dataset";
+    String dataStream = String.format("%s-%s-%s", type, dataset, INDEX);
+    props.put(DATA_STREAM_TYPE_CONFIG, type);
+    props.put(DATA_STREAM_DATASET_CONFIG, dataset);
     config = new ElasticsearchSinkConnectorConfig(props);
     ElasticsearchClient client = new ElasticsearchClient(config, null);
 
-    client.createIndexOrDataStream(INDEX);
-    assertTrue(helperClient.indexExists(INDEX));
+    client.createIndexOrDataStream(dataStream);
+
+    assertTrue(helperClient.indexExists(dataStream));
     client.close();
   }
 

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
@@ -284,8 +284,7 @@ public class ElasticsearchSinkTaskTest {
     setUpTask();
 
     String topic = "-dash";
-    SinkRecord record = record(topic, true, false, 0);
-    task.put(Collections.singletonList(record));
+    task.put(Collections.singletonList(record(topic, true, false, 0)));
     String indexName = convertToIndexTemplate(type, dataset, topic);
     verify(client, times(1)).createIndex(eq(indexName));
   }
@@ -299,8 +298,7 @@ public class ElasticsearchSinkTaskTest {
     setUpTask();
 
     String topic = "_underscore";
-    SinkRecord record = record(topic, true, false, 0);
-    task.put(Collections.singletonList(record));
+    task.put(Collections.singletonList(record(topic, true, false, 0)));
     String indexName = convertToIndexTemplate(type, dataset, topic);
     verify(client, times(1)).createIndex(eq(indexName));
   }
@@ -314,8 +312,7 @@ public class ElasticsearchSinkTaskTest {
     setUpTask();
 
     String topic = String.format("%0101d", 1);
-    SinkRecord record = record(topic, true, false, 0);
-    task.put(Collections.singletonList(record));
+    task.put(Collections.singletonList(record(topic, true, false, 0)));
     String indexName = convertToIndexTemplate(type, dataset, topic.substring(0, 100));
     verify(client, times(1)).createIndex(eq(indexName));
   }
@@ -329,8 +326,7 @@ public class ElasticsearchSinkTaskTest {
     setUpTask();
 
     String topic = "UPPERCASE";
-    SinkRecord record = record(topic, true, false, 0);
-    task.put(Collections.singletonList(record));
+    task.put(Collections.singletonList(record(topic, true, false, 0)));
     String indexName = convertToIndexTemplate(type, dataset, topic.toLowerCase());
     verify(client, times(1)).createIndex(eq(indexName));
   }

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
@@ -124,7 +124,7 @@ public class ElasticsearchSinkTaskTest {
   }
 
   @Test
-  public void testcreateIndexOrDataStream() {
+  public void testCreateIndex() {
     task.put(Collections.singletonList(record()));
     verify(client, times(1)).createIndexOrDataStream(eq(TOPIC));
   }

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
@@ -277,8 +277,8 @@ public class ElasticsearchSinkTaskTest {
 
   @Test
   public void testConvertTopicToDataStreamAllowsDashes() {
-    final String type = "logs";
-    final String dataset = "a_valid_dataset";
+    String type = "logs";
+    String dataset = "a_valid_dataset";
     props.put(DATA_STREAM_TYPE_CONFIG, type);
     props.put(DATA_STREAM_DATASET_CONFIG, dataset);
     setUpTask();
@@ -292,8 +292,8 @@ public class ElasticsearchSinkTaskTest {
 
   @Test
   public void testConvertTopicToDataStreamAllowUnderscores() {
-    final String type = "logs";
-    final String dataset = "a_valid_dataset";
+    String type = "logs";
+    String dataset = "a_valid_dataset";
     props.put(DATA_STREAM_TYPE_CONFIG, type);
     props.put(DATA_STREAM_DATASET_CONFIG, dataset);
     setUpTask();
@@ -307,8 +307,8 @@ public class ElasticsearchSinkTaskTest {
 
   @Test
   public void testConvertTopicToDataStreamTooLong() {
-    final String type = "logs";
-    final String dataset = "a_valid_dataset";
+    String type = "logs";
+    String dataset = "a_valid_dataset";
     props.put(DATA_STREAM_TYPE_CONFIG, type);
     props.put(DATA_STREAM_DATASET_CONFIG, dataset);
     setUpTask();
@@ -322,8 +322,8 @@ public class ElasticsearchSinkTaskTest {
 
   @Test
   public void testConvertTopicToDataStreamUpperCase() {
-    final String type = "logs";
-    final String dataset = "a_valid_dataset";
+    String type = "logs";
+    String dataset = "a_valid_dataset";
     props.put(DATA_STREAM_TYPE_CONFIG, type);
     props.put(DATA_STREAM_DATASET_CONFIG, dataset);
     setUpTask();

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
@@ -291,21 +291,6 @@ public class ElasticsearchSinkTaskTest {
   }
 
   @Test
-  public void testConvertTopicToDataStream_allowEmpty() {
-    final String type = "logs";
-    final String dataset = "a_valid_dataset";
-    props.put(DATA_STREAM_TYPE_CONFIG, type);
-    props.put(DATA_STREAM_DATASET_CONFIG, dataset);
-    setUpTask();
-
-    String emptyStr = "";
-    SinkRecord record = record(emptyStr, true, false, 0);
-    task.put(Collections.singletonList(record));
-    String indexName = convertToIndexTemplate(type, dataset, emptyStr);
-    verify(client, times(1)).createIndex(eq(indexName));
-  }
-
-  @Test
   public void testConvertTopicToDataStream_allowUnderscores() {
     final String type = "logs";
     final String dataset = "a_valid_dataset";

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
@@ -309,9 +309,8 @@ public class ElasticsearchSinkTaskTest {
     task.put(Collections.singletonList(record));
     verify(client, times(1)).createIndex(eq("dotdot"));
   }
-
   @Test
-  public void testConvertTopicToIndexTemplate() {
+  public void testConvertTopicToDataStream_upperCase() {
     final String type = "logs";
     final String dataset = "a_valid_dataset";
     props.put(DATA_STREAM_TYPE_CONFIG, type);
@@ -323,29 +322,65 @@ public class ElasticsearchSinkTaskTest {
     task.put(Collections.singletonList(record));
     String indexName = convertToIndexTemplate(type, dataset, upperCaseTopic.toLowerCase());
     verify(client, times(1)).createIndex(eq(indexName));
+  }
+
+  @Test
+  public void testConvertTopicToDataStream_tooLong() {
+    final String type = "logs";
+    final String dataset = "a_valid_dataset";
+    props.put(DATA_STREAM_TYPE_CONFIG, type);
+    props.put(DATA_STREAM_DATASET_CONFIG, dataset);
+    setUpTask();
 
     String tooLongTopic = String.format("%0101d", 1);
-    record = record(tooLongTopic, true, false, 0);
+    SinkRecord record = record(tooLongTopic, true, false, 0);
     task.put(Collections.singletonList(record));
-    indexName = convertToIndexTemplate(type, dataset, tooLongTopic.substring(0, 100));
+    String indexName = convertToIndexTemplate(type, dataset, tooLongTopic.substring(0, 100));
     verify(client, times(1)).createIndex(eq(indexName));
+  }
+
+  @Test
+  public void testConvertTopicToDataStream_allowDashes() {
+    final String type = "logs";
+    final String dataset = "a_valid_dataset";
+    props.put(DATA_STREAM_TYPE_CONFIG, type);
+    props.put(DATA_STREAM_DATASET_CONFIG, dataset);
+    setUpTask();
 
     String startsWithDash = "-dash";
-    record = record(startsWithDash, true, false, 0);
+    SinkRecord record = record(startsWithDash, true, false, 0);
     task.put(Collections.singletonList(record));
-    indexName = convertToIndexTemplate(type, dataset, startsWithDash);
+    String indexName = convertToIndexTemplate(type, dataset, startsWithDash);
     verify(client, times(1)).createIndex(eq(indexName));
+  }
+
+  @Test
+  public void testConvertTopicToDataStream_allowUnderscores() {
+    final String type = "logs";
+    final String dataset = "a_valid_dataset";
+    props.put(DATA_STREAM_TYPE_CONFIG, type);
+    props.put(DATA_STREAM_DATASET_CONFIG, dataset);
+    setUpTask();
 
     String startsWithUnderscore = "_underscore";
-    record = record(startsWithUnderscore, true, false, 0);
+    SinkRecord record = record(startsWithUnderscore, true, false, 0);
     task.put(Collections.singletonList(record));
-    indexName = convertToIndexTemplate(type, dataset, startsWithUnderscore);
+    String indexName = convertToIndexTemplate(type, dataset, startsWithUnderscore);
     verify(client, times(1)).createIndex(eq(indexName));
+  }
+
+  @Test
+  public void testConvertTopicToDataStream_allowEmpty() {
+    final String type = "logs";
+    final String dataset = "a_valid_dataset";
+    props.put(DATA_STREAM_TYPE_CONFIG, type);
+    props.put(DATA_STREAM_DATASET_CONFIG, dataset);
+    setUpTask();
 
     String emptyStr = "";
-    record = record(emptyStr, true, false, 0);
+    SinkRecord record = record(emptyStr, true, false, 0);
     task.put(Collections.singletonList(record));
-    indexName = convertToIndexTemplate(type, dataset, emptyStr);
+    String indexName = convertToIndexTemplate(type, dataset, emptyStr);
     verify(client, times(1)).createIndex(eq(indexName));
   }
 

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
@@ -285,7 +285,7 @@ public class ElasticsearchSinkTaskTest {
 
     String topic = "-dash";
     task.put(Collections.singletonList(record(topic, true, false, 0)));
-    String indexName = convertToIndexTemplate(type, dataset, topic);
+    String indexName = dataStreamName(type, dataset, topic);
     verify(client, times(1)).createIndex(eq(indexName));
   }
 
@@ -299,7 +299,7 @@ public class ElasticsearchSinkTaskTest {
 
     String topic = "_underscore";
     task.put(Collections.singletonList(record(topic, true, false, 0)));
-    String indexName = convertToIndexTemplate(type, dataset, topic);
+    String indexName = dataStreamName(type, dataset, topic);
     verify(client, times(1)).createIndex(eq(indexName));
   }
 
@@ -313,7 +313,7 @@ public class ElasticsearchSinkTaskTest {
 
     String topic = String.format("%0101d", 1);
     task.put(Collections.singletonList(record(topic, true, false, 0)));
-    String indexName = convertToIndexTemplate(type, dataset, topic.substring(0, 100));
+    String indexName = dataStreamName(type, dataset, topic.substring(0, 100));
     verify(client, times(1)).createIndex(eq(indexName));
   }
 
@@ -327,7 +327,7 @@ public class ElasticsearchSinkTaskTest {
 
     String topic = "UPPERCASE";
     task.put(Collections.singletonList(record(topic, true, false, 0)));
-    String indexName = convertToIndexTemplate(type, dataset, topic.toLowerCase());
+    String indexName = dataStreamName(type, dataset, topic.toLowerCase());
     verify(client, times(1)).createIndex(eq(indexName));
   }
 
@@ -377,7 +377,7 @@ public class ElasticsearchSinkTaskTest {
     setUpTask();
   }
 
-  private String convertToIndexTemplate(String type, String dataset, String namespace) {
+  private String dataStreamName(String type, String dataset, String namespace) {
     return String.format("%s-%s-%s", type, dataset, namespace);
   }
 

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
@@ -276,6 +276,81 @@ public class ElasticsearchSinkTaskTest {
   }
 
   @Test
+  public void testConvertTopicToDataStream_allowDashes() {
+    final String type = "logs";
+    final String dataset = "a_valid_dataset";
+    props.put(DATA_STREAM_TYPE_CONFIG, type);
+    props.put(DATA_STREAM_DATASET_CONFIG, dataset);
+    setUpTask();
+
+    String startsWithDash = "-dash";
+    SinkRecord record = record(startsWithDash, true, false, 0);
+    task.put(Collections.singletonList(record));
+    String indexName = convertToIndexTemplate(type, dataset, startsWithDash);
+    verify(client, times(1)).createIndex(eq(indexName));
+  }
+
+  @Test
+  public void testConvertTopicToDataStream_allowEmpty() {
+    final String type = "logs";
+    final String dataset = "a_valid_dataset";
+    props.put(DATA_STREAM_TYPE_CONFIG, type);
+    props.put(DATA_STREAM_DATASET_CONFIG, dataset);
+    setUpTask();
+
+    String emptyStr = "";
+    SinkRecord record = record(emptyStr, true, false, 0);
+    task.put(Collections.singletonList(record));
+    String indexName = convertToIndexTemplate(type, dataset, emptyStr);
+    verify(client, times(1)).createIndex(eq(indexName));
+  }
+
+  @Test
+  public void testConvertTopicToDataStream_allowUnderscores() {
+    final String type = "logs";
+    final String dataset = "a_valid_dataset";
+    props.put(DATA_STREAM_TYPE_CONFIG, type);
+    props.put(DATA_STREAM_DATASET_CONFIG, dataset);
+    setUpTask();
+
+    String startsWithUnderscore = "_underscore";
+    SinkRecord record = record(startsWithUnderscore, true, false, 0);
+    task.put(Collections.singletonList(record));
+    String indexName = convertToIndexTemplate(type, dataset, startsWithUnderscore);
+    verify(client, times(1)).createIndex(eq(indexName));
+  }
+
+  @Test
+  public void testConvertTopicToDataStream_tooLong() {
+    final String type = "logs";
+    final String dataset = "a_valid_dataset";
+    props.put(DATA_STREAM_TYPE_CONFIG, type);
+    props.put(DATA_STREAM_DATASET_CONFIG, dataset);
+    setUpTask();
+
+    String tooLongTopic = String.format("%0101d", 1);
+    SinkRecord record = record(tooLongTopic, true, false, 0);
+    task.put(Collections.singletonList(record));
+    String indexName = convertToIndexTemplate(type, dataset, tooLongTopic.substring(0, 100));
+    verify(client, times(1)).createIndex(eq(indexName));
+  }
+
+  @Test
+  public void testConvertTopicToDataStream_upperCase() {
+    final String type = "logs";
+    final String dataset = "a_valid_dataset";
+    props.put(DATA_STREAM_TYPE_CONFIG, type);
+    props.put(DATA_STREAM_DATASET_CONFIG, dataset);
+    setUpTask();
+
+    String upperCaseTopic = "UPPERCASE";
+    SinkRecord record = record(upperCaseTopic, true, false, 0);
+    task.put(Collections.singletonList(record));
+    String indexName = convertToIndexTemplate(type, dataset, upperCaseTopic.toLowerCase());
+    verify(client, times(1)).createIndex(eq(indexName));
+  }
+
+  @Test
   public void testConvertTopicToIndexName() {
     setUpTask();
 
@@ -308,80 +383,6 @@ public class ElasticsearchSinkTaskTest {
     record = record(dots, true, false, 0);
     task.put(Collections.singletonList(record));
     verify(client, times(1)).createIndex(eq("dotdot"));
-  }
-  @Test
-  public void testConvertTopicToDataStream_upperCase() {
-    final String type = "logs";
-    final String dataset = "a_valid_dataset";
-    props.put(DATA_STREAM_TYPE_CONFIG, type);
-    props.put(DATA_STREAM_DATASET_CONFIG, dataset);
-    setUpTask();
-
-    String upperCaseTopic = "UPPERCASE";
-    SinkRecord record = record(upperCaseTopic, true, false, 0);
-    task.put(Collections.singletonList(record));
-    String indexName = convertToIndexTemplate(type, dataset, upperCaseTopic.toLowerCase());
-    verify(client, times(1)).createIndex(eq(indexName));
-  }
-
-  @Test
-  public void testConvertTopicToDataStream_tooLong() {
-    final String type = "logs";
-    final String dataset = "a_valid_dataset";
-    props.put(DATA_STREAM_TYPE_CONFIG, type);
-    props.put(DATA_STREAM_DATASET_CONFIG, dataset);
-    setUpTask();
-
-    String tooLongTopic = String.format("%0101d", 1);
-    SinkRecord record = record(tooLongTopic, true, false, 0);
-    task.put(Collections.singletonList(record));
-    String indexName = convertToIndexTemplate(type, dataset, tooLongTopic.substring(0, 100));
-    verify(client, times(1)).createIndex(eq(indexName));
-  }
-
-  @Test
-  public void testConvertTopicToDataStream_allowDashes() {
-    final String type = "logs";
-    final String dataset = "a_valid_dataset";
-    props.put(DATA_STREAM_TYPE_CONFIG, type);
-    props.put(DATA_STREAM_DATASET_CONFIG, dataset);
-    setUpTask();
-
-    String startsWithDash = "-dash";
-    SinkRecord record = record(startsWithDash, true, false, 0);
-    task.put(Collections.singletonList(record));
-    String indexName = convertToIndexTemplate(type, dataset, startsWithDash);
-    verify(client, times(1)).createIndex(eq(indexName));
-  }
-
-  @Test
-  public void testConvertTopicToDataStream_allowUnderscores() {
-    final String type = "logs";
-    final String dataset = "a_valid_dataset";
-    props.put(DATA_STREAM_TYPE_CONFIG, type);
-    props.put(DATA_STREAM_DATASET_CONFIG, dataset);
-    setUpTask();
-
-    String startsWithUnderscore = "_underscore";
-    SinkRecord record = record(startsWithUnderscore, true, false, 0);
-    task.put(Collections.singletonList(record));
-    String indexName = convertToIndexTemplate(type, dataset, startsWithUnderscore);
-    verify(client, times(1)).createIndex(eq(indexName));
-  }
-
-  @Test
-  public void testConvertTopicToDataStream_allowEmpty() {
-    final String type = "logs";
-    final String dataset = "a_valid_dataset";
-    props.put(DATA_STREAM_TYPE_CONFIG, type);
-    props.put(DATA_STREAM_DATASET_CONFIG, dataset);
-    setUpTask();
-
-    String emptyStr = "";
-    SinkRecord record = record(emptyStr, true, false, 0);
-    task.put(Collections.singletonList(record));
-    String indexName = convertToIndexTemplate(type, dataset, emptyStr);
-    verify(client, times(1)).createIndex(eq(indexName));
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
@@ -124,24 +124,24 @@ public class ElasticsearchSinkTaskTest {
   }
 
   @Test
-  public void testCreateIndex() {
+  public void testcreateIndexOrDataStream() {
     task.put(Collections.singletonList(record()));
-    verify(client, times(1)).createIndex(eq(TOPIC));
+    verify(client, times(1)).createIndexOrDataStream(eq(TOPIC));
   }
 
   @Test
   public void testCreateUpperCaseIndex() {
     task.put(Collections.singletonList(record()));
-    verify(client, times(1)).createIndex(eq(TOPIC.toLowerCase()));
+    verify(client, times(1)).createIndexOrDataStream(eq(TOPIC.toLowerCase()));
   }
 
   @Test
   public void testDoNotCreateCachedIndex() {
     task.put(Collections.singletonList(record()));
-    verify(client, times(1)).createIndex(eq(TOPIC));
+    verify(client, times(1)).createIndexOrDataStream(eq(TOPIC));
 
     task.put(Collections.singletonList(record()));
-    verify(client, times(1)).createIndex(eq(TOPIC));
+    verify(client, times(1)).createIndexOrDataStream(eq(TOPIC));
   }
 
   @Test
@@ -286,7 +286,7 @@ public class ElasticsearchSinkTaskTest {
     String topic = "-dash";
     task.put(Collections.singletonList(record(topic, true, false, 0)));
     String indexName = dataStreamName(type, dataset, topic);
-    verify(client, times(1)).createIndex(eq(indexName));
+    verify(client, times(1)).createIndexOrDataStream(eq(indexName));
   }
 
   @Test
@@ -300,7 +300,7 @@ public class ElasticsearchSinkTaskTest {
     String topic = "_underscore";
     task.put(Collections.singletonList(record(topic, true, false, 0)));
     String indexName = dataStreamName(type, dataset, topic);
-    verify(client, times(1)).createIndex(eq(indexName));
+    verify(client, times(1)).createIndexOrDataStream(eq(indexName));
   }
 
   @Test
@@ -314,7 +314,7 @@ public class ElasticsearchSinkTaskTest {
     String topic = String.format("%0101d", 1);
     task.put(Collections.singletonList(record(topic, true, false, 0)));
     String indexName = dataStreamName(type, dataset, topic.substring(0, 100));
-    verify(client, times(1)).createIndex(eq(indexName));
+    verify(client, times(1)).createIndexOrDataStream(eq(indexName));
   }
 
   @Test
@@ -328,7 +328,7 @@ public class ElasticsearchSinkTaskTest {
     String topic = "UPPERCASE";
     task.put(Collections.singletonList(record(topic, true, false, 0)));
     String indexName = dataStreamName(type, dataset, topic.toLowerCase());
-    verify(client, times(1)).createIndex(eq(indexName));
+    verify(client, times(1)).createIndexOrDataStream(eq(indexName));
   }
 
   @Test
@@ -338,32 +338,32 @@ public class ElasticsearchSinkTaskTest {
     String upperCaseTopic = "UPPERCASE";
     SinkRecord record = record(upperCaseTopic, true, false, 0);
     task.put(Collections.singletonList(record));
-    verify(client, times(1)).createIndex(eq(upperCaseTopic.toLowerCase()));
+    verify(client, times(1)).createIndexOrDataStream(eq(upperCaseTopic.toLowerCase()));
 
     String tooLongTopic = String.format("%0256d", 1);
     record = record(tooLongTopic, true, false, 0);
     task.put(Collections.singletonList(record));
-    verify(client, times(1)).createIndex(eq(tooLongTopic.substring(0, 255)));
+    verify(client, times(1)).createIndexOrDataStream(eq(tooLongTopic.substring(0, 255)));
 
     String startsWithDash = "-dash";
     record = record(startsWithDash, true, false, 0);
     task.put(Collections.singletonList(record));
-    verify(client, times(1)).createIndex(eq("dash"));
+    verify(client, times(1)).createIndexOrDataStream(eq("dash"));
 
     String startsWithUnderscore = "_underscore";
     record = record(startsWithUnderscore, true, false, 0);
     task.put(Collections.singletonList(record));
-    verify(client, times(1)).createIndex(eq("underscore"));
+    verify(client, times(1)).createIndexOrDataStream(eq("underscore"));
 
     String dot = ".";
     record = record(dot, true, false, 0);
     task.put(Collections.singletonList(record));
-    verify(client, times(1)).createIndex(eq("dot"));
+    verify(client, times(1)).createIndexOrDataStream(eq("dot"));
 
     String dots = "..";
     record = record(dots, true, false, 0);
     task.put(Collections.singletonList(record));
-    verify(client, times(1)).createIndex(eq("dotdot"));
+    verify(client, times(1)).createIndexOrDataStream(eq("dotdot"));
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
@@ -276,7 +276,7 @@ public class ElasticsearchSinkTaskTest {
   }
 
   @Test
-  public void testConvertTopicToDataStream_allowDashes() {
+  public void testConvertTopicToDataStreamAllowsDashes() {
     final String type = "logs";
     final String dataset = "a_valid_dataset";
     props.put(DATA_STREAM_TYPE_CONFIG, type);

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
@@ -310,12 +310,8 @@ public class ElasticsearchSinkTaskTest {
     verify(client, times(1)).createIndex(eq("dotdot"));
   }
 
-  private String convertUsingIndexTemplate(String type, String dataset, String namespace) {
-    return String.format("%s-%s-%s", type, dataset, namespace);
-  }
-
   @Test
-  public void testConvertUsingIndexTemplate() {
+  public void testConvertTopicToIndexTemplate() {
     final String type = "logs";
     final String dataset = "a_valid_dataset";
     props.put(DATA_STREAM_TYPE_CONFIG, type);
@@ -325,31 +321,31 @@ public class ElasticsearchSinkTaskTest {
     String upperCaseTopic = "UPPERCASE";
     SinkRecord record = record(upperCaseTopic, true, false, 0);
     task.put(Collections.singletonList(record));
-    String indexName = convertUsingIndexTemplate(type, dataset, upperCaseTopic.toLowerCase());
+    String indexName = convertToIndexTemplate(type, dataset, upperCaseTopic.toLowerCase());
     verify(client, times(1)).createIndex(eq(indexName));
 
     String tooLongTopic = String.format("%0101d", 1);
     record = record(tooLongTopic, true, false, 0);
     task.put(Collections.singletonList(record));
-    indexName = convertUsingIndexTemplate(type, dataset, tooLongTopic.substring(0, 100));
+    indexName = convertToIndexTemplate(type, dataset, tooLongTopic.substring(0, 100));
     verify(client, times(1)).createIndex(eq(indexName));
 
     String startsWithDash = "-dash";
     record = record(startsWithDash, true, false, 0);
     task.put(Collections.singletonList(record));
-    indexName = convertUsingIndexTemplate(type, dataset, startsWithDash);
+    indexName = convertToIndexTemplate(type, dataset, startsWithDash);
     verify(client, times(1)).createIndex(eq(indexName));
 
     String startsWithUnderscore = "_underscore";
     record = record(startsWithUnderscore, true, false, 0);
     task.put(Collections.singletonList(record));
-    indexName = convertUsingIndexTemplate(type, dataset, startsWithUnderscore);
+    indexName = convertToIndexTemplate(type, dataset, startsWithUnderscore);
     verify(client, times(1)).createIndex(eq(indexName));
 
     String emptyStr = "";
     record = record(emptyStr, true, false, 0);
     task.put(Collections.singletonList(record));
-    indexName = convertUsingIndexTemplate(type, dataset, emptyStr);
+    indexName = convertToIndexTemplate(type, dataset, emptyStr);
     verify(client, times(1)).createIndex(eq(indexName));
   }
 
@@ -362,6 +358,10 @@ public class ElasticsearchSinkTaskTest {
     // call start twice for both exceptions
     setUpTask();
     setUpTask();
+  }
+
+  private String convertToIndexTemplate(String type, String dataset, String namespace) {
+    return String.format("%s-%s-%s", type, dataset, namespace);
   }
 
   private SinkRecord record() {

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
@@ -283,10 +283,10 @@ public class ElasticsearchSinkTaskTest {
     props.put(DATA_STREAM_DATASET_CONFIG, dataset);
     setUpTask();
 
-    String startsWithDash = "-dash";
-    SinkRecord record = record(startsWithDash, true, false, 0);
+    String topic = "-dash";
+    SinkRecord record = record(topic, true, false, 0);
     task.put(Collections.singletonList(record));
-    String indexName = convertToIndexTemplate(type, dataset, startsWithDash);
+    String indexName = convertToIndexTemplate(type, dataset, topic);
     verify(client, times(1)).createIndex(eq(indexName));
   }
 
@@ -298,10 +298,10 @@ public class ElasticsearchSinkTaskTest {
     props.put(DATA_STREAM_DATASET_CONFIG, dataset);
     setUpTask();
 
-    String startsWithUnderscore = "_underscore";
-    SinkRecord record = record(startsWithUnderscore, true, false, 0);
+    String topic = "_underscore";
+    SinkRecord record = record(topic, true, false, 0);
     task.put(Collections.singletonList(record));
-    String indexName = convertToIndexTemplate(type, dataset, startsWithUnderscore);
+    String indexName = convertToIndexTemplate(type, dataset, topic);
     verify(client, times(1)).createIndex(eq(indexName));
   }
 
@@ -313,10 +313,10 @@ public class ElasticsearchSinkTaskTest {
     props.put(DATA_STREAM_DATASET_CONFIG, dataset);
     setUpTask();
 
-    String tooLongTopic = String.format("%0101d", 1);
-    SinkRecord record = record(tooLongTopic, true, false, 0);
+    String topic = String.format("%0101d", 1);
+    SinkRecord record = record(topic, true, false, 0);
     task.put(Collections.singletonList(record));
-    String indexName = convertToIndexTemplate(type, dataset, tooLongTopic.substring(0, 100));
+    String indexName = convertToIndexTemplate(type, dataset, topic.substring(0, 100));
     verify(client, times(1)).createIndex(eq(indexName));
   }
 
@@ -328,10 +328,10 @@ public class ElasticsearchSinkTaskTest {
     props.put(DATA_STREAM_DATASET_CONFIG, dataset);
     setUpTask();
 
-    String upperCaseTopic = "UPPERCASE";
-    SinkRecord record = record(upperCaseTopic, true, false, 0);
+    String topic = "UPPERCASE";
+    SinkRecord record = record(topic, true, false, 0);
     task.put(Collections.singletonList(record));
-    String indexName = convertToIndexTemplate(type, dataset, upperCaseTopic.toLowerCase());
+    String indexName = convertToIndexTemplate(type, dataset, topic.toLowerCase());
     verify(client, times(1)).createIndex(eq(indexName));
   }
 

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
@@ -318,7 +318,7 @@ public class ElasticsearchSinkTaskTest {
   public void testConvertUsingIndexTemplate() {
     final String type = "logs";
     final String dataset = "a_valid_dataset";
-    props.put(DATA_STREAM_TYPE_CONFIG, type.toUpperCase());
+    props.put(DATA_STREAM_TYPE_CONFIG, type);
     props.put(DATA_STREAM_DATASET_CONFIG, dataset);
     setUpTask();
 
@@ -344,6 +344,12 @@ public class ElasticsearchSinkTaskTest {
     record = record(startsWithUnderscore, true, false, 0);
     task.put(Collections.singletonList(record));
     indexName = convertUsingIndexTemplate(type, dataset, startsWithUnderscore);
+    verify(client, times(1)).createIndex(eq(indexName));
+
+    String emptyStr = "";
+    record = record(emptyStr, true, false, 0);
+    task.put(Collections.singletonList(record));
+    indexName = convertUsingIndexTemplate(type, dataset, emptyStr);
     verify(client, times(1)).createIndex(eq(indexName));
   }
 

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
@@ -316,34 +316,34 @@ public class ElasticsearchSinkTaskTest {
 
   @Test
   public void testConvertUsingIndexTemplate() {
-    final String TYPE = "LOGS";
-    final String DATASET = "a_valid_dataset";
-    props.put(DATA_STREAM_TYPE_CONFIG, TYPE);
-    props.put(DATA_STREAM_DATASET_CONFIG, DATASET);
+    final String type = "logs";
+    final String dataset = "a_valid_dataset";
+    props.put(DATA_STREAM_TYPE_CONFIG, type.toUpperCase());
+    props.put(DATA_STREAM_DATASET_CONFIG, dataset);
     setUpTask();
 
     String upperCaseTopic = "UPPERCASE";
     SinkRecord record = record(upperCaseTopic, true, false, 0);
     task.put(Collections.singletonList(record));
-    String indexName = convertUsingIndexTemplate(TYPE, DATASET, upperCaseTopic.toLowerCase());
+    String indexName = convertUsingIndexTemplate(type, dataset, upperCaseTopic.toLowerCase());
     verify(client, times(1)).createIndex(eq(indexName));
 
     String tooLongTopic = String.format("%0101d", 1);
     record = record(tooLongTopic, true, false, 0);
     task.put(Collections.singletonList(record));
-    indexName = convertUsingIndexTemplate(TYPE, DATASET, tooLongTopic.substring(0, 100));
+    indexName = convertUsingIndexTemplate(type, dataset, tooLongTopic.substring(0, 100));
     verify(client, times(1)).createIndex(eq(indexName));
 
     String startsWithDash = "-dash";
     record = record(startsWithDash, true, false, 0);
     task.put(Collections.singletonList(record));
-    indexName = convertUsingIndexTemplate(TYPE, DATASET, startsWithDash);
+    indexName = convertUsingIndexTemplate(type, dataset, startsWithDash);
     verify(client, times(1)).createIndex(eq(indexName));
 
     String startsWithUnderscore = "_underscore";
     record = record(startsWithUnderscore, true, false, 0);
     task.put(Collections.singletonList(record));
-    indexName = convertUsingIndexTemplate(TYPE, DATASET, startsWithUnderscore);
+    indexName = convertUsingIndexTemplate(type, dataset, startsWithUnderscore);
     verify(client, times(1)).createIndex(eq(indexName));
   }
 

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
@@ -291,7 +291,7 @@ public class ElasticsearchSinkTaskTest {
   }
 
   @Test
-  public void testConvertTopicToDataStream_allowUnderscores() {
+  public void testConvertTopicToDataStreamAllowUnderscores() {
     final String type = "logs";
     final String dataset = "a_valid_dataset";
     props.put(DATA_STREAM_TYPE_CONFIG, type);
@@ -306,7 +306,7 @@ public class ElasticsearchSinkTaskTest {
   }
 
   @Test
-  public void testConvertTopicToDataStream_tooLong() {
+  public void testConvertTopicToDataStreamTooLong() {
     final String type = "logs";
     final String dataset = "a_valid_dataset";
     props.put(DATA_STREAM_TYPE_CONFIG, type);
@@ -321,7 +321,7 @@ public class ElasticsearchSinkTaskTest {
   }
 
   @Test
-  public void testConvertTopicToDataStream_upperCase() {
+  public void testConvertTopicToDataStreamUpperCase() {
     final String type = "logs";
     final String dataset = "a_valid_dataset";
     props.put(DATA_STREAM_TYPE_CONFIG, type);

--- a/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchContainer.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchContainer.java
@@ -51,7 +51,7 @@ public class ElasticsearchContainer
   /**
    * Default Elasticsearch version.
    */
-  public static final String DEFAULT_ES_VERSION = "7.9.03";
+  public static final String DEFAULT_ES_VERSION = "7.9.3";
 
   /**
    * Default Elasticsearch port.

--- a/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchContainer.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchContainer.java
@@ -51,7 +51,7 @@ public class ElasticsearchContainer
   /**
    * Default Elasticsearch version.
    */
-  public static final String DEFAULT_ES_VERSION = "7.0.1";
+  public static final String DEFAULT_ES_VERSION = "7.12.0";
 
   /**
    * Default Elasticsearch port.

--- a/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchContainer.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchContainer.java
@@ -51,7 +51,7 @@ public class ElasticsearchContainer
   /**
    * Default Elasticsearch version.
    */
-  public static final String DEFAULT_ES_VERSION = "7.12.0";
+  public static final String DEFAULT_ES_VERSION = "7.9.03";
 
   /**
    * Default Elasticsearch port.

--- a/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchHelperClient.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchHelperClient.java
@@ -18,20 +18,23 @@ package io.confluent.connect.elasticsearch.helper;
 import io.confluent.connect.elasticsearch.ConfigCallbackHandler;
 import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig;
 import java.io.IOException;
+import java.util.List;
+
 import org.apache.http.HttpHost;
+import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.client.core.CountRequest;
-import org.elasticsearch.client.indices.GetIndexRequest;
-import org.elasticsearch.client.indices.GetMappingsRequest;
-import org.elasticsearch.client.indices.GetMappingsResponse;
+import org.elasticsearch.client.indices.*;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.search.SearchHits;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static io.confluent.connect.elasticsearch.RetryUtil.callWithRetries;
 
 public class ElasticsearchHelperClient {
 
@@ -47,6 +50,21 @@ public class ElasticsearchHelperClient {
             .setHttpClientConfigCallback(configCallbackHandler)
             .setRequestConfigCallback(configCallbackHandler)
     );
+  }
+
+  public int getDataStreamCount(String index) throws IOException {
+    // todo: check if data stream was created
+//    GetDataStreamRequest request = new GetDataStreamRequest(index);
+//    List<DataStream> datastreams = client.indices().getDataStream(request, RequestOptions.DEFAULT).getDataStreams();
+//    System.out.println(datastreams.size());
+//    // do debugger here
+//    return datastreams.size();
+    CreateDataStreamRequest createRequest = new CreateDataStreamRequest("logs-dataset-test");
+    client.indices().createDataStream(createRequest, RequestOptions.DEFAULT);
+
+//    DataStreamsStatsRequest request = new DataStreamsStatsRequest("logs-dataset-test");
+//    client.indices().dataStreamsStats(request, RequestOptions.DEFAULT);
+    return 0;
   }
 
   public void deleteIndex(String index) throws IOException {

--- a/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchHelperClient.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchHelperClient.java
@@ -52,11 +52,10 @@ public class ElasticsearchHelperClient {
     );
   }
 
-  public int getDataStreamCount(String index) throws IOException {
-    // todo: check if amoutn is correct
+  public DataStream getDataStream(String index) throws IOException {
     GetDataStreamRequest request = new GetDataStreamRequest(index);
     List<DataStream> datastreams = client.indices().getDataStream(request, RequestOptions.DEFAULT).getDataStreams();
-    return datastreams.size();
+    return datastreams.get(0);
   }
 
   public void deleteIndex(String index, boolean isDataStream) throws IOException {

--- a/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchHelperClient.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchHelperClient.java
@@ -53,21 +53,18 @@ public class ElasticsearchHelperClient {
   }
 
   public int getDataStreamCount(String index) throws IOException {
-    // todo: check if data stream was created
-//    GetDataStreamRequest request = new GetDataStreamRequest(index);
-//    List<DataStream> datastreams = client.indices().getDataStream(request, RequestOptions.DEFAULT).getDataStreams();
-//    System.out.println(datastreams.size());
-//    // do debugger here
-//    return datastreams.size();
-    CreateDataStreamRequest createRequest = new CreateDataStreamRequest("logs-dataset-test");
-    client.indices().createDataStream(createRequest, RequestOptions.DEFAULT);
-
-//    DataStreamsStatsRequest request = new DataStreamsStatsRequest("logs-dataset-test");
-//    client.indices().dataStreamsStats(request, RequestOptions.DEFAULT);
-    return 0;
+    // todo: check if amoutn is correct
+    GetDataStreamRequest request = new GetDataStreamRequest(index);
+    List<DataStream> datastreams = client.indices().getDataStream(request, RequestOptions.DEFAULT).getDataStreams();
+    return datastreams.size();
   }
 
-  public void deleteIndex(String index) throws IOException {
+  public void deleteIndex(String index, boolean isDataStream) throws IOException {
+    if (isDataStream) {
+      DeleteDataStreamRequest request = new DeleteDataStreamRequest(index);
+      client.indices().deleteDataStream(request, RequestOptions.DEFAULT);
+      return;
+    }
     DeleteIndexRequest request = new DeleteIndexRequest(index);
     client.indices().delete(request, RequestOptions.DEFAULT);
   }

--- a/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchHelperClient.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchHelperClient.java
@@ -64,8 +64,8 @@ public class ElasticsearchHelperClient {
     client.indices().delete(request, RequestOptions.DEFAULT);
   }
 
-  public DataStream getDataStream(String index) throws IOException {
-    GetDataStreamRequest request = new GetDataStreamRequest(index);
+  public DataStream getDataStream(String dataStream) throws IOException {
+    GetDataStreamRequest request = new GetDataStreamRequest(dataStream);
     List<DataStream> datastreams = client.indices()
         .getDataStream(request, RequestOptions.DEFAULT)
         .getDataStreams();

--- a/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchHelperClient.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchHelperClient.java
@@ -27,7 +27,12 @@ import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.client.core.CountRequest;
-import org.elasticsearch.client.indices.*;
+import org.elasticsearch.client.indices.DataStream;
+import org.elasticsearch.client.indices.DeleteDataStreamRequest;
+import org.elasticsearch.client.indices.GetDataStreamRequest;
+import org.elasticsearch.client.indices.GetIndexRequest;
+import org.elasticsearch.client.indices.GetMappingsRequest;
+import org.elasticsearch.client.indices.GetMappingsResponse;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.search.SearchHits;
 import org.slf4j.Logger;
@@ -49,12 +54,6 @@ public class ElasticsearchHelperClient {
     );
   }
 
-  public DataStream getDataStream(String index) throws IOException {
-    GetDataStreamRequest request = new GetDataStreamRequest(index);
-    List<DataStream> datastreams = client.indices().getDataStream(request, RequestOptions.DEFAULT).getDataStreams();
-    return datastreams.get(0);
-  }
-
   public void deleteIndex(String index, boolean isDataStream) throws IOException {
     if (isDataStream) {
       DeleteDataStreamRequest request = new DeleteDataStreamRequest(index);
@@ -63,6 +62,14 @@ public class ElasticsearchHelperClient {
     }
     DeleteIndexRequest request = new DeleteIndexRequest(index);
     client.indices().delete(request, RequestOptions.DEFAULT);
+  }
+
+  public DataStream getDataStream(String index) throws IOException {
+    GetDataStreamRequest request = new GetDataStreamRequest(index);
+    List<DataStream> datastreams = client.indices()
+        .getDataStream(request, RequestOptions.DEFAULT)
+        .getDataStreams();
+    return datastreams.get(0);
   }
 
   public long getDocCount(String index) throws IOException {

--- a/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchHelperClient.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchHelperClient.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.util.List;
 
 import org.apache.http.HttpHost;
-import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.client.RequestOptions;
@@ -33,8 +32,6 @@ import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.search.SearchHits;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static io.confluent.connect.elasticsearch.RetryUtil.callWithRetries;
 
 public class ElasticsearchHelperClient {
 

--- a/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchHelperClient.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchHelperClient.java
@@ -28,7 +28,7 @@ import org.elasticsearch.client.core.CountRequest;
 import org.elasticsearch.client.indices.GetIndexRequest;
 import org.elasticsearch.client.indices.GetMappingsRequest;
 import org.elasticsearch.client.indices.GetMappingsResponse;
-import org.elasticsearch.cluster.metadata.MappingMetaData;
+import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.search.SearchHits;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,7 +59,7 @@ public class ElasticsearchHelperClient {
     return client.count(request, RequestOptions.DEFAULT).getCount();
   }
 
-  public MappingMetaData getMapping(String index) throws IOException {
+  public MappingMetadata getMapping(String index) throws IOException {
     GetMappingsRequest request = new GetMappingsRequest().indices(index);
     GetMappingsResponse response = client.indices().getMapping(request, RequestOptions.DEFAULT);
     return response.mappings().get(index);

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorBaseIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorBaseIT.java
@@ -133,7 +133,6 @@ public class ElasticsearchConnectorBaseIT extends BaseConnectorIT {
       } else {
         assertEquals(index, hit.getIndex());
       }
-      System.out.println("A HIT " + id);
     }
   }
 

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorBaseIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorBaseIT.java
@@ -147,13 +147,13 @@ public class ElasticsearchConnectorBaseIT extends BaseConnectorIT {
 
   protected void writeRecords(int numRecords) {
     for (int i = 0; i < numRecords; i++) {
-      connect.kafka().produce(TOPIC, String.valueOf(i), String.format("{\"doc_num\":%d}", i));
+      connect.kafka().produce(TOPIC, String.valueOf(i), String.format("{\"doc_num\":%d,\"@timestamp\":%s}", i, "\"2021-04-28T11:11:22.000Z\""));
     }
   }
 
   protected void writeRecordsFromStartIndex(int start, int numRecords) {
     for (int i  = start; i < start + numRecords; i++) {
-      connect.kafka().produce(TOPIC, String.valueOf(i), String.format("{\"doc_num\":%d}", i));
+      connect.kafka().produce(TOPIC, String.valueOf(i), String.format("{\"doc_num\":%d,\"@timestamp\":%s}", i, "\"2021-04-28T11:11:22.000Z\""));
     }
   }
 }

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorBaseIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorBaseIT.java
@@ -58,7 +58,6 @@ public class ElasticsearchConnectorBaseIT extends BaseConnectorIT {
   protected Map<String, String> props;
   protected String index;
 
-
   @AfterClass
   public static void cleanupAfterAll() {
     container.close();

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorBaseIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorBaseIT.java
@@ -53,10 +53,11 @@ public class ElasticsearchConnectorBaseIT extends BaseConnectorIT {
 
   protected static ElasticsearchContainer container;
 
+  protected boolean isDataStream;
   protected ElasticsearchHelperClient helperClient;
   protected Map<String, String> props;
   protected String index;
-  protected boolean isDatastream;
+
 
   @AfterClass
   public static void cleanupAfterAll() {
@@ -66,7 +67,7 @@ public class ElasticsearchConnectorBaseIT extends BaseConnectorIT {
   @Before
   public void setup() {
     index = TOPIC;
-    isDatastream = false;
+    isDataStream = false;
 
     startConnect();
     connect.kafka().createTopic(TOPIC);
@@ -83,7 +84,7 @@ public class ElasticsearchConnectorBaseIT extends BaseConnectorIT {
     stopConnect();
 
     if (helperClient != null) {
-      helperClient.deleteIndex(index, isDatastream);
+      helperClient.deleteIndex(index, isDataStream);
       helperClient.close();
     }
   }
@@ -128,7 +129,7 @@ public class ElasticsearchConnectorBaseIT extends BaseConnectorIT {
       assertNotNull(id);
       assertTrue(id < numRecords);
 
-      if (isDatastream) {
+      if (isDataStream) {
         assertTrue(hit.getIndex().contains(index));
       } else {
         assertEquals(index, hit.getIndex());

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorBaseIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorBaseIT.java
@@ -127,7 +127,13 @@ public class ElasticsearchConnectorBaseIT extends BaseConnectorIT {
       int id = (Integer) hit.getSourceAsMap().get("doc_num");
       assertNotNull(id);
       assertTrue(id < numRecords);
-      assertEquals(index, hit.getIndex());
+
+      if (isDatastream) {
+        assertTrue(hit.getIndex().contains(index));
+      } else {
+        assertEquals(index, hit.getIndex());
+      }
+      System.out.println("A HIT " + id);
     }
   }
 

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorBaseIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorBaseIT.java
@@ -55,6 +55,7 @@ public class ElasticsearchConnectorBaseIT extends BaseConnectorIT {
 
   protected ElasticsearchHelperClient helperClient;
   protected Map<String, String> props;
+  protected String index = TOPIC;
 
   @AfterClass
   public static void cleanupAfterAll() {
@@ -78,7 +79,7 @@ public class ElasticsearchConnectorBaseIT extends BaseConnectorIT {
     stopConnect();
 
     if (helperClient != null) {
-      helperClient.deleteIndex(TOPIC);
+      helperClient.deleteIndex(index);
       helperClient.close();
     }
   }
@@ -118,11 +119,11 @@ public class ElasticsearchConnectorBaseIT extends BaseConnectorIT {
   protected void verifySearchResults(int numRecords) throws Exception {
     waitForRecords(numRecords);
 
-    for (SearchHit hit : helperClient.search(TOPIC)) {
+    for (SearchHit hit : helperClient.search(index)) {
       int id = (Integer) hit.getSourceAsMap().get("doc_num");
       assertNotNull(id);
       assertTrue(id < numRecords);
-      assertEquals(TOPIC, hit.getIndex());
+      assertEquals(index, hit.getIndex());
     }
   }
 
@@ -130,7 +131,7 @@ public class ElasticsearchConnectorBaseIT extends BaseConnectorIT {
     TestUtils.waitForCondition(
         () -> {
           try {
-            return helperClient.getDocCount(TOPIC) == numRecords;
+            return helperClient.getDocCount(index) == numRecords;
           } catch (ElasticsearchStatusException e) {
             if (e.getMessage().contains("index_not_found_exception")) {
               return false;

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorBaseIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorBaseIT.java
@@ -156,14 +156,16 @@ public class ElasticsearchConnectorBaseIT extends BaseConnectorIT {
   }
 
   protected void writeRecords(int numRecords) {
-    for (int i = 0; i < numRecords; i++) {
-      connect.kafka().produce(TOPIC, String.valueOf(i), String.format("{\"doc_num\":%d,\"@timestamp\":%s}", i, "\"2021-04-28T11:11:22.000Z\""));
-    }
+    writeRecordsFromStartIndex(0, numRecords);
   }
 
   protected void writeRecordsFromStartIndex(int start, int numRecords) {
     for (int i  = start; i < start + numRecords; i++) {
-      connect.kafka().produce(TOPIC, String.valueOf(i), String.format("{\"doc_num\":%d,\"@timestamp\":\"2021-04-28T11:11:22.%03dZ\"}", i, i));
+      connect.kafka().produce(
+          TOPIC,
+          String.valueOf(i),
+          String.format("{\"doc_num\":%d,\"@timestamp\":\"2021-04-28T11:11:22.%03dZ\"}", i, i)
+      );
     }
   }
 }

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorBaseIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorBaseIT.java
@@ -55,7 +55,8 @@ public class ElasticsearchConnectorBaseIT extends BaseConnectorIT {
 
   protected ElasticsearchHelperClient helperClient;
   protected Map<String, String> props;
-  protected String index = TOPIC;
+  protected String index;
+  protected boolean isDatastream;
 
   @AfterClass
   public static void cleanupAfterAll() {
@@ -64,6 +65,9 @@ public class ElasticsearchConnectorBaseIT extends BaseConnectorIT {
 
   @Before
   public void setup() {
+    index = TOPIC;
+    isDatastream = false;
+
     startConnect();
     connect.kafka().createTopic(TOPIC);
 
@@ -79,7 +83,7 @@ public class ElasticsearchConnectorBaseIT extends BaseConnectorIT {
     stopConnect();
 
     if (helperClient != null) {
-      helperClient.deleteIndex(index);
+      helperClient.deleteIndex(index, isDatastream);
       helperClient.close();
     }
   }

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorIT.java
@@ -15,7 +15,14 @@
 
 package io.confluent.connect.elasticsearch.integration;
 
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.*;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BATCH_SIZE_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_DATASET_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_TYPE_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_KEY_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.LINGER_MS_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BULK_SIZE_BYTES_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.WRITE_METHOD_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG;
 import static org.junit.Assert.assertEquals;
 

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorIT.java
@@ -106,7 +106,7 @@ public class ElasticsearchConnectorIT extends ElasticsearchConnectorBaseIT {
 
   @Test
   public void testHappyPathDataStream() throws Exception {
-    isDatastream = true;
+    isDataStream = true;
     props.put(DATA_STREAM_TYPE_CONFIG, "logs");
     props.put(DATA_STREAM_DATASET_CONFIG, "dataset");
     index = "logs-dataset-" + TOPIC;

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorIT.java
@@ -106,26 +106,14 @@ public class ElasticsearchConnectorIT extends ElasticsearchConnectorBaseIT {
 
   @Test
   public void testHappyPathDataStream() throws Exception {
+    isDatastream = true;
     props.put(DATA_STREAM_TYPE_CONFIG, "logs");
     props.put(DATA_STREAM_DATASET_CONFIG, "dataset");
     index = "logs-dataset-" + TOPIC;
-    runSimpleTest(props);
-  }
 
-  @Test
-  public void testHappyPathDataStreamtest() throws Exception {
-    props.put(DATA_STREAM_TYPE_CONFIG, "logs");
-    props.put(DATA_STREAM_DATASET_CONFIG, "dataset");
-    index = "logs-dataset-" + TOPIC;
     runSimpleTest(props);
-    // it seems like it is not being written as data streams for some reason
-    System.out.println(helperClient.getDataStreamCount(index));
-    System.out.println("LOCA LOCA");
-  }
 
-  @Test
-  public void testDataStreamGeneralDeleteLater() throws Exception {
-    helperClient.getDataStreamCount(index);
+    assertEquals(index, helperClient.getDataStream(index).getName());
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorIT.java
@@ -15,12 +15,7 @@
 
 package io.confluent.connect.elasticsearch.integration;
 
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BATCH_SIZE_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_KEY_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.LINGER_MS_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BULK_SIZE_BYTES_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.WRITE_METHOD_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.*;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG;
 import static org.junit.Assert.assertEquals;
 
@@ -99,6 +94,14 @@ public class ElasticsearchConnectorIT extends ElasticsearchConnectorBaseIT {
 
   @Test
   public void testHappyPath() throws Exception {
+    runSimpleTest(props);
+  }
+
+  @Test
+  public void testHappyPathDataStream() throws Exception {
+    props.put(DATA_STREAM_TYPE_CONFIG, "logs");
+    props.put(DATA_STREAM_DATASET_CONFIG, "dataset");
+    index = "logs-dataset-test";
     runSimpleTest(props);
   }
 

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorIT.java
@@ -113,6 +113,21 @@ public class ElasticsearchConnectorIT extends ElasticsearchConnectorBaseIT {
   }
 
   @Test
+  public void testHappyPathDataStreamtest() throws Exception {
+    props.put(DATA_STREAM_TYPE_CONFIG, "logs");
+    props.put(DATA_STREAM_DATASET_CONFIG, "dataset");
+    index = "logs-dataset-" + TOPIC;
+    runSimpleTest(props);
+    // it seems like it is not being written as data streams for some reason
+    System.out.println(helperClient.getDataStreamCount(index));
+  }
+
+  @Test
+  public void testDataStreamGeneralDeleteLater() throws Exception {
+    helperClient.getDataStreamCount(index);
+  }
+
+  @Test
   public void testNullValue() throws Exception {
     runSimpleTest(props);
 

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorIT.java
@@ -120,6 +120,7 @@ public class ElasticsearchConnectorIT extends ElasticsearchConnectorBaseIT {
     runSimpleTest(props);
     // it seems like it is not being written as data streams for some reason
     System.out.println(helperClient.getDataStreamCount(index));
+    System.out.println("LOCA LOCA");
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorIT.java
@@ -108,7 +108,7 @@ public class ElasticsearchConnectorIT extends ElasticsearchConnectorBaseIT {
   public void testHappyPathDataStream() throws Exception {
     props.put(DATA_STREAM_TYPE_CONFIG, "logs");
     props.put(DATA_STREAM_DATASET_CONFIG, "dataset");
-    index = "logs-dataset-test";
+    index = "logs-dataset-" + TOPIC;
     runSimpleTest(props);
   }
 


### PR DESCRIPTION
## Problem
Elasticsearch connector does not allow writes to data streams.

## Solution
Extended functionality to alternatively allow writes to data stream if the data stream configurations are set.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
Will be released as part of the data stream feature.
<!-- Are you backporting or merging to master? -->
Not backporting or merging to master.
<!-- If you are reverting or rolling back, is it safe? --> 
Not reverting or rolling back.
