### PR TITLE
CCMSG-1135: Create a config that handles mapping to the @timestamp field.

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
@@ -212,8 +212,7 @@ public class DataConverter {
             return objectMapper.writeValueAsString(jsonNode);
           }
         }
-      }
-      if (jsonNode.get(TIMESTAMP_FIELD) == null) {
+      } else if (jsonNode.get(TIMESTAMP_FIELD) == null) {
         ((ObjectNode) jsonNode).put(TIMESTAMP_FIELD, timestamp);
         return objectMapper.writeValueAsString(jsonNode);
       }

--- a/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
@@ -205,8 +205,8 @@ public class DataConverter {
     }
     try {
       JsonNode jsonNode = objectMapper.readTree(payload);
-      if (!config.dataStreamTimestamp().isEmpty()) {
-        for (String timestampField : config.dataStreamTimestamp()) {
+      if (!config.dataStreamTimestampField().isEmpty()) {
+        for (String timestampField : config.dataStreamTimestampField()) {
           if (jsonNode.has(timestampField)) {
             ((ObjectNode) jsonNode).put(TIMESTAMP_FIELD, jsonNode.get(timestampField).asText());
             return objectMapper.writeValueAsString(jsonNode);

--- a/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
@@ -212,7 +212,7 @@ public class DataConverter {
             return objectMapper.writeValueAsString(jsonNode);
           }
         }
-      } else if (jsonNode.get(TIMESTAMP_FIELD) == null) {
+      } else {
         ((ObjectNode) jsonNode).put(TIMESTAMP_FIELD, timestamp);
         return objectMapper.writeValueAsString(jsonNode);
       }

--- a/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
@@ -205,6 +205,14 @@ public class DataConverter {
     }
     try {
       JsonNode jsonNode = objectMapper.readTree(payload);
+      if (!config.dataStreamTimestamp().isEmpty()) {
+        for (String timestampField : config.dataStreamTimestamp()) {
+          if (jsonNode.has(timestampField)) {
+            ((ObjectNode) jsonNode).put(TIMESTAMP_FIELD, jsonNode.get(timestampField).asText());
+            return objectMapper.writeValueAsString(jsonNode);
+          }
+        }
+      }
       if (jsonNode.get(TIMESTAMP_FIELD) == null) {
         ((ObjectNode) jsonNode).put(TIMESTAMP_FIELD, timestamp);
         return objectMapper.writeValueAsString(jsonNode);

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -341,8 +341,6 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
           + "already contain this field. This configuration can only be set if ``%s`` and ``%s`` "
           + "are set.",
       DATA_STREAM_TYPE_CONFIG,
-      DATA_STREAM_DATASET_CONFIG,
-      DATA_STREAM_TYPE_CONFIG,
       DATA_STREAM_DATASET_CONFIG
   );
   private static final String DATA_STREAM_TIMESTAMP_DISPLAY = "Data Stream Timestamp Field";

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -108,10 +108,11 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   public static final String DATA_STREAM_TIMESTAMP_CONFIG = "data.stream.timestamp";
   private static final String DATA_STREAM_TIMESTAMP_DOC = String.format(
       "The timestamp to use for the @timestamp field in messages sent to data streams. "
-          + "If multiple fields are listed, the the first field provided that also appears"
-          + " in the message would be used. If this field is not set and %s and %s are set, "
-          + "all of the messages will be auto-injected with the record timestamp. This "
-          + "field can only be set if %s and %s are set.",
+          + "If multiple fields are listed, the first field provided that also appears"
+          + " in the message would be used. If this field is not set but %s and %s are set, "
+          + "all of the messages will have the record timestamp as the @timestamp field. "
+          + "Note that the @timestamp field needs to be explicitly listed if messages "
+          + "already have this field. This field can only be set if %s and %s are set.",
       DATA_STREAM_TYPE_CONFIG,
       DATA_STREAM_DATASET_CONFIG,
       DATA_STREAM_TYPE_CONFIG,

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -78,33 +78,6 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   private static final String BULK_SIZE_BYTES_DISPLAY = "Bulk Size (bytes)";
   private static final int BULK_SIZE_BYTES_DEFAULT = 5 * 1024 * 1024;
 
-  public static final String DATA_STREAM_DATASET_CONFIG = "data.stream.dataset";
-  private static final String DATA_STREAM_DATASET_DOC =
-      "Generic name describing data ingested and its structure to be written to a data stream. "
-      + "Can be any arbitrary string that is no longer than 100 characters, is in all lowercase, "
-      + "and does not contain spaces or any of these special characters ``/\\*\"<>|,#:-``. "
-      + "Otherwise, no value indicates the connector will write to regular indices instead. "
-      + "If set, this configuration will be used alongside ``data.stream.type`` to "
-      + "construct the data stream name in the form of {``data.stream.type``"
-      + "}-{" + DATA_STREAM_DATASET_CONFIG + "}-{topic}.";
-  private static final String DATA_STREAM_DATASET_DISPLAY = "Data Stream Dataset";
-  private static final String DATA_STREAM_DATASET_DEFAULT = "";
-
-  public static final String DATA_STREAM_TYPE_CONFIG = "data.stream.type";
-  private static final String DATA_STREAM_TYPE_DOC = String.format(
-      "Generic type describing the data to be written to data stream. "
-          + "The default is %s which indicates the connector will write "
-          + "to regular indices instead. If set, this configuration will "
-          + "be used alongside %s to construct the data stream name in the form of"
-          + "{%s}-{%s}-{topic}.",
-      DataStreamType.NONE.name(),
-      DATA_STREAM_DATASET_CONFIG,
-      DATA_STREAM_TYPE_CONFIG,
-      DATA_STREAM_DATASET_CONFIG
-  );
-  private static final String DATA_STREAM_TYPE_DISPLAY = "Data Stream Type";
-  private static final DataStreamType DATA_STREAM_TYPE_DEFAULT = DataStreamType.NONE;
-
   public static final String MAX_IN_FLIGHT_REQUESTS_CONFIG = "max.in.flight.requests";
   private static final String MAX_IN_FLIGHT_REQUESTS_DOC =
       "The maximum number of indexing requests that can be in-flight to Elasticsearch before "
@@ -227,22 +200,6 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   private static final String COMPACT_MAP_ENTRIES_DISPLAY = "Compact Map Entries";
   private static final boolean COMPACT_MAP_ENTRIES_DEFAULT = true;
 
-  public static final String DATA_STREAM_TIMESTAMP_CONFIG = "data.stream.timestamp";
-  private static final String DATA_STREAM_TIMESTAMP_DOC = String.format(
-      "The timestamp to use for the @timestamp field in messages sent to data stream. "
-          + "If multiple fields are provided, the first field listed that also appears"
-          + " in the message would be used. If this field is not set but ``%s`` and ``%s`` are set,"
-          + " all of the messages will have the record timestamp as the @timestamp field value. "
-          + "Note that the @timestamp field needs to be explicitly listed if messages "
-          + "already have this field. This field can only be set if ``%s`` and ``%s`` are set.",
-      DATA_STREAM_TYPE_CONFIG,
-      DATA_STREAM_DATASET_CONFIG,
-      DATA_STREAM_TYPE_CONFIG,
-      DATA_STREAM_DATASET_CONFIG
-  );
-  private static final String DATA_STREAM_TIMESTAMP_DISPLAY = "Data Stream Timestamp";
-  private static final String DATA_STREAM_TIMESTAMP_DEFAULT = "";
-
   private static final String IGNORE_KEY_TOPICS_DOC =
       "List of topics for which ``" + IGNORE_KEY_CONFIG + "`` should be ``true``.";
   private static final String IGNORE_KEY_TOPICS_DISPLAY = "Topics for 'Ignore Key' mode";
@@ -344,11 +301,56 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
       + " authentication with Kerberos.";
   private static final String KERBEROS_KEYTAB_PATH_DEFAULT = null;
 
+  // Data stream configs
+  public static final String DATA_STREAM_DATASET_CONFIG = "data.stream.dataset";
+  private static final String DATA_STREAM_DATASET_DOC =
+      "Generic name describing data ingested and its structure to be written to a data stream. "
+          + "Can be any arbitrary string that is no longer than 100 characters, is in all lowercase, "
+          + "and does not contain spaces or any of these special characters ``/\\*\"<>|,#:-``. "
+          + "Otherwise, no value indicates the connector will write to regular indices instead. "
+          + "If set, this configuration will be used alongside ``data.stream.type`` to "
+          + "construct the data stream name in the form of {``data.stream.type``"
+          + "}-{" + DATA_STREAM_DATASET_CONFIG + "}-{topic}.";
+  private static final String DATA_STREAM_DATASET_DISPLAY = "Data Stream Dataset";
+  private static final String DATA_STREAM_DATASET_DEFAULT = "";
+
+  public static final String DATA_STREAM_TYPE_CONFIG = "data.stream.type";
+  private static final String DATA_STREAM_TYPE_DOC = String.format(
+      "Generic type describing the data to be written to data stream. "
+          + "The default is %s which indicates the connector will write "
+          + "to regular indices instead. If set, this configuration will "
+          + "be used alongside %s to construct the data stream name in the form of"
+          + "{%s}-{%s}-{topic}.",
+      DataStreamType.NONE.name(),
+      DATA_STREAM_DATASET_CONFIG,
+      DATA_STREAM_TYPE_CONFIG,
+      DATA_STREAM_DATASET_CONFIG
+  );
+  private static final String DATA_STREAM_TYPE_DISPLAY = "Data Stream Type";
+  private static final DataStreamType DATA_STREAM_TYPE_DEFAULT = DataStreamType.NONE;
+
+  public static final String DATA_STREAM_TIMESTAMP_CONFIG = "data.stream.timestamp.field";
+  private static final String DATA_STREAM_TIMESTAMP_DOC = String.format(
+      "The timestamp to use for the @timestamp field in messages sent to data stream. "
+          + "If multiple fields are provided, the first field listed that also appears"
+          + " in the message would be used. If this field is not set but ``%s`` and ``%s`` are set,"
+          + " all of the messages will have the record timestamp as the @timestamp field value. "
+          + "Note that the @timestamp field needs to be explicitly listed if messages "
+          + "already have this field. This field can only be set if ``%s`` and ``%s`` are set.",
+      DATA_STREAM_TYPE_CONFIG,
+      DATA_STREAM_DATASET_CONFIG,
+      DATA_STREAM_TYPE_CONFIG,
+      DATA_STREAM_DATASET_CONFIG
+  );
+  private static final String DATA_STREAM_TIMESTAMP_DISPLAY = "Data Stream Timestamp";
+  private static final String DATA_STREAM_TIMESTAMP_DEFAULT = "";
+
   private static final String CONNECTOR_GROUP = "Connector";
   private static final String DATA_CONVERSION_GROUP = "Data Conversion";
   private static final String PROXY_GROUP = "Proxy";
   private static final String SSL_GROUP = "Security";
   private static final String KERBEROS_GROUP = "Kerberos";
+  private static final String DATA_STREAM_GROUP = "Data Stream";
 
   public enum BehaviorOnMalformedDoc {
     IGNORE,
@@ -385,6 +387,7 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
     addProxyConfigs(configDef);
     addSslConfigs(configDef);
     addKerberosConfigs(configDef);
+    addDataStreamConfigs(configDef);
     return configDef;
   }
 
@@ -444,29 +447,6 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
             ++order,
             Width.SHORT,
             BULK_SIZE_BYTES_DISPLAY
-        ).define(
-            DATA_STREAM_DATASET_CONFIG,
-            Type.STRING,
-            DATA_STREAM_DATASET_DEFAULT,
-            new DataStreamDatasetValidator(),
-            Importance.LOW,
-            DATA_STREAM_DATASET_DOC,
-            CONNECTOR_GROUP,
-            ++order,
-            Width.MEDIUM,
-            DATA_STREAM_DATASET_DISPLAY
-        ).define(
-            DATA_STREAM_TYPE_CONFIG,
-            Type.STRING,
-            DATA_STREAM_TYPE_DEFAULT.name(),
-            new EnumRecommender<>(DataStreamType.class),
-            Importance.LOW,
-            DATA_STREAM_TYPE_DOC,
-            CONNECTOR_GROUP,
-            ++order,
-            Width.SHORT,
-            DATA_STREAM_TYPE_DISPLAY,
-            new EnumRecommender<>(DataStreamType.class)
         ).define(
             MAX_IN_FLIGHT_REQUESTS_CONFIG,
             Type.INT,
@@ -612,16 +592,6 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
             ++order,
             Width.SHORT,
             COMPACT_MAP_ENTRIES_DISPLAY
-        ).define(
-            DATA_STREAM_TIMESTAMP_CONFIG,
-            Type.LIST,
-            DATA_STREAM_TIMESTAMP_DEFAULT,
-            Importance.LOW,
-            DATA_STREAM_TIMESTAMP_DOC,
-            DATA_CONVERSION_GROUP,
-            ++order,
-            Width.LONG,
-            DATA_STREAM_TIMESTAMP_DISPLAY
         ).define(
             IGNORE_KEY_TOPICS_CONFIG,
             Type.LIST,
@@ -782,6 +752,45 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
             orderInGroup++,
             Width.LONG,
             KERBEROS_KEYTAB_PATH
+    );
+  }
+
+  private static void addDataStreamConfigs(ConfigDef configDef) {
+    int order = 0;
+    configDef
+        .define(
+            DATA_STREAM_DATASET_CONFIG,
+            Type.STRING,
+            DATA_STREAM_DATASET_DEFAULT,
+            new DataStreamDatasetValidator(),
+            Importance.LOW,
+            DATA_STREAM_DATASET_DOC,
+            DATA_STREAM_GROUP,
+            ++order,
+            Width.MEDIUM,
+            DATA_STREAM_DATASET_DISPLAY
+        ).define(
+            DATA_STREAM_TYPE_CONFIG,
+            Type.STRING,
+            DATA_STREAM_TYPE_DEFAULT.name(),
+            new EnumRecommender<>(DataStreamType.class),
+            Importance.LOW,
+            DATA_STREAM_TYPE_DOC,
+            DATA_STREAM_GROUP,
+            ++order,
+            Width.SHORT,
+            DATA_STREAM_TYPE_DISPLAY,
+            new EnumRecommender<>(DataStreamType.class)
+        ).define(
+            DATA_STREAM_TIMESTAMP_CONFIG,
+            Type.LIST,
+            DATA_STREAM_TIMESTAMP_DEFAULT,
+            Importance.LOW,
+            DATA_STREAM_TIMESTAMP_DOC,
+            DATA_STREAM_GROUP,
+            ++order,
+            Width.LONG,
+            DATA_STREAM_TIMESTAMP_DISPLAY
     );
   }
 

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -105,19 +105,6 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   private static final String DATA_STREAM_TYPE_DISPLAY = "Data Stream Type";
   private static final DataStreamType DATA_STREAM_TYPE_DEFAULT = DataStreamType.NONE;
 
-  public static final String DATA_STREAM_TIMESTAMP_CONFIG = "data.stream.timestamp";
-  private static final String DATA_STREAM_TIMESTAMP_DOC = String.format(
-      "The timestamp to use for the @timestamp field in messages sent to data stream. "
-          + "If multiple fields are listed, the first field provided that also appears"
-          + " in the message would be used. If this field is not set but %s and %s are set, "
-          + "all of the messages will have the record timestamp as the @timestamp field value. "
-          + "Note that the @timestamp field needs to be explicitly listed if messages "
-          + "already have this field. This field can only be set if %s and %s are set.",
-      DATA_STREAM_TYPE_CONFIG,
-      DATA_STREAM_DATASET_CONFIG,
-      DATA_STREAM_TYPE_CONFIG,
-      DATA_STREAM_DATASET_CONFIG
-  );
   private static final String DATA_STREAM_TIMESTAMP_DISPLAY = "Data Stream Timestamp";
   private static final String DATA_STREAM_TIMESTAMP_DEFAULT = "";
 
@@ -242,6 +229,20 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
           + "so set this to ``false`` to use that older behavior.";
   private static final String COMPACT_MAP_ENTRIES_DISPLAY = "Compact Map Entries";
   private static final boolean COMPACT_MAP_ENTRIES_DEFAULT = true;
+
+  public static final String DATA_STREAM_TIMESTAMP_CONFIG = "data.stream.timestamp";
+  private static final String DATA_STREAM_TIMESTAMP_DOC = String.format(
+      "The timestamp to use for the @timestamp field in messages sent to data stream. "
+          + "If multiple fields are listed, the first field provided that also appears"
+          + " in the message would be used. If this field is not set but %s and %s are set, "
+          + "all of the messages will have the record timestamp as the @timestamp field value. "
+          + "Note that the @timestamp field needs to be explicitly listed if messages "
+          + "already have this field. This field can only be set if %s and %s are set.",
+      DATA_STREAM_TYPE_CONFIG,
+      DATA_STREAM_DATASET_CONFIG,
+      DATA_STREAM_TYPE_CONFIG,
+      DATA_STREAM_DATASET_CONFIG
+  );
 
   private static final String IGNORE_KEY_TOPICS_DOC =
       "List of topics for which ``" + IGNORE_KEY_CONFIG + "`` should be ``true``.";

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -455,16 +455,6 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
             Width.MEDIUM,
             DATA_STREAM_DATASET_DISPLAY
         ).define(
-            DATA_STREAM_TIMESTAMP_CONFIG,
-            Type.LIST,
-            DATA_STREAM_TIMESTAMP_DEFAULT,
-            Importance.LOW,
-            DATA_STREAM_TIMESTAMP_DOC,
-            DATA_CONVERSION_GROUP,
-            ++order,
-            Width.LONG,
-            DATA_STREAM_TIMESTAMP_DISPLAY
-        ).define(
             DATA_STREAM_TYPE_CONFIG,
             Type.STRING,
             DATA_STREAM_TYPE_DEFAULT.name(),
@@ -476,6 +466,17 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
             Width.SHORT,
             DATA_STREAM_TYPE_DISPLAY,
             new EnumRecommender<>(DataStreamType.class)
+        ).define(
+            DATA_STREAM_TIMESTAMP_CONFIG,
+            Type.LIST,
+            DATA_STREAM_TIMESTAMP_DEFAULT,
+            Importance.LOW,
+            DATA_STREAM_TIMESTAMP_DOC,
+            DATA_CONVERSION_GROUP,
+            ++order,
+            Width.LONG,
+            DATA_STREAM_TIMESTAMP_DISPLAY
+
         ).define(
             MAX_IN_FLIGHT_REQUESTS_CONFIG,
             Type.INT,

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -105,6 +105,23 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   private static final String DATA_STREAM_TYPE_DISPLAY = "Data Stream Type";
   private static final DataStreamType DATA_STREAM_TYPE_DEFAULT = DataStreamType.NONE;
 
+
+  public static final String DATASTREAM_TIMESTAMP_CONFIG = "data.stream.timestamp";
+  private static final String DATASTREAM_TIMESTAMP_DOC = String.format(
+      "The timestamp to use for the @timestamp field in messages sent to data streams. "
+          + "If multiple fields are listed, the the first field provided that also appears"
+          + " in the message would be used. If this field is not set and %s and %s are set, "
+          + "all of the messages will be auto-injected with the record timestamp. This "
+          + "field can only be set if %s and %s are set.",
+      DATA_STREAM_TYPE_CONFIG,
+      DATA_STREAM_DATASET_CONFIG,
+      DATA_STREAM_TYPE_CONFIG,
+      DATA_STREAM_DATASET_CONFIG
+  );
+  private static final String DATASTREAM_TIMESTAMP_DISPLAY = "Data Stream Timestamp";
+  private static final String DATASTREAM_TIMESTAMP_DEFAULT = "";
+
+
   public static final String MAX_IN_FLIGHT_REQUESTS_CONFIG = "max.in.flight.requests";
   private static final String MAX_IN_FLIGHT_REQUESTS_DOC =
       "The maximum number of indexing requests that can be in-flight to Elasticsearch before "

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -105,9 +105,6 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   private static final String DATA_STREAM_TYPE_DISPLAY = "Data Stream Type";
   private static final DataStreamType DATA_STREAM_TYPE_DEFAULT = DataStreamType.NONE;
 
-  private static final String DATA_STREAM_TIMESTAMP_DISPLAY = "Data Stream Timestamp";
-  private static final String DATA_STREAM_TIMESTAMP_DEFAULT = "";
-
   public static final String MAX_IN_FLIGHT_REQUESTS_CONFIG = "max.in.flight.requests";
   private static final String MAX_IN_FLIGHT_REQUESTS_DOC =
       "The maximum number of indexing requests that can be in-flight to Elasticsearch before "
@@ -243,6 +240,8 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
       DATA_STREAM_TYPE_CONFIG,
       DATA_STREAM_DATASET_CONFIG
   );
+  private static final String DATA_STREAM_TIMESTAMP_DISPLAY = "Data Stream Timestamp";
+  private static final String DATA_STREAM_TIMESTAMP_DEFAULT = "";
 
   private static final String IGNORE_KEY_TOPICS_DOC =
       "List of topics for which ``" + IGNORE_KEY_CONFIG + "`` should be ``true``.";

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -873,6 +873,10 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
     return DataStreamType.valueOf(getString(DATA_STREAM_TYPE_CONFIG).toUpperCase());
   }
 
+  public List<String> dataStreamTimestamp() {
+    return getList(DATA_STREAM_TIMESTAMP_CONFIG);
+  }
+
   public long flushTimeoutMs() {
     return getLong(FLUSH_TIMEOUT_MS_CONFIG);
   }

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -331,12 +331,11 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
 
   public static final String DATA_STREAM_TIMESTAMP_CONFIG = "data.stream.timestamp.field";
   private static final String DATA_STREAM_TIMESTAMP_DOC = String.format(
-      "All documents sent to a data stream needs an``@timestamp`` field with values of type"
-          + " ``date`` or ``data_nanos``. Otherwise, "
-          + "the document would not be sent.\n The Kafka record field to use as the "
-          + "timestamp for the ``@timestamp`` field in documents sent to a data stream. "
-          + "If multiple fields are provided, the first field listed that also appears"
-          + " in the record will be used. If this configuration is left empty,"
+      "The Kafka record field to use as the timestamp for the ``@timestamp`` field in documents "
+          + "sent to a data stream.\n All documents sent to a data stream needs an``@timestamp`` "
+          + " field with values of type ``date`` or ``data_nanos``. Otherwise, the document "
+          + " would not be sent. If multiple fields are provided, the first field listed that "
+          + "also appears in the record will be used. If this configuration is left empty,"
           + " all of the documents will use the record timestamp as the ``@timestamp`` field "
           + "value. Note that the ``@timestamp`` field needs to be explicitly listed if records "
           + "already contain this field. This configuration can only be set if ``%s`` and ``%s`` "

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -334,10 +334,10 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
       "The Kafka record field to use as the timestamp for the ``@timestamp`` field in documents "
           + "sent to a data stream.\n All documents sent to a data stream needs an``@timestamp`` "
           + " field with values of type ``date`` or ``data_nanos``. Otherwise, the document "
-          + " would not be sent. If multiple fields are provided, the first field listed that "
+          + " will not be sent. If multiple fields are provided, the first field listed that "
           + "also appears in the record will be used. If this configuration is left empty,"
-          + " all of the documents will use the record timestamp as the ``@timestamp`` field "
-          + "value. Note that the ``@timestamp`` field needs to be explicitly listed if records "
+          + " all of the documents will use the Kafka record timestamp as the ``@timestamp`` field "
+          + "value. Note that ``@timestamp``still  needs to be explicitly listed if records "
           + "already contain this field. This configuration can only be set if ``%s`` and ``%s`` "
           + "are set.",
       DATA_STREAM_TYPE_CONFIG,

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -107,10 +107,10 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
 
   public static final String DATA_STREAM_TIMESTAMP_CONFIG = "data.stream.timestamp";
   private static final String DATA_STREAM_TIMESTAMP_DOC = String.format(
-      "The timestamp to use for the @timestamp field in messages sent to data streams. "
+      "The timestamp to use for the @timestamp field in messages sent to data stream. "
           + "If multiple fields are listed, the first field provided that also appears"
           + " in the message would be used. If this field is not set but %s and %s are set, "
-          + "all of the messages will have the record timestamp as the @timestamp field. "
+          + "all of the messages will have the record timestamp as the @timestamp field value. "
           + "Note that the @timestamp field needs to be explicitly listed if messages "
           + "already have this field. This field can only be set if %s and %s are set.",
       DATA_STREAM_TYPE_CONFIG,

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -234,8 +234,8 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   private static final String DATA_STREAM_TIMESTAMP_DOC = String.format(
       "The timestamp to use for the @timestamp field in messages sent to data stream. "
           + "If multiple fields are provided, the first field listed that also appears"
-          + " in the message would be used. If this field is not set but ``%s`` and ``%s`` are set, "
-          + "all of the messages will have the record timestamp as the @timestamp field value. "
+          + " in the message would be used. If this field is not set but ``%s`` and ``%s`` are set,"
+          + " all of the messages will have the record timestamp as the @timestamp field value. "
           + "Note that the @timestamp field needs to be explicitly listed if messages "
           + "already have this field. This field can only be set if ``%s`` and ``%s`` are set.",
       DATA_STREAM_TYPE_CONFIG,

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -233,11 +233,11 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   public static final String DATA_STREAM_TIMESTAMP_CONFIG = "data.stream.timestamp";
   private static final String DATA_STREAM_TIMESTAMP_DOC = String.format(
       "The timestamp to use for the @timestamp field in messages sent to data stream. "
-          + "If multiple fields are listed, the first field provided that also appears"
-          + " in the message would be used. If this field is not set but %s and %s are set, "
+          + "If multiple fields are provided, the first field listed that also appears"
+          + " in the message would be used. If this field is not set but ``%s`` and ``%s`` are set, "
           + "all of the messages will have the record timestamp as the @timestamp field value. "
           + "Note that the @timestamp field needs to be explicitly listed if messages "
-          + "already have this field. This field can only be set if %s and %s are set.",
+          + "already have this field. This field can only be set if ``%s`` and ``%s`` are set.",
       DATA_STREAM_TYPE_CONFIG,
       DATA_STREAM_DATASET_CONFIG,
       DATA_STREAM_TYPE_CONFIG,

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -331,18 +331,22 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
 
   public static final String DATA_STREAM_TIMESTAMP_CONFIG = "data.stream.timestamp.field";
   private static final String DATA_STREAM_TIMESTAMP_DOC = String.format(
-      "The timestamp to use for the @timestamp field in messages sent to data stream. "
+      "All documents sent to a data stream needs an``@timestamp`` field with values of type"
+          + " ``date`` or ``data_nanos``. Otherwise, "
+          + "the document would not be sent.\n The Kafka record field to use as the "
+          + "timestamp for the ``@timestamp`` field in documents sent to a data stream. "
           + "If multiple fields are provided, the first field listed that also appears"
-          + " in the message would be used. If this field is not set but ``%s`` and ``%s`` are set,"
-          + " all of the messages will have the record timestamp as the @timestamp field value. "
-          + "Note that the @timestamp field needs to be explicitly listed if messages "
-          + "already have this field. This field can only be set if ``%s`` and ``%s`` are set.",
+          + " in the record will be used. If this configuration is left empty,"
+          + " all of the documents will use the record timestamp as the ``@timestamp`` field "
+          + "value. Note that the ``@timestamp`` field needs to be explicitly listed if records "
+          + "already contain this field. This configuration can only be set if ``%s`` and ``%s`` "
+          + "are set.",
       DATA_STREAM_TYPE_CONFIG,
       DATA_STREAM_DATASET_CONFIG,
       DATA_STREAM_TYPE_CONFIG,
       DATA_STREAM_DATASET_CONFIG
   );
-  private static final String DATA_STREAM_TIMESTAMP_DISPLAY = "Data Stream Timestamp";
+  private static final String DATA_STREAM_TIMESTAMP_DISPLAY = "Data Stream Timestamp Field";
   private static final String DATA_STREAM_TIMESTAMP_DEFAULT = "";
 
   private static final String CONNECTOR_GROUP = "Connector";

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -105,9 +105,8 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   private static final String DATA_STREAM_TYPE_DISPLAY = "Data Stream Type";
   private static final DataStreamType DATA_STREAM_TYPE_DEFAULT = DataStreamType.NONE;
 
-
-  public static final String DATASTREAM_TIMESTAMP_CONFIG = "data.stream.timestamp";
-  private static final String DATASTREAM_TIMESTAMP_DOC = String.format(
+  public static final String DATA_STREAM_TIMESTAMP_CONFIG = "data.stream.timestamp";
+  private static final String DATA_STREAM_TIMESTAMP_DOC = String.format(
       "The timestamp to use for the @timestamp field in messages sent to data streams. "
           + "If multiple fields are listed, the the first field provided that also appears"
           + " in the message would be used. If this field is not set and %s and %s are set, "
@@ -118,9 +117,8 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
       DATA_STREAM_TYPE_CONFIG,
       DATA_STREAM_DATASET_CONFIG
   );
-  private static final String DATASTREAM_TIMESTAMP_DISPLAY = "Data Stream Timestamp";
-  private static final String DATASTREAM_TIMESTAMP_DEFAULT = "";
-
+  private static final String DATA_STREAM_TIMESTAMP_DISPLAY = "Data Stream Timestamp";
+  private static final String DATA_STREAM_TIMESTAMP_DEFAULT = "";
 
   public static final String MAX_IN_FLIGHT_REQUESTS_CONFIG = "max.in.flight.requests";
   private static final String MAX_IN_FLIGHT_REQUESTS_DOC =
@@ -456,6 +454,16 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
             ++order,
             Width.MEDIUM,
             DATA_STREAM_DATASET_DISPLAY
+        ).define(
+            DATA_STREAM_TIMESTAMP_CONFIG,
+            Type.LIST,
+            DATA_STREAM_TIMESTAMP_DEFAULT,
+            Importance.LOW,
+            DATA_STREAM_TIMESTAMP_DOC,
+            DATA_CONVERSION_GROUP,
+            ++order,
+            Width.LONG,
+            DATA_STREAM_TIMESTAMP_DISPLAY
         ).define(
             DATA_STREAM_TYPE_CONFIG,
             Type.STRING,

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -887,7 +887,7 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
     return DataStreamType.valueOf(getString(DATA_STREAM_TYPE_CONFIG).toUpperCase());
   }
 
-  public List<String> dataStreamTimestamp() {
+  public List<String> dataStreamTimestampField() {
     return getList(DATA_STREAM_TIMESTAMP_CONFIG);
   }
 

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -304,8 +304,8 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   // Data stream configs
   public static final String DATA_STREAM_DATASET_CONFIG = "data.stream.dataset";
   private static final String DATA_STREAM_DATASET_DOC =
-      "Generic name describing data ingested and its structure to be written to a data stream. "
-          + "Can be any arbitrary string that is no longer than 100 characters, is in all lowercase, "
+      "Generic name describing data ingested and its structure to be written to a data stream. Can"
+          + " be any arbitrary string that is no longer than 100 characters, is in all lowercase, "
           + "and does not contain spaces or any of these special characters ``/\\*\"<>|,#:-``. "
           + "Otherwise, no value indicates the connector will write to regular indices instead. "
           + "If set, this configuration will be used alongside ``data.stream.type`` to "

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -468,17 +468,6 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
             DATA_STREAM_TYPE_DISPLAY,
             new EnumRecommender<>(DataStreamType.class)
         ).define(
-            DATA_STREAM_TIMESTAMP_CONFIG,
-            Type.LIST,
-            DATA_STREAM_TIMESTAMP_DEFAULT,
-            Importance.LOW,
-            DATA_STREAM_TIMESTAMP_DOC,
-            DATA_CONVERSION_GROUP,
-            ++order,
-            Width.LONG,
-            DATA_STREAM_TIMESTAMP_DISPLAY
-
-        ).define(
             MAX_IN_FLIGHT_REQUESTS_CONFIG,
             Type.INT,
             MAX_IN_FLIGHT_REQUESTS_DEFAULT,
@@ -623,6 +612,16 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
             ++order,
             Width.SHORT,
             COMPACT_MAP_ENTRIES_DISPLAY
+        ).define(
+            DATA_STREAM_TIMESTAMP_CONFIG,
+            Type.LIST,
+            DATA_STREAM_TIMESTAMP_DEFAULT,
+            Importance.LOW,
+            DATA_STREAM_TIMESTAMP_DOC,
+            DATA_CONVERSION_GROUP,
+            ++order,
+            Width.LONG,
+            DATA_STREAM_TIMESTAMP_DISPLAY
         ).define(
             IGNORE_KEY_TOPICS_CONFIG,
             Type.LIST,

--- a/src/main/java/io/confluent/connect/elasticsearch/Validator.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/Validator.java
@@ -41,6 +41,7 @@ import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfi
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_URL_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_USERNAME_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_DATASET_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_TIMESTAMP_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_TYPE_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DataStreamType;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.FLUSH_TIMEOUT_MS_CONFIG;
@@ -160,6 +161,17 @@ public class Validator {
           DATA_STREAM_DATASET_CONFIG
       );
       addErrorMessage(BEHAVIOR_ON_NULL_VALUES_CONFIG, errorMessage);
+    }
+
+    if (!config.isDataStream() && !config.dataStreamTimestamp().isEmpty()) {
+      String errorMessage = String.format(
+          "Mapping a field to the @timestamp field is only necessary for data streams. "
+              + "%s must not be set if %s and %s are set.",
+          DATA_STREAM_TIMESTAMP_CONFIG,
+          DATA_STREAM_TYPE_CONFIG,
+          DATA_STREAM_DATASET_CONFIG
+      );
+      addErrorMessage(DATA_STREAM_TIMESTAMP_CONFIG, errorMessage);
     }
   }
 

--- a/src/main/java/io/confluent/connect/elasticsearch/Validator.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/Validator.java
@@ -163,7 +163,7 @@ public class Validator {
       addErrorMessage(BEHAVIOR_ON_NULL_VALUES_CONFIG, errorMessage);
     }
 
-    if (!config.isDataStream() && !config.dataStreamTimestamp().isEmpty()) {
+    if (!config.isDataStream() && !config.dataStreamTimestampField().isEmpty()) {
       String errorMessage = String.format(
           "Mapping a field to the @timestamp field is only necessary for data streams. "
               + "%s must not be set if %s and %s are set.",

--- a/src/test/java/io/confluent/connect/elasticsearch/DataConverterTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/DataConverterTest.java
@@ -379,7 +379,7 @@ public class DataConverterTest {
   }
 
   @Test
-  public void testInjectPayloadTimestampIfDataStreamAndTimestampNotSet() {
+  public void testInjectPayloadTimestampIfDataStreamAndTimestampMapNotSet() {
     props.put(ElasticsearchSinkConnectorConfig.DATA_STREAM_TYPE_CONFIG, "logs");
     props.put(ElasticsearchSinkConnectorConfig.DATA_STREAM_DATASET_CONFIG, "dataset");
     converter = new DataConverter(new ElasticsearchSinkConnectorConfig(props));
@@ -393,7 +393,7 @@ public class DataConverterTest {
   }
 
   @Test
-  public void testDoNotInjectMissingPayloadTimestampIfDataStreamAndTimestampSet() {
+  public void testDoNotInjectMissingPayloadTimestampIfDataStreamAndTimestampMapSet() {
     props.put(ElasticsearchSinkConnectorConfig.DATA_STREAM_TYPE_CONFIG, "logs");
     props.put(ElasticsearchSinkConnectorConfig.DATA_STREAM_DATASET_CONFIG, "dataset");
     props.put(ElasticsearchSinkConnectorConfig.DATA_STREAM_TIMESTAMP_CONFIG, "@timestamp");
@@ -419,7 +419,7 @@ public class DataConverterTest {
   }
 
   @Test
-  public void testDoNotInjectPayloadTimestampIfAlreadyExists() {
+  public void testInjectPayloadTimestampIfAlreadyExistsAndTimestampMapNotSet() {
     props.put(ElasticsearchSinkConnectorConfig.DATA_STREAM_TYPE_CONFIG, "logs");
     props.put(ElasticsearchSinkConnectorConfig.DATA_STREAM_DATASET_CONFIG, "dataset");
     converter = new DataConverter(new ElasticsearchSinkConnectorConfig(props));
@@ -435,7 +435,7 @@ public class DataConverterTest {
 
     IndexRequest actualRecord = (IndexRequest) converter.convertRecord(sinkRecord, index);
 
-    assertEquals(timestamp, actualRecord.sourceAsMap().get(TIMESTAMP_FIELD));
+    assertEquals(this.timestamp, actualRecord.sourceAsMap().get(TIMESTAMP_FIELD));
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/elasticsearch/DataConverterTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/DataConverterTest.java
@@ -379,7 +379,7 @@ public class DataConverterTest {
   }
 
   @Test
-  public void testInjectPayloadTimestampIfDataStream() {
+  public void testInjectPayloadTimestampIfDataStreamAndTimestampNotSet() {
     props.put(ElasticsearchSinkConnectorConfig.DATA_STREAM_TYPE_CONFIG, "logs");
     props.put(ElasticsearchSinkConnectorConfig.DATA_STREAM_DATASET_CONFIG, "dataset");
     converter = new DataConverter(new ElasticsearchSinkConnectorConfig(props));
@@ -390,6 +390,20 @@ public class DataConverterTest {
     IndexRequest actualRecord = (IndexRequest) converter.convertRecord(sinkRecord, index);
 
     assertEquals(timestamp, actualRecord.sourceAsMap().get(TIMESTAMP_FIELD));
+  }
+
+  @Test
+  public void testDoNotInjectMissingPayloadTimestampIfDataStreamAndTimestampSet() {
+    props.put(ElasticsearchSinkConnectorConfig.DATA_STREAM_TYPE_CONFIG, "logs");
+    props.put(ElasticsearchSinkConnectorConfig.DATA_STREAM_DATASET_CONFIG, "dataset");
+    props.put(ElasticsearchSinkConnectorConfig.DATA_STREAM_TIMESTAMP_CONFIG, "@timestamp");
+    converter = new DataConverter(new ElasticsearchSinkConnectorConfig(props));
+    Schema preProcessedSchema = converter.preProcessSchema(schema);
+    Struct struct = new Struct(preProcessedSchema).put("string", "myValue");
+    SinkRecord sinkRecord = createSinkRecordWithValue(struct);
+
+    IndexRequest actualRecord = (IndexRequest) converter.convertRecord(sinkRecord, index);
+    assertFalse(actualRecord.sourceAsMap().containsKey(TIMESTAMP_FIELD));
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/elasticsearch/DataConverterTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/DataConverterTest.java
@@ -379,7 +379,7 @@ public class DataConverterTest {
   }
 
   @Test
-  public void testInjectPayloadTimestampIfDataStreamAndNoTimestampMap() {
+  public void testInjectPayloadTimestampIfDataStreamAndNoTimestampMapSet() {
     setDataStream();
     converter = new DataConverter(new ElasticsearchSinkConnectorConfig(props));
     Schema preProcessedSchema = converter.preProcessSchema(schema);
@@ -417,7 +417,7 @@ public class DataConverterTest {
   }
 
   @Test
-  public void testInjectPayloadTimestampIfAlreadyExistsAndTimestampMapNotSet() {
+  public void testInjectPayloadTimestampEvenIfAlreadyExistsAndTimestampMapNotSet() {
     setDataStream();
     converter = new DataConverter(new ElasticsearchSinkConnectorConfig(props));
     schema = SchemaBuilder
@@ -436,7 +436,7 @@ public class DataConverterTest {
   }
 
   @Test
-  public void testMapPayloadTimestampIfDataStreamSetAndOneTimestampMap() {
+  public void testMapPayloadTimestampIfDataStreamSetAndOneTimestampMapSet() {
     String timestampFieldMap = "onefield";
     setDataStream();
     props.put(ElasticsearchSinkConnectorConfig.DATA_STREAM_TIMESTAMP_CONFIG, timestampFieldMap);
@@ -457,7 +457,7 @@ public class DataConverterTest {
   }
 
   @Test
-  public void testMapPayloadTimestampByPriorityIfMultipleTimestampMap() {
+  public void testMapPayloadTimestampByPriorityIfMultipleTimestampMapsSet() {
     String timestampFieldToUse = "two";
     setDataStream();
     props.put(ElasticsearchSinkConnectorConfig.DATA_STREAM_TIMESTAMP_CONFIG, "one, two, field");

--- a/src/test/java/io/confluent/connect/elasticsearch/DataConverterTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/DataConverterTest.java
@@ -392,7 +392,7 @@ public class DataConverterTest {
 
   @Test
   public void testDoNotInjectMissingPayloadTimestampIfDataStreamAndTimestampMapNotFound() {
-    setDataStream();
+    configureDataStream();
     props.put(ElasticsearchSinkConnectorConfig.DATA_STREAM_TIMESTAMP_CONFIG, "timestampFieldNotPresent");
     converter = new DataConverter(new ElasticsearchSinkConnectorConfig(props));
     Schema preProcessedSchema = converter.preProcessSchema(schema);
@@ -405,7 +405,7 @@ public class DataConverterTest {
 
   @Test
   public void testInjectPayloadTimestampIfDataStreamAndNoTimestampMapSet() {
-    setDataStream();
+    configureDataStream();
     converter = new DataConverter(new ElasticsearchSinkConnectorConfig(props));
     Schema preProcessedSchema = converter.preProcessSchema(schema);
     Struct struct = new Struct(preProcessedSchema).put("string", "myValue");
@@ -418,7 +418,7 @@ public class DataConverterTest {
 
   @Test
   public void testInjectPayloadTimestampEvenIfAlreadyExistsAndTimestampMapNotSet() {
-    setDataStream();
+    configureDataStream();
     converter = new DataConverter(new ElasticsearchSinkConnectorConfig(props));
     schema = SchemaBuilder
         .struct()
@@ -438,7 +438,7 @@ public class DataConverterTest {
   @Test
   public void testMapPayloadTimestampIfDataStreamSetAndOneTimestampMapSet() {
     String timestampFieldMap = "onefield";
-    setDataStream();
+    configureDataStream();
     props.put(ElasticsearchSinkConnectorConfig.DATA_STREAM_TIMESTAMP_CONFIG, timestampFieldMap);
     converter = new DataConverter(new ElasticsearchSinkConnectorConfig(props));
     schema = SchemaBuilder
@@ -459,7 +459,7 @@ public class DataConverterTest {
   @Test
   public void testMapPayloadTimestampByPriorityIfMultipleTimestampMapsSet() {
     String timestampFieldToUse = "two";
-    setDataStream();
+    configureDataStream();
     props.put(ElasticsearchSinkConnectorConfig.DATA_STREAM_TIMESTAMP_CONFIG, "one, two, field");
     converter = new DataConverter(new ElasticsearchSinkConnectorConfig(props));
     schema = SchemaBuilder
@@ -480,7 +480,7 @@ public class DataConverterTest {
 
   @Test
   public void testDoNotAddExternalVersioningIfDataStream() {
-    setDataStream();
+    configureDataStream();
     props.put(ElasticsearchSinkConnectorConfig.IGNORE_KEY_CONFIG, "false");
     converter = new DataConverter(new ElasticsearchSinkConnectorConfig(props));
     Schema preProcessedSchema = converter.preProcessSchema(schema);
@@ -492,7 +492,7 @@ public class DataConverterTest {
     assertEquals(VersionType.INTERNAL, actualRecord.versionType());
   }
 
-  private void setDataStream() {
+  private void configureDataStream() {
     props.put(ElasticsearchSinkConnectorConfig.DATA_STREAM_TYPE_CONFIG, "logs");
     props.put(ElasticsearchSinkConnectorConfig.DATA_STREAM_DATASET_CONFIG, "dataset");
   }

--- a/src/test/java/io/confluent/connect/elasticsearch/DataConverterTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/DataConverterTest.java
@@ -379,7 +379,7 @@ public class DataConverterTest {
   }
 
   @Test
-  public void testInjectPayloadTimestampIfDataStreamAndTimestampMapNotSet() {
+  public void testInjectPayloadTimestampIfDataStreamAndNoTimestampMap() {
     setDataStream();
     converter = new DataConverter(new ElasticsearchSinkConnectorConfig(props));
     Schema preProcessedSchema = converter.preProcessSchema(schema);
@@ -392,9 +392,9 @@ public class DataConverterTest {
   }
 
   @Test
-  public void testDoNotInjectMissingPayloadTimestampIfDataStreamAndTimestampMapSet() {
+  public void testDoNotInjectMissingPayloadTimestampIfDataStreamAndTimestampMapNotFound() {
     setDataStream();
-    props.put(ElasticsearchSinkConnectorConfig.DATA_STREAM_TIMESTAMP_CONFIG, "@timestamp");
+    props.put(ElasticsearchSinkConnectorConfig.DATA_STREAM_TIMESTAMP_CONFIG, "timestampFieldNotPresent");
     converter = new DataConverter(new ElasticsearchSinkConnectorConfig(props));
     Schema preProcessedSchema = converter.preProcessSchema(schema);
     Struct struct = new Struct(preProcessedSchema).put("string", "myValue");
@@ -436,7 +436,7 @@ public class DataConverterTest {
   }
 
   @Test
-  public void testMapPayloadTimestampIfGivenOneMap() {
+  public void testMapPayloadTimestampIfDataStreamSetAndOneTimestampMap() {
     String timestampFieldMap = "onefield";
     setDataStream();
     props.put(ElasticsearchSinkConnectorConfig.DATA_STREAM_TIMESTAMP_CONFIG, timestampFieldMap);
@@ -457,7 +457,7 @@ public class DataConverterTest {
   }
 
   @Test
-  public void testMapPayloadTimestampByPriorityIfGivenMultipleMap() {
+  public void testMapPayloadTimestampByPriorityIfMultipleTimestampMap() {
     String timestampFieldToUse = "two";
     setDataStream();
     props.put(ElasticsearchSinkConnectorConfig.DATA_STREAM_TIMESTAMP_CONFIG, "one, two, field");

--- a/src/test/java/io/confluent/connect/elasticsearch/DataConverterTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/DataConverterTest.java
@@ -380,8 +380,7 @@ public class DataConverterTest {
 
   @Test
   public void testInjectPayloadTimestampIfDataStreamAndTimestampMapNotSet() {
-    props.put(ElasticsearchSinkConnectorConfig.DATA_STREAM_TYPE_CONFIG, "logs");
-    props.put(ElasticsearchSinkConnectorConfig.DATA_STREAM_DATASET_CONFIG, "dataset");
+    setDataStream();
     converter = new DataConverter(new ElasticsearchSinkConnectorConfig(props));
     Schema preProcessedSchema = converter.preProcessSchema(schema);
     Struct struct = new Struct(preProcessedSchema).put("string", "myValue");
@@ -394,8 +393,7 @@ public class DataConverterTest {
 
   @Test
   public void testDoNotInjectMissingPayloadTimestampIfDataStreamAndTimestampMapSet() {
-    props.put(ElasticsearchSinkConnectorConfig.DATA_STREAM_TYPE_CONFIG, "logs");
-    props.put(ElasticsearchSinkConnectorConfig.DATA_STREAM_DATASET_CONFIG, "dataset");
+    setDataStream();
     props.put(ElasticsearchSinkConnectorConfig.DATA_STREAM_TIMESTAMP_CONFIG, "@timestamp");
     converter = new DataConverter(new ElasticsearchSinkConnectorConfig(props));
     Schema preProcessedSchema = converter.preProcessSchema(schema);
@@ -420,8 +418,7 @@ public class DataConverterTest {
 
   @Test
   public void testInjectPayloadTimestampIfAlreadyExistsAndTimestampMapNotSet() {
-    props.put(ElasticsearchSinkConnectorConfig.DATA_STREAM_TYPE_CONFIG, "logs");
-    props.put(ElasticsearchSinkConnectorConfig.DATA_STREAM_DATASET_CONFIG, "dataset");
+    setDataStream();
     converter = new DataConverter(new ElasticsearchSinkConnectorConfig(props));
     schema = SchemaBuilder
         .struct()
@@ -441,8 +438,7 @@ public class DataConverterTest {
   @Test
   public void testMapPayloadTimestampIfGivenOneMap() {
     String timestampFieldMap = "onefield";
-    props.put(ElasticsearchSinkConnectorConfig.DATA_STREAM_TYPE_CONFIG, "logs");
-    props.put(ElasticsearchSinkConnectorConfig.DATA_STREAM_DATASET_CONFIG, "dataset");
+    setDataStream();
     props.put(ElasticsearchSinkConnectorConfig.DATA_STREAM_TIMESTAMP_CONFIG, timestampFieldMap);
     converter = new DataConverter(new ElasticsearchSinkConnectorConfig(props));
     schema = SchemaBuilder
@@ -463,8 +459,7 @@ public class DataConverterTest {
   @Test
   public void testMapPayloadTimestampByPriorityIfGivenMultipleMap() {
     String timestampFieldToUse = "two";
-    props.put(ElasticsearchSinkConnectorConfig.DATA_STREAM_TYPE_CONFIG, "logs");
-    props.put(ElasticsearchSinkConnectorConfig.DATA_STREAM_DATASET_CONFIG, "dataset");
+    setDataStream();
     props.put(ElasticsearchSinkConnectorConfig.DATA_STREAM_TIMESTAMP_CONFIG, "one, two, field");
     converter = new DataConverter(new ElasticsearchSinkConnectorConfig(props));
     schema = SchemaBuilder
@@ -485,8 +480,7 @@ public class DataConverterTest {
 
   @Test
   public void testDoNotAddExternalVersioningIfDataStream() {
-    props.put(ElasticsearchSinkConnectorConfig.DATA_STREAM_TYPE_CONFIG, "logs");
-    props.put(ElasticsearchSinkConnectorConfig.DATA_STREAM_DATASET_CONFIG, "dataset");
+    setDataStream();
     props.put(ElasticsearchSinkConnectorConfig.IGNORE_KEY_CONFIG, "false");
     converter = new DataConverter(new ElasticsearchSinkConnectorConfig(props));
     Schema preProcessedSchema = converter.preProcessSchema(schema);
@@ -496,5 +490,10 @@ public class DataConverterTest {
     IndexRequest actualRecord = (IndexRequest) converter.convertRecord(sinkRecord, index);
 
     assertEquals(VersionType.INTERNAL, actualRecord.versionType());
+  }
+
+  private void setDataStream() {
+    props.put(ElasticsearchSinkConnectorConfig.DATA_STREAM_TYPE_CONFIG, "logs");
+    props.put(ElasticsearchSinkConnectorConfig.DATA_STREAM_DATASET_CONFIG, "dataset");
   }
 }

--- a/src/test/java/io/confluent/connect/elasticsearch/ValidatorTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ValidatorTest.java
@@ -410,7 +410,7 @@ public class ValidatorTest {
 
   @Test
   public void testTimestampMappingDataStreamSet() {
-    setDataStream();
+    configureDataStream();
     props.put(DATA_STREAM_TIMESTAMP_CONFIG, "one, two, fields");
     validator = new Validator(props, () -> mockClient);
 
@@ -431,7 +431,7 @@ public class ValidatorTest {
 
   @Test
   public void testIncompatibleVersionDataStreamSet() {
-    setDataStream();
+    configureDataStream();
     validator = new Validator(props, () -> mockClient);
     when(mockInfoResponse.getVersion().getNumber()).thenReturn("7.8.1");
 
@@ -468,7 +468,7 @@ public class ValidatorTest {
 
   @Test
   public void testCompatibleVersionDataStreamSet() {
-    setDataStream();
+    configureDataStream();
     validator = new Validator(props, () -> mockClient);
     String[] compatibleESVersions = {"7.9.0", "7.9.3", "7.9.3-amd64", "7.10.0", "7.10.2", "7.11.0", "7.11.2", "7.12.0", "7.12.1",
         "8.0.0", "10.10.10", "10.1.10", "10.1.1", "8.10.10"};
@@ -493,7 +493,7 @@ public class ValidatorTest {
     config.configValues().forEach(c -> assertTrue(c.errorMessages().isEmpty()));
   }
 
-  private void setDataStream() {
+  private void configureDataStream() {
     props.put(DATA_STREAM_DATASET_CONFIG, "a_valid_dataset");
     props.put(DATA_STREAM_TYPE_CONFIG, "logs");
   }

--- a/src/test/java/io/confluent/connect/elasticsearch/ValidatorTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ValidatorTest.java
@@ -409,7 +409,7 @@ public class ValidatorTest {
   }
 
   @Test
-  public void testTimestampMappingsDataStreamSet() {
+  public void testTimestampMappingDataStreamSet() {
     setDataStream();
     props.put(DATA_STREAM_TIMESTAMP_CONFIG, "one, two, fields");
     validator = new Validator(props, () -> mockClient);
@@ -420,7 +420,7 @@ public class ValidatorTest {
   }
 
   @Test
-  public void testTimestampMappingsDataStreamNotSet() {
+  public void testTimestampMappingDataStreamNotSet() {
     props.put(DATA_STREAM_TIMESTAMP_CONFIG, "one, two, fields");
     validator = new Validator(props, () -> mockClient);
 


### PR DESCRIPTION
## Problem
The `@timestamp` field is needed in messages to send them to data stream. Currently, the `@timestamp` field is auto-injected with the record timestamp if it is missing. However, users may not want to inject the `@timestamp` field and may instead want those records to fail. Injecting the `@timestamp` field should only happen if records have no timestamp value at all. Otherwise, having both sets of values (the original `@timestamp` value and the injected value) would be confusing. 

Additionally, field names with special characters are not allowed in [Avro](http://avro.apache.org/docs/current/spec.html#names) and Protobuf, meaning users with Avro or Protobuf schemas can not have an `@timestamp` field. 

## Solution
Since both of these issues relate to the `@timestamp` field, we can add one connector configuration to resolve both of them. 
With this configuration, users set the field names they would like to map to the `@timestamp` field. If multiple are provided, the first match based on the order they were listed is used. If they choose to leave this config unset, all the records would have the `@timestamp` field be the record timestamp.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
Releasing as part of the data streams feature.
<!-- Are you backporting or merging to master? -->
Not backporting or merging to master.
<!-- If you are reverting or rolling back, is it safe? --> 
Not reverting or rolling back.
