### PR TITLE
CCMSG-1116: Prevent adding external versioning to data stream.

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
@@ -219,7 +219,7 @@ public class DataConverter {
       DocWriteRequest<?> request,
       SinkRecord record
   ) {
-    if (!config.shouldIgnoreKey(record.topic()) && !config.isDataStream()) {
+    if (!config.isDataStream() && !config.shouldIgnoreKey(record.topic())) {
       request.versionType(VersionType.EXTERNAL);
       request.version(record.kafkaOffset());
     }

--- a/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
@@ -219,7 +219,7 @@ public class DataConverter {
       DocWriteRequest<?> request,
       SinkRecord record
   ) {
-    if (!config.shouldIgnoreKey(record.topic())) {
+    if (!config.shouldIgnoreKey(record.topic()) && !config.isDataStream()) {
       request.versionType(VersionType.EXTERNAL);
       request.version(record.kafkaOffset());
     }

--- a/src/test/java/io/confluent/connect/elasticsearch/DataConverterTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/DataConverterTest.java
@@ -40,7 +40,6 @@ import static io.confluent.connect.elasticsearch.DataConverter.TIMESTAMP_FIELD;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class DataConverterTest {
@@ -437,6 +436,6 @@ public class DataConverterTest {
 
     IndexRequest actualRecord = (IndexRequest) converter.convertRecord(sinkRecord, index);
 
-    assertTrue(actualRecord.versionType() == VersionType.INTERNAL);
+    assertEquals(VersionType.INTERNAL, actualRecord.versionType());
   }
 }

--- a/src/test/java/io/confluent/connect/elasticsearch/DataConverterTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/DataConverterTest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.index.VersionType;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -39,6 +40,7 @@ import static io.confluent.connect.elasticsearch.DataConverter.TIMESTAMP_FIELD;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class DataConverterTest {
@@ -421,5 +423,20 @@ public class DataConverterTest {
     IndexRequest actualRecord = (IndexRequest) converter.convertRecord(sinkRecord, index);
 
     assertEquals(timestamp, actualRecord.sourceAsMap().get(TIMESTAMP_FIELD));
+  }
+
+  @Test
+  public void testDoNotAddExternalVersioningIfDataStream() {
+    props.put(ElasticsearchSinkConnectorConfig.DATA_STREAM_TYPE_CONFIG, "logs");
+    props.put(ElasticsearchSinkConnectorConfig.DATA_STREAM_DATASET_CONFIG, "dataset");
+    props.put(ElasticsearchSinkConnectorConfig.IGNORE_KEY_CONFIG, "false");
+    converter = new DataConverter(new ElasticsearchSinkConnectorConfig(props));
+    Schema preProcessedSchema = converter.preProcessSchema(schema);
+    Struct struct = new Struct(preProcessedSchema).put("string", "myValue");
+    SinkRecord sinkRecord = createSinkRecordWithValue(struct);
+
+    IndexRequest actualRecord = (IndexRequest) converter.convertRecord(sinkRecord, index);
+
+    assertTrue(actualRecord.versionType() == VersionType.INTERNAL);
   }
 }


### PR DESCRIPTION
## Problem
When writing records to regular elasticsearch indices, external versioning ensures only the latest record with the same key ends up in elasticsearch. However, external versioning is not supported for data stream as mentioned in [Elasticsearch's index API documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html#docs-index_). 

Currently, external versioning is set for records with the same key regardless of whether data stream is enabled. This causes the Bulk Request to fail with the error
`org.elasticsearch.action.ActionRequestValidationException: Validation Failed: 1: create operations only support internal versioning. use index instead`

## Solution
Prevent updating the versioning type and version number if data streams is enabled. If messages with the same key exist in a topic, only the oldest message gets written to data stream.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
Releasing as part of the whole data stream feature.
<!-- Are you backporting or merging to master? -->
Not backporting or merging to master.
<!-- If you are reverting or rolling back, is it safe? --> 
Not reverting or rolling back.
