### PR TITLE
CCMSG-1181: Updated validateConnection to not fail if user doesn't have monitor permission.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,29 @@ To build a development version you'll need a recent version of Kafka as well as 
 
 You can build kafka-connect-elasticsearch with Maven using the standard lifecycle phases.
 
+# Configuring
+## Creating an Elasticsearch user and assigning required privileges
+### Create an Elasticsearch role
+```
+curl -u elastic:elastic -X POST "localhost:9200/_security/role/es_sink_connector_role?pretty" -H 'Content-Type: application/json' -d'
+{
+  "indices": [
+    {
+      "names": [ "*" ],
+      "privileges": ["create_index", "read", "write", "view_index_metadata"]
+    }
+  ]
+}'
+```
+### Create an Elasticsearch user
+```
+curl -u elastic:elastic -X POST "localhost:9200/_security/user/es_sink_connector_user?pretty" -H 'Content-Type: application/json' -d'
+{
+  "password" : "seCret-secUre-PaSsW0rD",
+  "roles" : [ "es_sink_connector_role" ]
+}'
+```
+
 # Contribute
 
 - Source Code: https://github.com/confluentinc/kafka-connect-elasticsearch

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
@@ -26,12 +26,10 @@ import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfi
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.MAX_BUFFERED_RECORDS_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.MAX_IN_FLIGHT_REQUESTS_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.MAX_RETRIES_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.READ_TIMEOUT_MS_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.RETRY_BACKOFF_MS_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SECURITY_PROTOCOL_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SSL_CONFIG_PREFIX;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.WRITE_METHOD_CONFIG;
-import static io.confluent.connect.elasticsearch.helper.ElasticsearchContainer.ELASTIC_PASSWORD;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
@@ -73,6 +71,8 @@ import org.junit.Test;
 public class ElasticsearchClientTest {
 
   private static final String INDEX = "index";
+  private static final String ELASTIC_SUPERUSER_NAME = "elastic";
+  private static final String ELASTIC_SUPERUSER_PASSWORD = "elastic";
 
   private static ElasticsearchContainer container;
 
@@ -539,8 +539,8 @@ public class ElasticsearchClientTest {
 
     String address = container.getConnectionUrl().replace(container.getContainerIpAddress(), container.hostMachineIpAddress());
     props.put(CONNECTION_URL_CONFIG, address);
-    props.put(CONNECTION_USERNAME_CONFIG, "elastic");
-    props.put(CONNECTION_PASSWORD_CONFIG, ELASTIC_PASSWORD);
+    props.put(CONNECTION_USERNAME_CONFIG, ELASTIC_SUPERUSER_NAME);
+    props.put(CONNECTION_PASSWORD_CONFIG, ELASTIC_SUPERUSER_PASSWORD);
     props.put(SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SSL.name());
     props.put(SSL_CONFIG_PREFIX + SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, container.getKeystorePath());
     props.put(SSL_CONFIG_PREFIX + SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, container.getKeystorePassword());

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorBaseIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorBaseIT.java
@@ -15,6 +15,29 @@
 
 package io.confluent.connect.elasticsearch.integration;
 
+import org.apache.kafka.connect.json.JsonConverter;
+import org.apache.kafka.connect.storage.StringConverter;
+import org.apache.kafka.test.TestUtils;
+import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.client.security.user.User;
+import org.elasticsearch.client.security.user.privileges.IndicesPrivileges;
+import org.elasticsearch.client.security.user.privileges.Role;
+import org.elasticsearch.client.security.user.privileges.Role.Builder;
+import org.elasticsearch.search.SearchHit;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import io.confluent.connect.elasticsearch.ElasticsearchSinkConnector;
+import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig;
+import io.confluent.connect.elasticsearch.helper.ElasticsearchContainer;
+import io.confluent.connect.elasticsearch.helper.ElasticsearchHelperClient;
+
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_URL_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_KEY_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_SCHEMA_CONFIG;
@@ -28,28 +51,18 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import io.confluent.connect.elasticsearch.ElasticsearchSinkConnector;
-import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig;
-import io.confluent.connect.elasticsearch.helper.ElasticsearchContainer;
-import io.confluent.connect.elasticsearch.helper.ElasticsearchHelperClient;
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-import org.apache.kafka.connect.json.JsonConverter;
-import org.apache.kafka.connect.storage.StringConverter;
-import org.apache.kafka.test.TestUtils;
-import org.elasticsearch.ElasticsearchStatusException;
-import org.elasticsearch.search.SearchHit;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-
 public class ElasticsearchConnectorBaseIT extends BaseConnectorIT {
 
   protected static final int NUM_RECORDS = 5;
   protected static final int TASKS_MAX = 1;
   protected static final String CONNECTOR_NAME = "es-connector";
   protected static final String TOPIC = "test";
+
+  // User that has a minimal required and documented set of privileges
+  public static final String ELASTIC_MINIMAL_PRIVILEGES_NAME = "frank";
+  public static final String ELASTIC_MINIMAL_PRIVILEGES_PASSWORD = "WatermelonInEasterHay";
+
+  private static final String ES_SINK_CONNECTOR_ROLE = "es_sink_connector_role";
 
   protected static ElasticsearchContainer container;
 
@@ -67,10 +80,7 @@ public class ElasticsearchConnectorBaseIT extends BaseConnectorIT {
     connect.kafka().createTopic(TOPIC);
 
     props = createProps();
-    helperClient = new ElasticsearchHelperClient(
-        container.getConnectionUrl(),
-        new ElasticsearchSinkConnectorConfig(props)
-    );
+    helperClient = container.getHelperClient(props);
   }
 
   @After
@@ -154,5 +164,25 @@ public class ElasticsearchConnectorBaseIT extends BaseConnectorIT {
     for (int i  = start; i < start + numRecords; i++) {
       connect.kafka().produce(TOPIC, String.valueOf(i), String.format("{\"doc_num\":%d}", i));
     }
+  }
+
+  protected static Role getMinimalPrivilegesRole() {
+    IndicesPrivileges.Builder indicesPrivilegesBuilder = IndicesPrivileges.builder();
+    IndicesPrivileges indicesPrivileges = indicesPrivilegesBuilder
+        .indices("*")
+        .privileges("create_index", "read", "write", "view_index_metadata")
+        .build();
+    Builder builder = Role.builder();
+    Role role = builder.name(ES_SINK_CONNECTOR_ROLE).indicesPrivileges(indicesPrivileges).build();
+    return role;
+  }
+
+  protected static User getMinimalPrivilegesUser() {
+        return new User(ELASTIC_MINIMAL_PRIVILEGES_NAME,
+            Collections.singletonList(ES_SINK_CONNECTOR_ROLE));
+  }
+
+  protected static String getMinimalPrivilegesPassword() {
+    return ELASTIC_MINIMAL_PRIVILEGES_PASSWORD;
   }
 }

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorIT.java
@@ -17,6 +17,8 @@ package io.confluent.connect.elasticsearch.integration;
 
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BATCH_SIZE_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_PASSWORD_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_USERNAME_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_KEY_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.LINGER_MS_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.WRITE_METHOD_CONFIG;
@@ -26,14 +28,21 @@ import static org.junit.Assert.assertEquals;
 import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BehaviorOnNullValues;
 import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.WriteMethod;
 import io.confluent.connect.elasticsearch.helper.ElasticsearchContainer;
+
 import org.apache.kafka.connect.storage.StringConverter;
 import org.apache.kafka.test.IntegrationTest;
+import org.elasticsearch.client.security.user.User;
+import org.elasticsearch.client.security.user.privileges.Role;
 import org.elasticsearch.search.SearchHit;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 @Category(IntegrationTest.class)
 public class ElasticsearchConnectorIT extends ElasticsearchConnectorBaseIT {
@@ -44,8 +53,18 @@ public class ElasticsearchConnectorIT extends ElasticsearchConnectorBaseIT {
 
   @BeforeClass
   public static void setupBeforeAll() {
-    container = ElasticsearchContainer.fromSystemProperties();
+    Map<User, String> users = Collections.singletonMap(getMinimalPrivilegesUser(), getMinimalPrivilegesPassword());
+    List<Role> roles = Collections.singletonList(getMinimalPrivilegesRole());
+    container = ElasticsearchContainer.fromSystemProperties().withBasicAuth(users, roles);
     container.start();
+  }
+
+  @Override
+  protected Map<String, String> createProps() {
+    props = super.createProps();
+    props.put(CONNECTION_USERNAME_CONFIG, ELASTIC_MINIMAL_PRIVILEGES_NAME);
+    props.put(CONNECTION_PASSWORD_CONFIG, ELASTIC_MINIMAL_PRIVILEGES_PASSWORD);
+    return props;
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorKerberosIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorKerberosIT.java
@@ -3,9 +3,7 @@ package io.confluent.connect.elasticsearch.integration;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.KERBEROS_KEYTAB_PATH_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.KERBEROS_PRINCIPAL_CONFIG;
 
-import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig;
 import io.confluent.connect.elasticsearch.helper.ElasticsearchContainer;
-import io.confluent.connect.elasticsearch.helper.ElasticsearchHelperClient;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -48,10 +46,7 @@ public class ElasticsearchConnectorKerberosIT extends ElasticsearchConnectorBase
   @Test
   public void testKerberos() throws Exception {
     addKerberosConfigs(props);
-    helperClient = new ElasticsearchHelperClient(
-        container.getConnectionUrl(),
-        new ElasticsearchSinkConnectorConfig(props)
-    );
+    helperClient = container.getHelperClient(props);
     runSimpleTest(props);
   }
 

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorKerberosWithSslIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorKerberosWithSslIT.java
@@ -4,10 +4,8 @@ import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfi
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SECURITY_PROTOCOL_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SSL_CONFIG_PREFIX;
 
-import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig;
 import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SecurityProtocol;
 import io.confluent.connect.elasticsearch.helper.ElasticsearchContainer;
-import io.confluent.connect.elasticsearch.helper.ElasticsearchHelperClient;
 import org.apache.kafka.common.config.SslConfigs;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -49,10 +47,7 @@ public class ElasticsearchConnectorKerberosWithSslIT extends ElasticsearchConnec
     props.put(SSL_CONFIG_PREFIX + SslConfigs.SSL_KEY_PASSWORD_CONFIG, container.getKeyPassword());
     addKerberosConfigs(props);
 
-    helperClient = new ElasticsearchHelperClient(
-        address,
-        new ElasticsearchSinkConnectorConfig(props)
-    );
+    helperClient = container.getHelperClient(props);
 
     // Start connector
     runSimpleTest(props);

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorSslIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorSslIT.java
@@ -20,19 +20,26 @@ import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig;
 import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SecurityProtocol;
 import io.confluent.connect.elasticsearch.helper.ElasticsearchContainer;
 import io.confluent.connect.elasticsearch.helper.ElasticsearchHelperClient;
+
 import org.apache.kafka.common.config.SslConfigs;
+import org.elasticsearch.client.security.user.User;
+import org.elasticsearch.client.security.user.privileges.Role;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_PASSWORD_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_URL_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_USERNAME_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SECURITY_PROTOCOL_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SSL_CONFIG_PREFIX;
-import static io.confluent.connect.elasticsearch.helper.ElasticsearchContainer.ELASTIC_PASSWORD;
+
 
 @Category(IntegrationTest.class)
 public class ElasticsearchConnectorSslIT extends ElasticsearchConnectorBaseIT {
@@ -41,7 +48,10 @@ public class ElasticsearchConnectorSslIT extends ElasticsearchConnectorBaseIT {
 
   @BeforeClass
   public static void setupBeforeAll() {
-    container = ElasticsearchContainer.fromSystemProperties().withSslEnabled(true);
+    Map<User, String> users = Collections
+        .singletonMap(getMinimalPrivilegesUser(), getMinimalPrivilegesPassword());
+    List<Role> roles = Collections.singletonList(getMinimalPrivilegesRole());
+    container = ElasticsearchContainer.fromSystemProperties().withSslEnabled(true).withBasicAuth(users, roles);
     container.start();
   }
 
@@ -59,10 +69,7 @@ public class ElasticsearchConnectorSslIT extends ElasticsearchConnectorBaseIT {
     props.put(CONNECTION_URL_CONFIG, address);
     addSslProps();
 
-    helperClient = new ElasticsearchHelperClient(
-        address,
-        new ElasticsearchSinkConnectorConfig(props)
-    );
+    helperClient = container.getHelperClient(props);
 
     // Start connector
     runSimpleTest(props);
@@ -81,10 +88,7 @@ public class ElasticsearchConnectorSslIT extends ElasticsearchConnectorBaseIT {
     // disable hostname verification
     props.put(SSL_CONFIG_PREFIX + SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "");
 
-    helperClient = new ElasticsearchHelperClient(
-        address,
-        new ElasticsearchSinkConnectorConfig(props)
-    );
+    helperClient = container.getHelperClient(props);
 
     // Start connector
     runSimpleTest(props);
@@ -97,7 +101,7 @@ public class ElasticsearchConnectorSslIT extends ElasticsearchConnectorBaseIT {
     props.put(SSL_CONFIG_PREFIX + SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, container.getTruststorePath());
     props.put(SSL_CONFIG_PREFIX + SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, container.getTruststorePassword());
     props.put(SSL_CONFIG_PREFIX + SslConfigs.SSL_KEY_PASSWORD_CONFIG, container.getKeyPassword());
-    props.put(CONNECTION_USERNAME_CONFIG, "elastic");
-    props.put(CONNECTION_PASSWORD_CONFIG, ELASTIC_PASSWORD);
+    props.put(CONNECTION_USERNAME_CONFIG, ELASTIC_MINIMAL_PRIVILEGES_NAME);
+    props.put(CONNECTION_PASSWORD_CONFIG, ELASTIC_MINIMAL_PRIVILEGES_PASSWORD);
   }
 }

--- a/src/test/resources/basic/elasticsearch.yml
+++ b/src/test/resources/basic/elasticsearch.yml
@@ -1,0 +1,5 @@
+cluster.name: "docker-cluster"
+network.host: 0.0.0.0
+
+xpack.license.self_generated.type: trial
+xpack.security.enabled: true

--- a/src/test/resources/basic/instances.yml
+++ b/src/test/resources/basic/instances.yml
@@ -1,0 +1,18 @@
+instances:
+  - name: elasticsearch
+    dns:
+      - elasticsearch
+    ip:
+      - ipAddress
+  - name: kibana
+    dns:
+      - kibana
+      - localhost
+    ip:
+      - ipAddress
+  - name: logstash
+    dns:
+      - logstash
+      - localhost
+    ip:
+      - ipAddress

--- a/src/test/resources/both/start-elasticsearch.sh
+++ b/src/test/resources/both/start-elasticsearch.sh
@@ -84,5 +84,5 @@ if [[ -n "$ELASTIC_PASSWORD" ]]; then
 fi
 
 echo
-echo "Starting Elasticsearch with SSL enabled ..."
+echo "Starting Elasticsearch with SSL and Kerberos enabled ..."
 /usr/local/bin/docker-entrypoint.sh


### PR DESCRIPTION
## Problem
After we introduced `io.confluent.connect.elasticsearch.Validator#validateConnection` method, the validation started to fail with the following exception:
```
Caused by: ElasticsearchStatusException[method [HEAD], host [https://XXX:1234], URI [/], status line [HTTP/1.1 403 Forbidden]]; nested: ResponseException[method [HEAD], host [https://XXX:1234], URI [/], status line [HTTP/1.1 403 Forbidden]];
	at org.elasticsearch.client.RestHighLevelClient.parseResponseException(RestHighLevelClient.java:1680)
	at org.elasticsearch.client.RestHighLevelClient.internalPerformRequest(RestHighLevelClient.java:1446)
	at org.elasticsearch.client.RestHighLevelClient.performRequest(RestHighLevelClient.java:1403)
	at org.elasticsearch.client.RestHighLevelClient.ping(RestHighLevelClient.java:677)
	at io.confluent.connect.elasticsearch.Validator.validateConnection(Validator.java:271)
	at io.confluent.connect.elasticsearch.Validator.validate(Validator.java:100)
	at io.confluent.connect.elasticsearch.ElasticsearchSinkConnector.validate(ElasticsearchSinkConnector.java:80)
	at org.apache.kafka.connect.runtime.AbstractHerder.validateConnectorConfig(AbstractHerder.java:406)
	at org.apache.kafka.connect.runtime.AbstractHerder.lambda$validateConnectorConfig$2(AbstractHerder.java:354)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
	... 1 more
Caused by: org.elasticsearch.client.ResponseException: method [HEAD], host [XXX:1234], URI [/], status line [HTTP/1.1 403 Forbidden]
	at org.elasticsearch.client.RestClient.convertResponse(RestClient.java:260)
	at org.elasticsearch.client.RestClient.performRequest(RestClient.java:238)
	at org.elasticsearch.client.RestClient.performRequest(RestClient.java:212)
	at org.elasticsearch.client.RestHighLevelClient.internalPerformRequest(RestHighLevelClient.java:1433)
	... 12 more
```  
which can be a false-negative, since a cluster is actually running, but a user is not authorized to call this endpoint.

## Solution

- Treat `403` status as a cluster, that we can establish a connection to.
- Do not use an Elastic superuser in integration tests(ES super user is still used in `ElasticsearchClientTest`, which not an integration test).
- Update docs(https://github.com/confluentinc/docs-kafka-connect-elasticsearch/pull/45) and README to have an accurate list of required Elasticsearch privileges.


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
