### PR TITLE
CCMSG-961: Elasticsearch Datastreams

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,4 +4,5 @@ common {
   upstreamProjects = 'confluentinc/common'
   pintMerge = true
   downStreamValidate = false
+  nodeLabel = 'docker-oraclejdk8'
 }

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -9,7 +9,7 @@
     <!-- switch statements on types exceed maximum complexity -->
     <suppress
       checks="(CyclomaticComplexity)"
-      files="Mapping.java"
+      files="(Mapping|DataConverter).java"
     />
 
     <suppress

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     </scm>
 
     <properties>
-        <es.version>7.0.1</es.version>
+        <es.version>7.9.3</es.version>
         <hamcrest.version>1.3</hamcrest.version>
         <mockito.version>2.28.2</mockito.version>
         <gson.version>2.8.6</gson.version>

--- a/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
@@ -30,6 +30,7 @@ import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.storage.Converter;
 import org.elasticsearch.action.DocWriteRequest;
+import org.elasticsearch.action.DocWriteRequest.OpType;
 import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.update.UpdateRequest;
@@ -162,8 +163,9 @@ public class DataConverter {
             .upsert(payload, XContentType.JSON)
             .retryOnConflict(Math.min(config.maxInFlightRequests(), 5));
       case INSERT:
+        OpType opType = config.isDataStream() ? OpType.CREATE : OpType.INDEX;
         return maybeAddExternalVersioning(
-            new IndexRequest(index).id(id).source(payload, XContentType.JSON),
+            new IndexRequest(index).id(id).source(payload, XContentType.JSON).opType(opType),
             record
         );
       default:

--- a/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
@@ -205,7 +205,14 @@ public class DataConverter {
     }
     try {
       JsonNode jsonNode = objectMapper.readTree(payload);
-      if (jsonNode.get(TIMESTAMP_FIELD) == null) {
+      if (!config.dataStreamTimestampField().isEmpty()) {
+        for (String timestampField : config.dataStreamTimestampField()) {
+          if (jsonNode.has(timestampField)) {
+            ((ObjectNode) jsonNode).put(TIMESTAMP_FIELD, jsonNode.get(timestampField).asText());
+            return objectMapper.writeValueAsString(jsonNode);
+          }
+        }
+      } else {
         ((ObjectNode) jsonNode).put(TIMESTAMP_FIELD, timestamp);
         return objectMapper.writeValueAsString(jsonNode);
       }

--- a/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
@@ -219,7 +219,7 @@ public class DataConverter {
       DocWriteRequest<?> request,
       SinkRecord record
   ) {
-    if (!config.shouldIgnoreKey(record.topic())) {
+    if (!config.isDataStream() && !config.shouldIgnoreKey(record.topic())) {
       request.versionType(VersionType.EXTERNAL);
       request.version(record.kafkaOffset());
     }

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -18,9 +18,9 @@ package io.confluent.connect.elasticsearch;
 import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.apache.kafka.common.config.AbstractConfig;
@@ -29,10 +29,6 @@ import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.ConfigDef.Validator;
 import org.apache.kafka.common.config.ConfigDef.Width;
-
-import java.util.Map;
-import java.util.stream.Collectors;
-
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.types.Password;
 import org.elasticsearch.common.unit.ByteSizeValue;
@@ -447,18 +443,14 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
             DATA_STREAM_TYPE_CONFIG,
             Type.STRING,
             DATA_STREAM_TYPE_DEFAULT.name(),
-            ConfigDef.CaseInsensitiveValidString.in(
-                Arrays.stream(DataStreamType.values())
-                    .map(DataStreamType::name)
-                    .collect(Collectors.toList())
-                    .toArray(new String[DataStreamType.values().length])
-            ),
+            new EnumRecommender<>(DataStreamType.class),
             Importance.LOW,
             DATA_STREAM_TYPE_DOC,
             CONNECTOR_GROUP,
             ++order,
             Width.SHORT,
-            DATA_STREAM_TYPE_DISPLAY
+            DATA_STREAM_TYPE_DISPLAY,
+            new EnumRecommender<>(DataStreamType.class)
         ).define(
             MAX_IN_FLIGHT_REQUESTS_CONFIG,
             Type.INT,

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -304,13 +304,13 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   // Data stream configs
   public static final String DATA_STREAM_DATASET_CONFIG = "data.stream.dataset";
   private static final String DATA_STREAM_DATASET_DOC =
-      "Generic name describing data ingested and its structure to be written to a data stream. Can"
-          + " be any arbitrary string that is no longer than 100 characters, is in all lowercase, "
+      "Generic name describing data ingested and its structure to be written to a data stream. Can "
+          + "be any arbitrary string that is no longer than 100 characters, is in all lowercase, "
           + "and does not contain spaces or any of these special characters ``/\\*\"<>|,#:-``. "
           + "Otherwise, no value indicates the connector will write to regular indices instead. "
           + "If set, this configuration will be used alongside ``data.stream.type`` to "
           + "construct the data stream name in the form of {``data.stream.type``"
-          + "}-{" + DATA_STREAM_DATASET_CONFIG + "}-{topic}.";
+          + "}-{``" + DATA_STREAM_DATASET_CONFIG + "``}-{topic}.";
   private static final String DATA_STREAM_DATASET_DISPLAY = "Data Stream Dataset";
   private static final String DATA_STREAM_DATASET_DEFAULT = "";
 
@@ -319,8 +319,8 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
       "Generic type describing the data to be written to data stream. "
           + "The default is %s which indicates the connector will write "
           + "to regular indices instead. If set, this configuration will "
-          + "be used alongside %s to construct the data stream name in the form of"
-          + "{%s}-{%s}-{topic}.",
+          + "be used alongside %s to construct the data stream name in the form of "
+          + "{``%s``}-{``%s``}-{topic}.",
       DataStreamType.NONE.name(),
       DATA_STREAM_DATASET_CONFIG,
       DATA_STREAM_TYPE_CONFIG,
@@ -332,12 +332,12 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   public static final String DATA_STREAM_TIMESTAMP_CONFIG = "data.stream.timestamp.field";
   private static final String DATA_STREAM_TIMESTAMP_DOC = String.format(
       "The Kafka record field to use as the timestamp for the ``@timestamp`` field in documents "
-          + "sent to a data stream.\n All documents sent to a data stream needs an``@timestamp`` "
-          + " field with values of type ``date`` or ``data_nanos``. Otherwise, the document "
-          + " will not be sent. If multiple fields are provided, the first field listed that "
-          + "also appears in the record will be used. If this configuration is left empty,"
-          + " all of the documents will use the Kafka record timestamp as the ``@timestamp`` field "
-          + "value. Note that ``@timestamp``still  needs to be explicitly listed if records "
+          + "sent to a data stream.\n All documents sent to a data stream needs an ``@timestamp`` "
+          + "field with values of type ``date`` or ``data_nanos``. Otherwise, the document "
+          + "will not be sent. If multiple fields are provided, the first field listed that "
+          + "also appears in the record will be used. If this configuration is left empty, "
+          + "all of the documents will use the Kafka record timestamp as the ``@timestamp`` field "
+          + "value. Note that ``@timestamp`` still needs to be explicitly listed if records "
           + "already contain this field. This configuration can only be set if ``%s`` and ``%s`` "
           + "are set.",
       DATA_STREAM_TYPE_CONFIG,

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -18,6 +18,7 @@ package io.confluent.connect.elasticsearch;
 import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -30,6 +31,8 @@ import org.apache.kafka.common.config.ConfigDef.Validator;
 import org.apache.kafka.common.config.ConfigDef.Width;
 
 import java.util.Map;
+import java.util.stream.Collectors;
+
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.types.Password;
 import org.elasticsearch.common.unit.ByteSizeValue;

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -999,19 +999,19 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
 
       if (dataset.length() > 100) {
         throw new ConfigException(
-            name, value, "The specified dataset must be no longer than 100 characters."
+            name, dataset, "The specified dataset must be no longer than 100 characters."
         );
       }
 
-      if (!value.equals(dataset.toLowerCase())) {
+      if (!dataset.equals(dataset.toLowerCase())) {
         throw new ConfigException(
-            name, value, "The specified dataset must be in all lowercase."
+            name, dataset, "The specified dataset must be in all lowercase."
         );
       }
 
       if (dataset.matches(".*[\\\\\\/\\*\\?\\\"<>| ,#\\-:]+.*")) {
         throw new ConfigException(
-            name, value,
+            name, dataset,
             "The specified dataset must not contain any spaces or "
             + "invalid characters \\/*?\"<>|,#-:"
         );

--- a/src/main/java/io/confluent/connect/elasticsearch/Validator.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/Validator.java
@@ -41,6 +41,7 @@ import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfi
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_URL_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_USERNAME_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_DATASET_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_TIMESTAMP_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_TYPE_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DataStreamType;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.FLUSH_TIMEOUT_MS_CONFIG;
@@ -160,6 +161,17 @@ public class Validator {
           DATA_STREAM_DATASET_CONFIG
       );
       addErrorMessage(BEHAVIOR_ON_NULL_VALUES_CONFIG, errorMessage);
+    }
+
+    if (!config.isDataStream() && !config.dataStreamTimestampField().isEmpty()) {
+      String errorMessage = String.format(
+          "Mapping a field to the '@timestamp' field is only necessary for data streams. "
+              + "%s must not be set if %s and %s are not set.",
+          DATA_STREAM_TIMESTAMP_CONFIG,
+          DATA_STREAM_TYPE_CONFIG,
+          DATA_STREAM_DATASET_CONFIG
+      );
+      addErrorMessage(DATA_STREAM_TIMESTAMP_CONFIG, errorMessage);
     }
   }
 

--- a/src/main/java/io/confluent/connect/elasticsearch/Validator.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/Validator.java
@@ -34,9 +34,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BATCH_SIZE_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BehaviorOnNullValues;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_PASSWORD_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_URL_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_USERNAME_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_DATASET_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_TYPE_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DataStreamType;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.FLUSH_TIMEOUT_MS_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_KEY_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_KEY_TOPICS_CONFIG;
@@ -53,6 +58,8 @@ import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfi
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SECURITY_PROTOCOL_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SSL_CONFIG_PREFIX;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.KERBEROS_PRINCIPAL_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.WRITE_METHOD_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.WriteMethod;
 
 public class Validator {
 
@@ -88,6 +95,7 @@ public class Validator {
 
     try (RestHighLevelClient client = clientFactory.client()) {
       validateCredentials();
+      validateDataStreamConfigs();
       validateIgnoreConfigs();
       validateKerberos();
       validateLingerMs();
@@ -114,6 +122,40 @@ public class Validator {
       );
       addErrorMessage(CONNECTION_USERNAME_CONFIG, errorMessage);
       addErrorMessage(CONNECTION_PASSWORD_CONFIG, errorMessage);
+    }
+  }
+
+  private void validateDataStreamConfigs() {
+    if (config.dataStreamType() == DataStreamType.NONE ^ config.dataStreamDataset().isEmpty()) {
+      String errorMessage = String.format(
+          "Either both or neither '%s' and '%s' must be set.",
+          DATA_STREAM_DATASET_CONFIG,
+          DATA_STREAM_TYPE_CONFIG
+      );
+      addErrorMessage(DATA_STREAM_TYPE_CONFIG, errorMessage);
+      addErrorMessage(DATA_STREAM_DATASET_CONFIG, errorMessage);
+    }
+
+    if (config.isDataStream() && config.writeMethod() == WriteMethod.UPSERT) {
+      String errorMessage = String.format(
+          "Upserts are not supported with data streams. %s must not be %s if %s and %s are set.",
+          WRITE_METHOD_CONFIG,
+          WriteMethod.UPSERT,
+          DATA_STREAM_TYPE_CONFIG,
+          DATA_STREAM_DATASET_CONFIG
+      );
+      addErrorMessage(WRITE_METHOD_CONFIG, errorMessage);
+    }
+
+    if (config.isDataStream() && config.behaviorOnNullValues() == BehaviorOnNullValues.DELETE) {
+      String errorMessage = String.format(
+          "Deletes are not supported with data streams. %s must not be %s if %s and %s are set.",
+          BEHAVIOR_ON_NULL_VALUES_CONFIG,
+          BehaviorOnNullValues.DELETE,
+          DATA_STREAM_TYPE_CONFIG,
+          DATA_STREAM_DATASET_CONFIG
+      );
+      addErrorMessage(BEHAVIOR_ON_NULL_VALUES_CONFIG, errorMessage);
     }
   }
 

--- a/src/main/java/io/confluent/connect/elasticsearch/Validator.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/Validator.java
@@ -110,6 +110,8 @@ public class Validator {
       if (!hasErrors()) {
         // no point if previous configs are invalid
         validateConnection(client);
+      }
+      if (!hasErrors()) {
         validateVersion(client);
       }
     } catch (IOException e) {

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
@@ -74,6 +74,8 @@ import org.junit.Test;
 public class ElasticsearchClientTest {
 
   private static final String TOPIC = "index";
+  private static final String DATA_STREAM_TYPE = "logs";
+  private static final String DATA_STREAM_DATASET = "dataset";
 
   private static ElasticsearchContainer container;
 
@@ -155,12 +157,10 @@ public class ElasticsearchClientTest {
 
   @Test
   public void testCreateExistingDataStream() throws Exception {
-    String type = "logs";
-    String dataset = "dataset";
-    index = String.format("%s-%s-%s", type, dataset, TOPIC); // data stream name
-    props.put(DATA_STREAM_TYPE_CONFIG, type);
-    props.put(DATA_STREAM_DATASET_CONFIG, dataset);
+    props.put(DATA_STREAM_TYPE_CONFIG, DATA_STREAM_TYPE);
+    props.put(DATA_STREAM_DATASET_CONFIG, DATA_STREAM_DATASET);
     config = new ElasticsearchSinkConnectorConfig(props);
+    index = createIndexName(TOPIC);
     ElasticsearchClient client = new ElasticsearchClient(config, null);
 
     assertTrue(client.createIndexOrDataStream(index));
@@ -171,12 +171,10 @@ public class ElasticsearchClientTest {
 
   @Test
   public void testCreateNewDataStream() throws Exception {
-    String type = "logs";
-    String dataset = "dataset";
-    index = String.format("%s-%s-%s", type, dataset, TOPIC); // data stream name
-    props.put(DATA_STREAM_TYPE_CONFIG, type);
-    props.put(DATA_STREAM_DATASET_CONFIG, dataset);
+    props.put(DATA_STREAM_TYPE_CONFIG, DATA_STREAM_TYPE);
+    props.put(DATA_STREAM_DATASET_CONFIG, DATA_STREAM_DATASET);
     config = new ElasticsearchSinkConnectorConfig(props);
+    index = createIndexName(TOPIC);
     ElasticsearchClient client = new ElasticsearchClient(config, null);
 
     assertTrue(client.createIndexOrDataStream(index));
@@ -601,6 +599,12 @@ public class ElasticsearchClientTest {
     container.start();
   }
 
+  private String createIndexName(String name) {
+    return config.isDataStream()
+        ? String.format("%s-%s-%s", DATA_STREAM_TYPE, DATA_STREAM_DATASET, name)
+        : name;
+  }
+
   private static Schema schema() {
     return SchemaBuilder
         .struct()
@@ -638,6 +642,6 @@ public class ElasticsearchClientTest {
   }
 
   private void writeRecord(SinkRecord record, ElasticsearchClient client) {
-    client.index(record, converter.convertRecord(record, record.topic()));
+    client.index(record, converter.convertRecord(record, createIndexName(record.topic())));
   }
 }

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
@@ -21,12 +21,13 @@ import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfi
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_PASSWORD_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_URL_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_USERNAME_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_DATASET_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_TYPE_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_KEY_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.LINGER_MS_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.MAX_BUFFERED_RECORDS_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.MAX_IN_FLIGHT_REQUESTS_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.MAX_RETRIES_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.READ_TIMEOUT_MS_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.RETRY_BACKOFF_MS_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SECURITY_PROTOCOL_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SSL_CONFIG_PREFIX;
@@ -72,7 +73,7 @@ import org.junit.Test;
 
 public class ElasticsearchClientTest {
 
-  private static final String INDEX = "index";
+  private static final String TOPIC = "index";
 
   private static ElasticsearchContainer container;
 
@@ -80,6 +81,7 @@ public class ElasticsearchClientTest {
   private ElasticsearchHelperClient helperClient;
   private ElasticsearchSinkConnectorConfig config;
   private Map<String, String> props;
+  private String index;
 
   @BeforeClass
   public static void setupBeforeAll() {
@@ -94,6 +96,7 @@ public class ElasticsearchClientTest {
 
   @Before
   public void setup() {
+    index = TOPIC;
     props = ElasticsearchSinkConnectorConfigTest.addNecessaryProps(new HashMap<>());
     props.put(CONNECTION_URL_CONFIG, container.getConnectionUrl());
     props.put(IGNORE_KEY_CONFIG, "true");
@@ -105,8 +108,8 @@ public class ElasticsearchClientTest {
 
   @After
   public void cleanup() throws IOException {
-    if (helperClient != null && helperClient.indexExists(INDEX)){
-      helperClient.deleteIndex(INDEX);
+    if (helperClient != null && helperClient.indexExists(index)){
+      helperClient.deleteIndex(index, config.isDataStream());
     }
   }
 
@@ -143,42 +146,73 @@ public class ElasticsearchClientTest {
   @Test
   public void testCreateIndex() throws IOException {
     ElasticsearchClient client = new ElasticsearchClient(config, null);
-    assertFalse(helperClient.indexExists(INDEX));
+    assertFalse(helperClient.indexExists(index));
 
-    client.createIndex(INDEX);
-    assertTrue(helperClient.indexExists(INDEX));
+    client.createIndexOrDataStream(index);
+    assertTrue(helperClient.indexExists(index));
+    client.close();
+  }
+
+  @Test
+  public void testCreateExistingDataStream() throws Exception {
+    String type = "logs";
+    String dataset = "dataset";
+    index = String.format("%s-%s-%s", type, dataset, TOPIC); // data stream name
+    props.put(DATA_STREAM_TYPE_CONFIG, type);
+    props.put(DATA_STREAM_DATASET_CONFIG, dataset);
+    config = new ElasticsearchSinkConnectorConfig(props);
+    ElasticsearchClient client = new ElasticsearchClient(config, null);
+
+    assertTrue(client.createIndexOrDataStream(index));
+    assertTrue(helperClient.indexExists(index));
+    assertFalse(client.createIndexOrDataStream(index));
+    client.close();
+  }
+
+  @Test
+  public void testCreateNewDataStream() throws Exception {
+    String type = "logs";
+    String dataset = "dataset";
+    index = String.format("%s-%s-%s", type, dataset, TOPIC); // data stream name
+    props.put(DATA_STREAM_TYPE_CONFIG, type);
+    props.put(DATA_STREAM_DATASET_CONFIG, dataset);
+    config = new ElasticsearchSinkConnectorConfig(props);
+    ElasticsearchClient client = new ElasticsearchClient(config, null);
+
+    assertTrue(client.createIndexOrDataStream(index));
+    assertTrue(helperClient.indexExists(index));
     client.close();
   }
 
   @Test
   public void testDoesNotCreateAlreadyExistingIndex() throws IOException {
     ElasticsearchClient client = new ElasticsearchClient(config, null);
-    assertFalse(helperClient.indexExists(INDEX));
+    assertFalse(helperClient.indexExists(index));
 
-    assertTrue(client.createIndex(INDEX));
-    assertTrue(helperClient.indexExists(INDEX));
+    assertTrue(client.createIndexOrDataStream(index));
+    assertTrue(helperClient.indexExists(index));
 
-    assertFalse(client.createIndex(INDEX));
-    assertTrue(helperClient.indexExists(INDEX));
+    assertFalse(client.createIndexOrDataStream(index));
+    assertTrue(helperClient.indexExists(index));
     client.close();
   }
 
   @Test
   public void testIndexExists() throws IOException {
     ElasticsearchClient client = new ElasticsearchClient(config, null);
-    assertFalse(helperClient.indexExists(INDEX));
+    assertFalse(helperClient.indexExists(index));
 
-    assertTrue(client.createIndex(INDEX));
-    assertTrue(client.indexExists(INDEX));
+    assertTrue(client.createIndexOrDataStream(index));
+    assertTrue(client.indexExists(index));
     client.close();
   }
 
   @Test
   public void testIndexDoesNotExist() throws IOException {
     ElasticsearchClient client = new ElasticsearchClient(config, null);
-    assertFalse(helperClient.indexExists(INDEX));
+    assertFalse(helperClient.indexExists(index));
 
-    assertFalse(client.indexExists(INDEX));
+    assertFalse(client.indexExists(index));
     client.close();
   }
 
@@ -186,13 +220,13 @@ public class ElasticsearchClientTest {
   @SuppressWarnings("unchecked")
   public void testCreateMapping() throws IOException {
     ElasticsearchClient client = new ElasticsearchClient(config, null);
-    client.createIndex(INDEX);
+    client.createIndexOrDataStream(index);
 
-    client.createMapping(INDEX, schema());
+    client.createMapping(index, schema());
 
-    assertTrue(client.hasMapping(INDEX));
+    assertTrue(client.hasMapping(index));
 
-    Map<String, Object> mapping = helperClient.getMapping(INDEX).sourceAsMap();
+    Map<String, Object> mapping = helperClient.getMapping(index).sourceAsMap();
     assertTrue(mapping.containsKey("properties"));
     Map<String, Object> props = (Map<String, Object>) mapping.get("properties");
     assertTrue(props.containsKey("offset"));
@@ -209,20 +243,20 @@ public class ElasticsearchClientTest {
   @Test
   public void testHasMapping() {
     ElasticsearchClient client = new ElasticsearchClient(config, null);
-    client.createIndex(INDEX);
+    client.createIndexOrDataStream(index);
 
-    client.createMapping(INDEX, schema());
+    client.createMapping(index, schema());
 
-    assertTrue(client.hasMapping(INDEX));
+    assertTrue(client.hasMapping(index));
     client.close();
   }
 
   @Test
   public void testDoesNotHaveMapping() {
     ElasticsearchClient client = new ElasticsearchClient(config, null);
-    client.createIndex(INDEX);
+    client.createIndexOrDataStream(index);
 
-    assertFalse(client.hasMapping(INDEX));
+    assertFalse(client.hasMapping(index));
     client.close();
   }
 
@@ -232,14 +266,14 @@ public class ElasticsearchClientTest {
     props.put(MAX_BUFFERED_RECORDS_CONFIG, "1");
     config = new ElasticsearchSinkConnectorConfig(props);
     ElasticsearchClient client = new ElasticsearchClient(config, null);
-    client.createIndex(INDEX);
+    client.createIndexOrDataStream(index);
 
     writeRecord(sinkRecord(0), client);
     assertEquals(1, client.numRecords.get());
     client.flush();
 
     waitUntilRecordsInES(1);
-    assertEquals(1, helperClient.getDocCount(INDEX));
+    assertEquals(1, helperClient.getDocCount(index));
     assertEquals(0, client.numRecords.get());
 
     writeRecord(sinkRecord(1), client);
@@ -258,26 +292,26 @@ public class ElasticsearchClientTest {
     props.put(LINGER_MS_CONFIG, String.valueOf(TimeUnit.DAYS.toMillis(1)));
     config = new ElasticsearchSinkConnectorConfig(props);
     ElasticsearchClient client = new ElasticsearchClient(config, null);
-    client.createIndex(INDEX);
+    client.createIndexOrDataStream(index);
 
     writeRecord(sinkRecord(0), client);
-    assertEquals(0, helperClient.getDocCount(INDEX)); // should be empty before flush
+    assertEquals(0, helperClient.getDocCount(index)); // should be empty before flush
     client.flush();
     waitUntilRecordsInES(1);
-    assertEquals(1, helperClient.getDocCount(INDEX));
+    assertEquals(1, helperClient.getDocCount(index));
     client.close();
   }
 
   @Test
   public void testIndexRecord() throws Exception {
     ElasticsearchClient client = new ElasticsearchClient(config, null);
-    client.createIndex(INDEX);
+    client.createIndexOrDataStream(index);
 
     writeRecord(sinkRecord(0), client);
     client.flush();
 
     waitUntilRecordsInES(1);
-    assertEquals(1, helperClient.getDocCount(INDEX));
+    assertEquals(1, helperClient.getDocCount(index));
     client.close();
   }
 
@@ -288,7 +322,7 @@ public class ElasticsearchClientTest {
     config = new ElasticsearchSinkConnectorConfig(props);
     converter = new DataConverter(config);
     ElasticsearchClient client = new ElasticsearchClient(config, null);
-    client.createIndex(INDEX);
+    client.createIndexOrDataStream(index);
 
     writeRecord(sinkRecord("key0", 0), client);
     writeRecord(sinkRecord("key1", 1), client);
@@ -297,7 +331,7 @@ public class ElasticsearchClientTest {
     waitUntilRecordsInES(2);
 
     // delete 1
-    SinkRecord deleteRecord = new SinkRecord(INDEX, 0, Schema.STRING_SCHEMA, "key0", null, null, 3);
+    SinkRecord deleteRecord = new SinkRecord(TOPIC, 0, Schema.STRING_SCHEMA, "key0", null, null, 3);
     writeRecord(deleteRecord, client);
 
     waitUntilRecordsInES(1);
@@ -311,7 +345,7 @@ public class ElasticsearchClientTest {
     config = new ElasticsearchSinkConnectorConfig(props);
     converter = new DataConverter(config);
     ElasticsearchClient client = new ElasticsearchClient(config, null);
-    client.createIndex(INDEX);
+    client.createIndexOrDataStream(index);
 
     writeRecord(sinkRecord("key0", 0), client);
     writeRecord(sinkRecord("key1", 1), client);
@@ -328,9 +362,9 @@ public class ElasticsearchClientTest {
         .build();
 
     Struct value = new Struct(schema).put("offset", 2);
-    SinkRecord upsertRecord = new SinkRecord(INDEX, 0, Schema.STRING_SCHEMA, "key0", schema, value, 2);
+    SinkRecord upsertRecord = new SinkRecord(index, 0, Schema.STRING_SCHEMA, "key0", schema, value, 2);
     Struct value2 = new Struct(schema).put("offset", 3);
-    SinkRecord upsertRecord2 = new SinkRecord(INDEX, 0, Schema.STRING_SCHEMA, "key0", schema, value2, 3);
+    SinkRecord upsertRecord2 = new SinkRecord(index, 0, Schema.STRING_SCHEMA, "key0", schema, value2, 3);
 
 
     // upsert 2, write another
@@ -340,7 +374,7 @@ public class ElasticsearchClientTest {
     client.flush();
 
     waitUntilRecordsInES(3);
-    for (SearchHit hit : helperClient.search(INDEX)) {
+    for (SearchHit hit : helperClient.search(index)) {
       if (hit.getId().equals("key0")) {
         assertEquals(3, hit.getSourceAsMap().get("offset"));
         assertEquals(0, hit.getSourceAsMap().get("another"));
@@ -357,8 +391,8 @@ public class ElasticsearchClientTest {
     converter = new DataConverter(config);
 
     ElasticsearchClient client = new ElasticsearchClient(config, null);
-    client.createIndex(INDEX);
-    client.createMapping(INDEX, schema());
+    client.createIndexOrDataStream(index);
+    client.createMapping(index, schema());
 
     Schema schema = SchemaBuilder
         .struct()
@@ -366,7 +400,7 @@ public class ElasticsearchClientTest {
         .field("not_mapped_field", SchemaBuilder.int32().defaultValue(0).build())
         .build();
     Struct value = new Struct(schema).put("not_mapped_field", 420);
-    SinkRecord badRecord = new SinkRecord(INDEX, 0, Schema.STRING_SCHEMA, "key", schema, value, 0);
+    SinkRecord badRecord = new SinkRecord(TOPIC, 0, Schema.STRING_SCHEMA, "key", schema, value, 0);
 
     writeRecord(sinkRecord(0), client);
     client.flush();
@@ -378,15 +412,15 @@ public class ElasticsearchClientTest {
     client.flush();
 
     waitUntilRecordsInES(2);
-    assertEquals(2, helperClient.getDocCount(INDEX));
+    assertEquals(2, helperClient.getDocCount(index));
     client.close();
   }
 
   @Test(expected = ConnectException.class)
   public void testFailOnBadRecord() throws Exception {
     ElasticsearchClient client = new ElasticsearchClient(config, null);
-    client.createIndex(INDEX);
-    client.createMapping(INDEX, schema());
+    client.createIndexOrDataStream(index);
+    client.createMapping(index, schema());
 
     Schema schema = SchemaBuilder
         .struct()
@@ -394,7 +428,7 @@ public class ElasticsearchClientTest {
         .field("offset", SchemaBuilder.bool().defaultValue(false).build())
         .build();
     Struct value = new Struct(schema).put("offset", false);
-    SinkRecord badRecord = new SinkRecord(INDEX, 0, Schema.STRING_SCHEMA, "key", schema, value, 0);
+    SinkRecord badRecord = new SinkRecord(TOPIC, 0, Schema.STRING_SCHEMA, "key", schema, value, 0);
 
     writeRecord(sinkRecord(0), client);
     client.flush();
@@ -428,7 +462,7 @@ public class ElasticsearchClientTest {
 
     // mock bulk processor to throw errors
     ElasticsearchClient client = new ElasticsearchClient(config, null);
-    client.createIndex(INDEX);
+    client.createIndexOrDataStream(index);
 
     // bring down ES service
     NetworkErrorContainer delay = new NetworkErrorContainer(container.getContainerName());
@@ -456,8 +490,8 @@ public class ElasticsearchClientTest {
 
     ErrantRecordReporter reporter = mock(ErrantRecordReporter.class);
     ElasticsearchClient client = new ElasticsearchClient(config, reporter);
-    client.createIndex(INDEX);
-    client.createMapping(INDEX, schema());
+    client.createIndexOrDataStream(index);
+    client.createMapping(index, schema());
 
     Schema schema = SchemaBuilder
         .struct()
@@ -465,7 +499,7 @@ public class ElasticsearchClientTest {
         .field("offset", SchemaBuilder.bool().defaultValue(false).build())
         .build();
     Struct value = new Struct(schema).put("offset", false);
-    SinkRecord badRecord = new SinkRecord(INDEX, 0, Schema.STRING_SCHEMA, "key0", schema, value, 1);
+    SinkRecord badRecord = new SinkRecord(index, 0, Schema.STRING_SCHEMA, "key0", schema, value, 1);
 
     writeRecord(sinkRecord("key0", 0), client);
     client.flush();
@@ -489,7 +523,7 @@ public class ElasticsearchClientTest {
   public void testReporterNotCalled() throws Exception {
     ErrantRecordReporter reporter = mock(ErrantRecordReporter.class);
     ElasticsearchClient client = new ElasticsearchClient(config, reporter);
-    client.createIndex(INDEX);
+    client.createIndexOrDataStream(index);
 
     writeRecord(sinkRecord(0), client);
     writeRecord(sinkRecord(1), client);
@@ -497,7 +531,7 @@ public class ElasticsearchClientTest {
     client.flush();
 
     waitUntilRecordsInES(3);
-    assertEquals(3, helperClient.getDocCount(INDEX));
+    assertEquals(3, helperClient.getDocCount(index));
     verify(reporter, never()).report(eq(sinkRecord(0)), any(Throwable.class));
     client.close();
   }
@@ -514,7 +548,7 @@ public class ElasticsearchClientTest {
     ElasticsearchClient client = new ElasticsearchClient(config, reporter);
     ElasticsearchClient client2 = new ElasticsearchClient(config, reporter2);
 
-    client.createIndex(INDEX);
+    client.createIndexOrDataStream(index);
 
     writeRecord(sinkRecord(0), client);
     writeRecord(sinkRecord(1), client2);
@@ -524,7 +558,7 @@ public class ElasticsearchClientTest {
     writeRecord(sinkRecord(5), client2);
 
     waitUntilRecordsInES(1);
-    assertEquals(1, helperClient.getDocCount(INDEX));
+    assertEquals(1, helperClient.getDocCount(index));
     verify(reporter, never()).report(any(SinkRecord.class), any(Throwable.class));
     verify(reporter2, never()).report(any(SinkRecord.class), any(Throwable.class));
     client.close();
@@ -552,13 +586,13 @@ public class ElasticsearchClientTest {
 
     ElasticsearchClient client = new ElasticsearchClient(config, null);
     helperClient = new ElasticsearchHelperClient(address, config);
-    client.createIndex(INDEX);
+    client.createIndexOrDataStream(index);
 
     writeRecord(sinkRecord(0), client);
     client.flush();
 
     waitUntilRecordsInES(1);
-    assertEquals(1, helperClient.getDocCount(INDEX));
+    assertEquals(1, helperClient.getDocCount(index));
     client.close();
     helperClient = null;
 
@@ -582,14 +616,14 @@ public class ElasticsearchClientTest {
 
   private static SinkRecord sinkRecord(String key, int offset) {
     Struct value = new Struct(schema()).put("offset", offset).put("another", offset + 1);
-    return new SinkRecord(INDEX, 0, Schema.STRING_SCHEMA, key, schema(), value, offset);
+    return new SinkRecord(TOPIC, 0, Schema.STRING_SCHEMA, key, schema(), value, offset);
   }
 
   private void waitUntilRecordsInES(int expectedRecords) throws InterruptedException {
     TestUtils.waitForCondition(
         () -> {
           try {
-            return helperClient.getDocCount(INDEX) == expectedRecords;
+            return helperClient.getDocCount(index) == expectedRecords;
           } catch (ElasticsearchStatusException e) {
             if (e.getMessage().contains("index_not_found_exception")) {
               return false;

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
@@ -2,6 +2,8 @@ package io.confluent.connect.elasticsearch;
 
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_TIMEOUT_MS_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_URL_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_DATASET_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_TYPE_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.KERBEROS_KEYTAB_PATH_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.PROXY_HOST_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.PROXY_PASSWORD_CONFIG;
@@ -52,6 +54,48 @@ public class ElasticsearchSinkConnectorConfigTest {
 
     assertEquals(config.readTimeoutMs(), 10000);
     assertEquals(config.connectionTimeoutMs(), 15000);
+  }
+
+  @Test
+  public void shouldAllowValidChractersDataStreamDataset() {
+    props.put(DATA_STREAM_DATASET_CONFIG, "a_valid.dataset123");
+    new ElasticsearchSinkConnectorConfig(props);
+  }
+
+  @Test
+  public void shouldAllowValidDataStreamType() {
+    props.put(DATA_STREAM_TYPE_CONFIG, "metrics");
+    new ElasticsearchSinkConnectorConfig(props);
+  }
+
+  @Test
+  public void shouldAllowValidDataStreamTypeCaseInsensitive() {
+    props.put(DATA_STREAM_TYPE_CONFIG, "mEtRICS");
+    new ElasticsearchSinkConnectorConfig(props);
+  }
+
+  @Test(expected = ConfigException.class)
+  public void shouldNotAllowInvalidCaseDataStreamDataset() {
+    props.put(DATA_STREAM_DATASET_CONFIG, "AN_INVALID.dataset123");
+    new ElasticsearchSinkConnectorConfig(props);
+  }
+
+  @Test(expected = ConfigException.class)
+  public void shouldNotAllowInvalidCharactersDataStreamDataset() {
+    props.put(DATA_STREAM_DATASET_CONFIG, "not-valid?");
+    new ElasticsearchSinkConnectorConfig(props);
+  }
+
+  @Test(expected = ConfigException.class)
+  public void shouldNotAllowInvalidDataStreamType() {
+    props.put(DATA_STREAM_TYPE_CONFIG, "notLogOrMetrics");
+    new ElasticsearchSinkConnectorConfig(props);
+  }
+
+  @Test(expected = ConfigException.class)
+  public void shouldNotAllowLongDataStreamDataset() {
+    props.put(DATA_STREAM_DATASET_CONFIG, String.format("%d%100d", 1, 1));
+    new ElasticsearchSinkConnectorConfig(props);
   }
 
   @Test(expected = ConfigException.class)

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorTest.java
@@ -8,7 +8,6 @@ import static org.junit.Assert.assertTrue;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.kafka.common.config.Config;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkConnector;
 import org.junit.Before;

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
@@ -34,6 +34,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BehaviorOnNullValues;
+import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -410,7 +411,9 @@ public class ElasticsearchSinkTaskTest {
       nullKey ? null : "key",
       schema,
       nullValue ? null : struct,
-      offset
+      offset,
+      System.currentTimeMillis(),
+      TimestampType.CREATE_TIME
   );
 }
 }

--- a/src/test/java/io/confluent/connect/elasticsearch/ValidatorTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ValidatorTest.java
@@ -17,9 +17,12 @@
 package io.confluent.connect.elasticsearch;
 
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BATCH_SIZE_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_PASSWORD_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_URL_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_USERNAME_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_DATASET_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_TYPE_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.FLUSH_TIMEOUT_MS_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_KEY_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_KEY_TOPICS_CONFIG;
@@ -35,6 +38,7 @@ import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfi
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SECURITY_PROTOCOL_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SSL_CONFIG_PREFIX;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.KERBEROS_PRINCIPAL_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.WRITE_METHOD_CONFIG;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -71,10 +75,26 @@ public class ValidatorTest {
   }
 
   @Test
+  public void testValidDefaultConfig() {
+    validator = new Validator(props, () -> mockClient);
+    Config result = validator.validate();
+    assertNoErrors(result);
+  }
+
+  @Test
   public void testInvalidIndividualConfigs() {
     validator = new Validator(new HashMap<>(), () -> mockClient);
     Config result = validator.validate();
     assertHasErrorMessage(result, CONNECTION_URL_CONFIG, "Missing required configuration");
+  }
+
+  @Test
+  public void testValidUpsertDeleteOnDefaultConfig() {
+    props.put(BEHAVIOR_ON_NULL_VALUES_CONFIG, "delete");
+    props.put(WRITE_METHOD_CONFIG, "upsert");
+    validator = new Validator(props, () -> mockClient);
+    Config result = validator.validate();
+    assertNoErrors(result);
   }
 
   @Test
@@ -109,6 +129,32 @@ public class ValidatorTest {
 
     result = validator.validate();
     assertNoErrors(result);
+  }
+
+  @Test
+  public void testInvalidMissingOneDataStreamConfig() {
+    props.put(DATA_STREAM_DATASET_CONFIG, "a_valid_dataset");
+    validator = new Validator(props, () -> mockClient);
+    Config result = validator.validate();
+    assertHasErrorMessage(result, DATA_STREAM_DATASET_CONFIG, "must be set");
+    assertHasErrorMessage(result, DATA_STREAM_TYPE_CONFIG, "must be set");
+  }
+
+  @Test
+  public void testInvalidUpsertDeleteOnValidDataStreamConfigs() {
+    props.put(DATA_STREAM_DATASET_CONFIG, "a_valid_dataset");
+    props.put(DATA_STREAM_TYPE_CONFIG, "logs");
+    validator = new Validator(props, () -> mockClient);
+    Config result = validator.validate();
+    assertNoErrors(result);
+
+    props.put(BEHAVIOR_ON_NULL_VALUES_CONFIG, "delete");
+    props.put(WRITE_METHOD_CONFIG, "upsert");
+    validator = new Validator(props, () -> mockClient);
+
+    result = validator.validate();
+    assertHasErrorMessage(result, BEHAVIOR_ON_NULL_VALUES_CONFIG, "must not be");
+    assertHasErrorMessage(result, WRITE_METHOD_CONFIG, "must not be");
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/elasticsearch/ValidatorTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ValidatorTest.java
@@ -22,6 +22,7 @@ import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfi
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_URL_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_USERNAME_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_DATASET_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_TIMESTAMP_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_TYPE_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.FLUSH_TIMEOUT_MS_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_KEY_CONFIG;
@@ -408,9 +409,29 @@ public class ValidatorTest {
   }
 
   @Test
+  public void testTimestampMappingDataStreamSet() {
+    configureDataStream();
+    props.put(DATA_STREAM_TIMESTAMP_CONFIG, "one, two, fields");
+    validator = new Validator(props, () -> mockClient);
+
+    Config result = validator.validate();
+
+    assertNoErrors(result);
+  }
+
+  @Test
+  public void testTimestampMappingDataStreamNotSet() {
+    props.put(DATA_STREAM_TIMESTAMP_CONFIG, "one, two, fields");
+    validator = new Validator(props, () -> mockClient);
+
+    Config result = validator.validate();
+
+    assertHasErrorMessage(result, DATA_STREAM_TIMESTAMP_CONFIG, "only necessary for data streams");
+  }
+
+  @Test
   public void testIncompatibleVersionDataStreamSet() {
-    props.put(DATA_STREAM_DATASET_CONFIG, "a_valid_dataset");
-    props.put(DATA_STREAM_TYPE_CONFIG, "logs");
+    configureDataStream();
     validator = new Validator(props, () -> mockClient);
     when(mockInfoResponse.getVersion().getNumber()).thenReturn("7.8.1");
 
@@ -447,8 +468,7 @@ public class ValidatorTest {
 
   @Test
   public void testCompatibleVersionDataStreamSet() {
-    props.put(DATA_STREAM_DATASET_CONFIG, "a_valid_dataset");
-    props.put(DATA_STREAM_TYPE_CONFIG, "logs");
+    configureDataStream();
     validator = new Validator(props, () -> mockClient);
     String[] compatibleESVersions = {"7.9.0", "7.9.3", "7.9.3-amd64", "7.10.0", "7.10.2", "7.11.0", "7.11.2", "7.12.0", "7.12.1",
         "8.0.0", "10.10.10", "10.1.10", "10.1.1", "8.10.10"};
@@ -471,5 +491,10 @@ public class ValidatorTest {
 
   private static void assertNoErrors(Config config) {
     config.configValues().forEach(c -> assertTrue(c.errorMessages().isEmpty()));
+  }
+
+  private void configureDataStream() {
+    props.put(DATA_STREAM_DATASET_CONFIG, "a_valid_dataset");
+    props.put(DATA_STREAM_TYPE_CONFIG, "logs");
   }
 }

--- a/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchContainer.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchContainer.java
@@ -51,7 +51,7 @@ public class ElasticsearchContainer
   /**
    * Default Elasticsearch version.
    */
-  public static final String DEFAULT_ES_VERSION = "7.0.1";
+  public static final String DEFAULT_ES_VERSION = "7.9.3";
 
   /**
    * Default Elasticsearch port.

--- a/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchContainer.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchContainer.java
@@ -101,6 +101,15 @@ public class ElasticsearchContainer
     return new ElasticsearchContainer(imageName + ":" + version);
   }
 
+  public static ElasticsearchContainer withESVersion(String ESVersion) {
+    String imageName = getSystemOrEnvProperty(
+        "elasticsearch.image",
+        "ELASTICSEARCH_IMAGE",
+        DEFAULT_DOCKER_IMAGE_NAME
+    );
+    return new ElasticsearchContainer(imageName + ":" + ESVersion);
+  }
+
   private static final String KEY_PASSWORD = "asdfasdf";
   public static final String ELASTIC_PASSWORD = "elastic";
   private static final String KEYSTORE_PASSWORD = KEY_PASSWORD;

--- a/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchHelperClient.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchHelperClient.java
@@ -69,7 +69,7 @@ public class ElasticsearchHelperClient {
     List<DataStream> datastreams = client.indices()
         .getDataStream(request, RequestOptions.DEFAULT)
         .getDataStreams();
-    return datastreams.get(0);
+    return datastreams.size() == 0 ? null : datastreams.get(0);
   }
 
   public long getDocCount(String index) throws IOException {

--- a/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchHelperClient.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchHelperClient.java
@@ -18,6 +18,8 @@ package io.confluent.connect.elasticsearch.helper;
 import io.confluent.connect.elasticsearch.ConfigCallbackHandler;
 import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig;
 import java.io.IOException;
+import java.util.List;
+
 import org.apache.http.HttpHost;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.search.SearchRequest;
@@ -25,10 +27,13 @@ import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.client.core.CountRequest;
+import org.elasticsearch.client.indices.DataStream;
+import org.elasticsearch.client.indices.DeleteDataStreamRequest;
+import org.elasticsearch.client.indices.GetDataStreamRequest;
 import org.elasticsearch.client.indices.GetIndexRequest;
 import org.elasticsearch.client.indices.GetMappingsRequest;
 import org.elasticsearch.client.indices.GetMappingsResponse;
-import org.elasticsearch.cluster.metadata.MappingMetaData;
+import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.search.SearchHits;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,9 +54,22 @@ public class ElasticsearchHelperClient {
     );
   }
 
-  public void deleteIndex(String index) throws IOException {
+  public void deleteIndex(String index, boolean isDataStream) throws IOException {
+    if (isDataStream) {
+      DeleteDataStreamRequest request = new DeleteDataStreamRequest(index);
+      client.indices().deleteDataStream(request, RequestOptions.DEFAULT);
+      return;
+    }
     DeleteIndexRequest request = new DeleteIndexRequest(index);
     client.indices().delete(request, RequestOptions.DEFAULT);
+  }
+
+  public DataStream getDataStream(String dataStream) throws IOException {
+    GetDataStreamRequest request = new GetDataStreamRequest(dataStream);
+    List<DataStream> datastreams = client.indices()
+        .getDataStream(request, RequestOptions.DEFAULT)
+        .getDataStreams();
+    return datastreams.get(0);
   }
 
   public long getDocCount(String index) throws IOException {
@@ -59,7 +77,7 @@ public class ElasticsearchHelperClient {
     return client.count(request, RequestOptions.DEFAULT).getCount();
   }
 
-  public MappingMetaData getMapping(String index) throws IOException {
+  public MappingMetadata getMapping(String index) throws IOException {
     GetMappingsRequest request = new GetMappingsRequest().indices(index);
     GetMappingsResponse response = client.indices().getMapping(request, RequestOptions.DEFAULT);
     return response.mappings().get(index);

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorBaseIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorBaseIT.java
@@ -18,6 +18,8 @@ package io.confluent.connect.elasticsearch.integration;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_URL_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_KEY_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_SCHEMA_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_DATASET_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_TYPE_CONFIG;
 import static org.apache.kafka.connect.json.JsonConverterConfig.SCHEMAS_ENABLE_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLASS_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG;
@@ -119,6 +121,21 @@ public class ElasticsearchConnectorBaseIT extends BaseConnectorIT {
     verifySearchResults(NUM_RECORDS);
   }
 
+  protected void setDataStream() {
+    isDataStream = true;
+    props.put(DATA_STREAM_TYPE_CONFIG, "logs");
+    props.put(DATA_STREAM_DATASET_CONFIG, "dataset");
+    index = "logs-dataset-" + TOPIC;
+  }
+
+  protected void setupFromContainer() {
+    String address = container.getConnectionUrl();
+    props.put(CONNECTION_URL_CONFIG, address);
+    helperClient = new ElasticsearchHelperClient(
+        props.get(CONNECTION_URL_CONFIG),
+        new ElasticsearchSinkConnectorConfig(props)
+    );
+  }
 
   protected void verifySearchResults(int numRecords) throws Exception {
     waitForRecords(numRecords);

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorIT.java
@@ -17,6 +17,8 @@ package io.confluent.connect.elasticsearch.integration;
 
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BATCH_SIZE_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_DATASET_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_TYPE_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_KEY_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.LINGER_MS_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BULK_SIZE_BYTES_CONFIG;
@@ -100,6 +102,18 @@ public class ElasticsearchConnectorIT extends ElasticsearchConnectorBaseIT {
   @Test
   public void testHappyPath() throws Exception {
     runSimpleTest(props);
+  }
+
+  @Test
+  public void testHappyPathDataStream() throws Exception {
+    isDataStream = true;
+    props.put(DATA_STREAM_TYPE_CONFIG, "logs");
+    props.put(DATA_STREAM_DATASET_CONFIG, "dataset");
+    index = "logs-dataset-" + TOPIC;
+
+    runSimpleTest(props);
+
+    assertEquals(index, helperClient.getDataStream(index).getName());
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorIT.java
@@ -17,8 +17,6 @@ package io.confluent.connect.elasticsearch.integration;
 
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BATCH_SIZE_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_DATASET_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_TYPE_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_KEY_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.LINGER_MS_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BULK_SIZE_BYTES_CONFIG;
@@ -106,10 +104,7 @@ public class ElasticsearchConnectorIT extends ElasticsearchConnectorBaseIT {
 
   @Test
   public void testHappyPathDataStream() throws Exception {
-    isDataStream = true;
-    props.put(DATA_STREAM_TYPE_CONFIG, "logs");
-    props.put(DATA_STREAM_DATASET_CONFIG, "dataset");
-    index = "logs-dataset-" + TOPIC;
+    setDataStream();
 
     runSimpleTest(props);
 
@@ -170,5 +165,20 @@ public class ElasticsearchConnectorIT extends ElasticsearchConnectorBaseIT {
         assertEquals(0, docNum);
       }
     }
+  }
+
+  @Test
+  public void testBackwardsCompatibilityDataStream() throws Exception {
+    container.close();
+    container = ElasticsearchContainer.withESVersion("7.0.1");
+    container.start();
+    setupFromContainer();
+
+    runSimpleTest(props);
+
+    helperClient = null;
+    container.close();
+    container = ElasticsearchContainer.fromSystemProperties();
+    container.start();
   }
 }


### PR DESCRIPTION
## Problem

Elasticsearch recently release a new feature called Data Streams. 

## Solution
This PR allows the connector to alternatively write to a data stream and is the accumulation of many smaller PRs that have been approved over time.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
Releasing on-premise and on-cloud.
<!-- Are you backporting or merging to master? -->
Yes, merging into master.
<!-- If you are reverting or rolling back, is it safe? --> 
Not reverting or rolling back.