### PR TITLE
CCMSG-947: Add validation to ES connector to check if it's connecting to a compatible ES sink

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/Validator.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/Validator.java
@@ -332,8 +332,10 @@ public class Validator {
     MainResponse response;
     try {
       response = client.info(RequestOptions.DEFAULT);
-    } catch (IOException e) {
-      // Same error messages as from validating the connection.
+    } catch (IOException | ElasticsearchStatusException e) {
+      // Same error messages as from validating the connection for IOException.
+      // Insufficient privileges to validate the version number if caught
+      // ElasticsearchStatusException.
       return;
     }
     String esVersionNumber = response.getVersion().getNumber();

--- a/src/main/java/io/confluent/connect/elasticsearch/Validator.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/Validator.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.ConfigValue;
 import org.apache.kafka.common.config.SslConfigs;
+import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.client.core.MainResponse;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestClient;

--- a/src/main/java/io/confluent/connect/elasticsearch/Validator.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/Validator.java
@@ -333,25 +333,25 @@ public class Validator {
       // Same error messages as from validating the connection.
       return;
     }
-    String versionNumber = response.getVersion().getNumber();
+    String esVersionNumber = response.getVersion().getNumber();
     if (config.isDataStream()
-        && compareVersions(versionNumber, DATA_STREAM_COMPATIBLE_ES_VERSION) < 0) {
+        && compareVersions(esVersionNumber, DATA_STREAM_COMPATIBLE_ES_VERSION) < 0) {
       String errorMessage = String.format(
           "Elasticsearch version %s is not compatible with data streams. Elasticsearch"
               + "version must be at least %s.",
-          versionNumber,
+          esVersionNumber,
           DATA_STREAM_COMPATIBLE_ES_VERSION
       );
       addErrorMessage(CONNECTION_URL_CONFIG, errorMessage);
       addErrorMessage(DATA_STREAM_TYPE_CONFIG, errorMessage);
       addErrorMessage(DATA_STREAM_DATASET_CONFIG, errorMessage);
     }
-    if (compareVersions(versionNumber, CONNECTOR_V11_COMPATIBLE_ES_VERSION) < 0) {
+    if (compareVersions(esVersionNumber, CONNECTOR_V11_COMPATIBLE_ES_VERSION) < 0) {
       String errorMessage = String.format(
           "Connector version %s is not compatible with Elasticsearch version %s. Elasticsearch "
               + "version must be at least %s.",
           Version.getVersion(),
-          versionNumber,
+          esVersionNumber,
           CONNECTOR_V11_COMPATIBLE_ES_VERSION
       );
       addErrorMessage(CONNECTION_URL_CONFIG, errorMessage);

--- a/src/main/java/io/confluent/connect/elasticsearch/Validator.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/Validator.java
@@ -67,8 +67,8 @@ public class Validator {
 
   private static final Logger log = LoggerFactory.getLogger(Validator.class);
 
-  private static final String DATA_STREAM_COMPATIBLE_ES_VERSION = "7.9.0";
   private static final String CONNECTOR_V11_COMPATIBLE_ES_VERSION = "7.0.0";
+  private static final String DATA_STREAM_COMPATIBLE_ES_VERSION = "7.9.0";
 
   private ElasticsearchSinkConnectorConfig config;
   private Map<String, ConfigValue> values;

--- a/src/test/java/io/confluent/connect/elasticsearch/ValidatorTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ValidatorTest.java
@@ -372,6 +372,26 @@ public class ValidatorTest {
   }
 
   @Test
+  public void testIncompatibleESVersionWithConnector() {
+    validator = new Validator(props, () -> mockClient);
+    when(mockInfoResponse.getVersion().getNumber()).thenReturn("6.0.0");
+    Config result = validator.validate();
+    assertHasErrorMessage(result, CONNECTION_URL_CONFIG, "not compatible with Elasticsearch");
+  }
+
+  @Test
+  public void testCompatibleESVersionWithConnector() {
+    validator = new Validator(props, () -> mockClient);
+    String[] compatibleESVersions = {"7.0.0", "7.9.3", "7.10.0", "7.12.1", "8.0.0", "10.10.10"};
+    for (String version : compatibleESVersions) {
+      when(mockInfoResponse.getVersion().getNumber()).thenReturn(version);
+      Config result = validator.validate();
+
+      assertNoErrors(result);
+    }
+  }
+
+  @Test
   public void testValidSsl() {
     // no SSL
     props.put(SECURITY_PROTOCOL_CONFIG, SecurityProtocol.PLAINTEXT.name());


### PR DESCRIPTION
## Problem
Elasticsearch connector version 11.0.x and above must be using Elasticsearch version 7.0.x or above.

## Solution
Add a validator that ensures the Elasticsearch version is above 7.0.x

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?
This is similar to the version validation done for data streams ([PR](https://github.com/confluentinc/kafka-connect-elasticsearch/pull/525)).

## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
Not backporting or merging into master
<!-- If you are reverting or rolling back, is it safe? --> 
Not reverting or rolling back.