### PR TITLE
CCMSG-1137: Handle ElasticsearchStatusException in validateConnection.

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/Validator.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/Validator.java
@@ -269,7 +269,7 @@ public class Validator {
     String exceptionMessage = "";
     try {
       successful = client.ping(RequestOptions.DEFAULT);
-    } catch (IOException | RuntimeException e) {
+    } catch (Exception e) {
       successful = false;
       exceptionMessage = String.format("Error message: %s", e.getMessage());
     }

--- a/src/main/java/io/confluent/connect/elasticsearch/Validator.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/Validator.java
@@ -27,6 +27,7 @@ import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.ConfigValue;
 import org.apache.kafka.common.config.SslConfigs;
+import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
@@ -43,6 +44,7 @@ import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfi
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_SCHEMA_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_SCHEMA_TOPICS_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.KERBEROS_KEYTAB_PATH_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.KERBEROS_PRINCIPAL_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.LINGER_MS_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.MAX_BUFFERED_RECORDS_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.MAX_IN_FLIGHT_REQUESTS_CONFIG;
@@ -52,7 +54,6 @@ import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfi
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.PROXY_USERNAME_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SECURITY_PROTOCOL_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SSL_CONFIG_PREFIX;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.KERBEROS_PRINCIPAL_CONFIG;
 
 public class Validator {
 
@@ -269,11 +270,10 @@ public class Validator {
     String exceptionMessage = "";
     try {
       successful = client.ping(RequestOptions.DEFAULT);
-    } catch (IOException e) {
+    } catch (IOException | ElasticsearchStatusException e) {
       successful = false;
       exceptionMessage = String.format("Error message: %s", e.getMessage());
     }
-
     if (!successful) {
       String errorMessage = String.format(
           "Could not connect to Elasticsearch. %s",

--- a/src/main/java/io/confluent/connect/elasticsearch/Validator.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/Validator.java
@@ -270,7 +270,7 @@ public class Validator {
     String exceptionMessage = "";
     try {
       successful = client.ping(RequestOptions.DEFAULT);
-    } catch (IOException | ElasticsearchStatusException e) {
+    } catch (IOException | RuntimeException e) {
       successful = false;
       exceptionMessage = String.format("Error message: %s", e.getMessage());
     }

--- a/src/main/java/io/confluent/connect/elasticsearch/Validator.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/Validator.java
@@ -27,7 +27,6 @@ import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.ConfigValue;
 import org.apache.kafka.common.config.SslConfigs;
-import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;

--- a/src/test/java/io/confluent/connect/elasticsearch/ValidatorTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ValidatorTest.java
@@ -51,8 +51,10 @@ import java.util.Map;
 import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigValue;
 import org.apache.kafka.common.config.SslConfigs;
+import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.rest.RestStatus;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -92,6 +94,14 @@ public class ValidatorTest {
     result = validator.validate();
     assertHasErrorMessage(result, CONNECTION_USERNAME_CONFIG, "must be set");
     assertHasErrorMessage(result, CONNECTION_PASSWORD_CONFIG, "must be set");
+  }
+
+  @Test
+  public void testClientThrowsElasticsearchStatusException() throws IOException {
+    when(mockClient.ping(any(RequestOptions.class))).thenThrow(new ElasticsearchStatusException("Deleted resource.", RestStatus.GONE));
+    validator = new Validator(props, () -> mockClient);
+    Config result = validator.validate();
+    assertHasErrorMessage(result, CONNECTION_URL_CONFIG, "Could not connect to Elasticsearch. Error message: Deleted resource.");
   }
 
   @Test


### PR DESCRIPTION
## Problem
We call `org.elasticsearch.client.RestHighLevelClient#ping` in `io.confluent.connect.elasticsearch.Validator#validateConnection` and we are catching `IOException` only.
But `RestHighLevelClient` can throw `ElasticsearchStatusException` as well, which results in the validate endpoint returning HTTP 500.


## Solution
Catch `ElasticsearchStatusException` to avoid throwing `500`.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
