### PR TITLE
use https confluent maven repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <repository>
             <id>confluent</id>
             <name>Confluent</name>
-            <url>http://packages.confluent.io/maven/</url>
+            <url>https://packages.confluent.io/maven/</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
## Problem
https://issues.apache.org/jira/browse/MNG-7118

high version maven block HTTP repositories by default

```
[ERROR] Failed to execute goal on project kafka-connect-elasticsearch: Could not resolve dependencies for project io.confluent:kafka-connect-elasticsearch:jar:5.5.2: Failed to collect dependencies at org.apache.kafka:connect-api:jar:7.0.0-87-ccs: Failed to read artifact descriptor for org.apache.kafka:connect-api:jar:7.0.0-87-ccs: 
Could not transfer artifact org.apache.kafka:connect-api:pom:7.0.0-87-ccs from/to maven-default-http-blocker (http://0.0.0.0/): 
Blocked mirror for repositories: [confluent (http://packages.confluent.io/maven/, default, releases+snapshots)] -> [Help 1]
```


## Solution
change pom.yml
use ```            <url>https://packages.confluent.io/maven/</url>``` instead of ``` <url>http://packages.confluent.io/maven/</url>```

