### PR TITLE
CCMSG-1119: Add drop down menus for the existing enum configs.

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -857,7 +857,7 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   }
 
   private SecurityProtocol securityProtocol() {
-    return SecurityProtocol.valueOf(getString(SECURITY_PROTOCOL_CONFIG));
+    return SecurityProtocol.valueOf(getString(SECURITY_PROTOCOL_CONFIG).toUpperCase());
   }
 
   public Map<String, Object> sslConfigs() {

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -569,7 +569,8 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
             DATA_CONVERSION_GROUP,
             ++order,
             Width.SHORT,
-            BEHAVIOR_ON_NULL_VALUES_DISPLAY
+            BEHAVIOR_ON_NULL_VALUES_DISPLAY,
+            new EnumRecommender<>(BehaviorOnNullValues.class)
         ).define(
             BEHAVIOR_ON_MALFORMED_DOCS_CONFIG,
             Type.STRING,
@@ -585,7 +586,8 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
             DATA_CONVERSION_GROUP,
             ++order,
             Width.SHORT,
-            BEHAVIOR_ON_MALFORMED_DOCS_DISPLAY
+            BEHAVIOR_ON_MALFORMED_DOCS_DISPLAY,
+            new EnumRecommender<>(BehaviorOnMalformedDoc.class)
         ).define(
             WRITE_METHOD_CONFIG,
             Type.STRING,
@@ -601,7 +603,8 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
             DATA_CONVERSION_GROUP,
             ++order,
             Width.SHORT,
-            WRITE_METHOD_DISPLAY
+            WRITE_METHOD_DISPLAY,
+            new EnumRecommender<>(WriteMethod.class)
     );
   }
 
@@ -671,7 +674,8 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
         SSL_GROUP,
         ++order,
         Width.SHORT,
-        SECURITY_PROTOCOL_DISPLAY
+        SECURITY_PROTOCOL_DISPLAY,
+        new EnumRecommender<>(SecurityProtocol.class)
     );
     configDef.embed(SSL_CONFIG_PREFIX, SSL_GROUP, configDef.configKeys().size() + 2, sslConfigDef);
   }

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -18,15 +18,12 @@ package io.confluent.connect.elasticsearch;
 import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
-import org.apache.kafka.common.config.ConfigDef.CaseInsensitiveValidString;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.ConfigDef.Validator;
@@ -558,12 +555,7 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
             BEHAVIOR_ON_NULL_VALUES_CONFIG,
             Type.STRING,
             BEHAVIOR_ON_NULL_VALUES_DEFAULT.name(),
-            ConfigDef.CaseInsensitiveValidString.in(
-                Arrays.stream(BehaviorOnNullValues.values())
-                    .map(BehaviorOnNullValues::name)
-                    .collect(Collectors.toList())
-                    .toArray(new String[BehaviorOnNullValues.values().length])
-            ),
+            new EnumRecommender<>(BehaviorOnNullValues.class),
             Importance.LOW,
             BEHAVIOR_ON_NULL_VALUES_DOC,
             DATA_CONVERSION_GROUP,
@@ -575,12 +567,7 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
             BEHAVIOR_ON_MALFORMED_DOCS_CONFIG,
             Type.STRING,
             BEHAVIOR_ON_MALFORMED_DOCS_DEFAULT.name(),
-            ConfigDef.CaseInsensitiveValidString.in(
-                Arrays.stream(BehaviorOnMalformedDoc.values())
-                    .map(BehaviorOnMalformedDoc::name)
-                    .collect(Collectors.toList())
-                    .toArray(new String[BehaviorOnMalformedDoc.values().length])
-            ),
+            new EnumRecommender<>(BehaviorOnMalformedDoc.class),
             Importance.LOW,
             BEHAVIOR_ON_MALFORMED_DOCS_DOC,
             DATA_CONVERSION_GROUP,
@@ -592,12 +579,7 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
             WRITE_METHOD_CONFIG,
             Type.STRING,
             WRITE_METHOD_DEFAULT,
-            ConfigDef.CaseInsensitiveValidString.in(
-                Arrays.stream(WriteMethod.values())
-                    .map(WriteMethod::name)
-                    .collect(Collectors.toList())
-                    .toArray(new String[WriteMethod.values().length])
-            ),
+            new EnumRecommender<>(WriteMethod.class),
             Importance.LOW,
             WRITE_METHOD_DOC,
             DATA_CONVERSION_GROUP,
@@ -663,12 +645,7 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
         SECURITY_PROTOCOL_CONFIG,
         Type.STRING,
         SECURITY_PROTOCOL_DEFAULT,
-        CaseInsensitiveValidString.in(
-            Arrays.stream(SecurityProtocol.values())
-                .map(SecurityProtocol::name)
-                .collect(Collectors.toList())
-                .toArray(new String[SecurityProtocol.values().length])
-        ),
+        new EnumRecommender<>(SecurityProtocol.class),
         Importance.MEDIUM,
         SECURITY_PROTOCOL_DOC,
         SSL_GROUP,

--- a/src/main/java/io/confluent/connect/elasticsearch/EnumRecommender.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/EnumRecommender.java
@@ -15,7 +15,7 @@
 
 package io.confluent.connect.elasticsearch;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -43,9 +43,12 @@ class EnumRecommender<T extends Enum<?>> implements ConfigDef.Validator, ConfigD
 
   @Override
   public void ensureValid(String key, Object value) {
-    String enum = value.toString().toUpperCase();
-    if (value != null && !validValues.contains(enum)) {
-      throw new ConfigException(key, value, "Value must be one of: " + toString());
+    if (value == null) {
+      return;
+    }
+    String enumValue = value.toString().toUpperCase();
+    if (value != null && !validValues.contains(enumValue)) {
+      throw new ConfigException(key, value, "Value must be one of: " + this);
     }
   }
 
@@ -56,7 +59,7 @@ class EnumRecommender<T extends Enum<?>> implements ConfigDef.Validator, ConfigD
 
   @Override
   public List<Object> validValues(String name, Map<String, Object> connectorConfigs) {
-    return Collections.unmodifiableList(new ArrayList<>(validValues)));
+    return Collections.unmodifiableList(new ArrayList<>(validValues));
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/elasticsearch/EnumRecommender.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/EnumRecommender.java
@@ -46,7 +46,7 @@ class EnumRecommender<T extends Enum<?>> implements ConfigDef.Validator, ConfigD
     if (value == null) {
       return;
     }
-    String enumValue = value.toString().toUpperCase();
+    String enumValue = value.toString().toLowerCase();
     if (value != null && !validValues.contains(enumValue)) {
       throw new ConfigException(key, value, "Value must be one of: " + this);
     }

--- a/src/main/java/io/confluent/connect/elasticsearch/EnumRecommender.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/EnumRecommender.java
@@ -31,10 +31,7 @@ class EnumRecommender<T extends Enum> implements ConfigDef.Validator, ConfigDef.
   private final Set<String> validValues;
   private final Class<T> enumClass;
 
-  public EnumRecommender(
-      Class<T> enumClass
-  ) {
-
+  public EnumRecommender(Class<T> enumClass) {
     this.enumClass = enumClass;
     Set<String> validEnums = new LinkedHashSet<>();
     for (Object o : enumClass.getEnumConstants()) {

--- a/src/main/java/io/confluent/connect/elasticsearch/EnumRecommender.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/EnumRecommender.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.elasticsearch;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
+
+@SuppressWarnings("rawtypes")
+class EnumRecommender<T extends Enum> implements ConfigDef.Validator, ConfigDef.Recommender {
+
+  private final Set<String> validValues;
+  private final Class<T> enumClass;
+
+  public EnumRecommender(
+      Class<T> enumClass
+  ) {
+
+    this.enumClass = enumClass;
+    Set<String> validEnums = new LinkedHashSet<>();
+    for (Object o : enumClass.getEnumConstants()) {
+      String key = o.toString().toLowerCase();
+      validEnums.add(key);
+    }
+
+    this.validValues = Collections.unmodifiableSet(validEnums);
+  }
+
+  @Override
+  public void ensureValid(String key, Object value) {
+    // calling toString on itself because IDE complains if the Object is passed.
+    if (value != null && !validValues.contains(value.toString())) {
+      throw new ConfigException(key, value, "Invalid enumerator");
+    }
+  }
+
+  @Override
+  public String toString() {
+    return validValues.toString();
+  }
+
+  @Override
+  public List<Object> validValues(String name, Map<String, Object> connectorConfigs) {
+    return Collections.unmodifiableList(Arrays.asList(validValues.toArray()));
+  }
+
+  @Override
+  public boolean visible(String name, Map<String, Object> connectorConfigs) {
+    return true;
+  }
+}

--- a/src/main/java/io/confluent/connect/elasticsearch/EnumRecommender.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/EnumRecommender.java
@@ -43,9 +43,9 @@ class EnumRecommender<T extends Enum<?>> implements ConfigDef.Validator, ConfigD
 
   @Override
   public void ensureValid(String key, Object value) {
-    // calling toString on itself because IDE complains if the Object is passed.
-    if (value != null && !validValues.contains(value.toString())) {
-      throw new ConfigException(key, value, "Invalid enumerator");
+    String enum = value.toString().toUpperCase();
+    if (value != null && !validValues.contains(enum)) {
+      throw new ConfigException(key, value, "Value must be one of: " + toString());
     }
   }
 
@@ -56,7 +56,7 @@ class EnumRecommender<T extends Enum<?>> implements ConfigDef.Validator, ConfigD
 
   @Override
   public List<Object> validValues(String name, Map<String, Object> connectorConfigs) {
-    return Collections.unmodifiableList(Arrays.asList(validValues.toArray()));
+    return Collections.unmodifiableList(new ArrayList<>(validValues)));
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/elasticsearch/EnumRecommender.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/EnumRecommender.java
@@ -25,8 +25,7 @@ import java.util.Set;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
 
-@SuppressWarnings("rawtypes")
-class EnumRecommender<T extends Enum> implements ConfigDef.Validator, ConfigDef.Recommender {
+class EnumRecommender<T extends Enum<?>> implements ConfigDef.Validator, ConfigDef.Recommender {
 
   private final Set<String> validValues;
   private final Class<T> enumClass;


### PR DESCRIPTION
## Problem
The enum configs are set by filling in the blank which requires users to review the config descriptions for what the values are and which configs have specific values.

## Solution
Add a recommender to each of those configurations such that it recommends the specific values.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?
The `data.stream.type` config could also use a recommender. (#531)

## Test Strategy
After adding the recommenders, checked in confluent platform that those configs had the correct recommenders and that the configs are settable.

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
Backporting to 11.0.x, which is the oldest version still being supported.
<!-- Are you backporting or merging to master? -->
Not backporting or merging to master.
<!-- If you are reverting or rolling back, is it safe? --> 
Not reverting or rolling back.