### PR TITLE
Add logging for retries

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/RetryUtil.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/RetryUtil.java
@@ -160,6 +160,7 @@ public class RetryUtil {
         );
         return function.call();
       } catch (IOException e) {
+        log.debug("Failed to {} due to {}. Retrying attempt ({}/{})", description, e, attempt, maxAttempts);
         if (attempt >= maxAttempts) {
           throw new ConnectException("Failed to " + description, e);
         }

--- a/src/main/java/io/confluent/connect/elasticsearch/RetryUtil.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/RetryUtil.java
@@ -161,7 +161,8 @@ public class RetryUtil {
         return function.call();
       } catch (IOException e) {
         if (attempt >= maxAttempts) {
-          log.error("Failed to {} due to {} after total of {} attempt(s)", description, e.getCause(), maxAttempts, e);
+          log.error("Failed to {} due to {} after total of {} attempt(s)",
+              description, e.getCause(), maxAttempts, e.getMessage());
           throw new ConnectException("Failed to " + description, e);
         }
         // Otherwise it is retriable and we should retry

--- a/src/main/java/io/confluent/connect/elasticsearch/RetryUtil.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/RetryUtil.java
@@ -160,7 +160,7 @@ public class RetryUtil {
         );
         return function.call();
       } catch (IOException e) {
-        log.debug("Failed to {} due to {}. Retrying attempt ({}/{})", description, e, attempt, maxAttempts);
+        log.debug("Failed to {} due to {}. Retrying attempt ({}/{})", description, e.getCause(), attempt, maxAttempts);
         if (attempt >= maxAttempts) {
           throw new ConnectException("Failed to " + description, e);
         }

--- a/src/main/java/io/confluent/connect/elasticsearch/RetryUtil.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/RetryUtil.java
@@ -160,13 +160,14 @@ public class RetryUtil {
         );
         return function.call();
       } catch (IOException e) {
-        log.warn("Failed to {} due to {}. Retrying attempt ({}/{})", description, e.getCause(), attempt, maxAttempts);
         if (attempt >= maxAttempts) {
+          log.error("Failed to {} due to {} after total of {} attempt(s)", description, e.getCause(), maxAttempts, e);
           throw new ConnectException("Failed to " + description, e);
         }
-
         // Otherwise it is retriable and we should retry
         long backoff = computeRandomRetryWaitTimeInMillis(attempt, initialBackoff);
+        log.warn("Failed to {} due to {}. Retrying attempt ({}/{}) after backoff of {} ms",
+            description, e.getCause(), attempt, maxAttempts, backoff);
         clock.sleep(backoff);
       }
     }

--- a/src/main/java/io/confluent/connect/elasticsearch/RetryUtil.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/RetryUtil.java
@@ -160,7 +160,7 @@ public class RetryUtil {
         );
         return function.call();
       } catch (IOException e) {
-        log.debug("Failed to {} due to {}. Retrying attempt ({}/{})", description, e.getCause(), attempt, maxAttempts);
+        log.warn("Failed to {} due to {}. Retrying attempt ({}/{})", description, e.getCause(), attempt, maxAttempts);
         if (attempt >= maxAttempts) {
           throw new ConnectException("Failed to " + description, e);
         }


### PR DESCRIPTION
## Problem
When we retry failed requests, we don't log the cause of the failure until we exhaust the retries. If the consumer leaves the group before we exhaust the retries, we will never see the cause of the error.

## Solution
Log every retry attempt with the exception

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
