### PR TITLE
Fix breaking builds by pinning snakeyaml to 1.28

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
         <commons.codec.version>1.15</commons.codec.version>
+        <snakeyaml.version>1.28</snakeyaml.version>
     </properties>
 
     <repositories>
@@ -181,6 +182,11 @@
             <artifactId>elasticsearch</artifactId>
             <version>${test.containers.version}</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>${snakeyaml.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## Problem
snakeyaml dependency was missing causing build failures

## Solution
Pin snakeyaml to 1.28

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
