### PR TITLE
CCMSG-917: Elasticsearch sink connector fails if URL has trailing /

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -30,6 +30,8 @@ import org.apache.kafka.common.config.ConfigDef.Validator;
 import org.apache.kafka.common.config.ConfigDef.Width;
 
 import java.util.Map;
+import java.util.stream.Collectors;
+
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.types.Password;
 
@@ -750,7 +752,9 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   }
 
   public Set<String> connectionUrls() {
-    return new HashSet<>(getList(CONNECTION_URL_CONFIG));
+    return getList(CONNECTION_URL_CONFIG)
+        .stream().map(s -> s.endsWith("/") ? s.substring(0, s.length() - 1) : s)
+        .collect(Collectors.toCollection(HashSet::new));
   }
 
   public boolean dropInvalidMessage() {

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -20,19 +20,17 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.concurrent.TimeUnit;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.ConfigDef.Validator;
 import org.apache.kafka.common.config.ConfigDef.Width;
-
-import java.util.Map;
-import java.util.stream.Collectors;
-
-import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.types.Password;
 
 import static org.apache.kafka.common.config.ConfigDef.Range.between;

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
@@ -567,6 +567,15 @@ public class ElasticsearchClientTest {
     container.start();
   }
 
+  @Test
+  public void testConnectionUrlExtraSlash() {
+    String withExtraSlash = container.getConnectionUrl() + "/";
+    props.put(CONNECTION_URL_CONFIG, withExtraSlash);
+    config = new ElasticsearchSinkConnectorConfig(props);
+    ElasticsearchClient client = new ElasticsearchClient(config, null);
+    client.close();
+  }
+
   private static Schema schema() {
     return SchemaBuilder
         .struct()

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
@@ -569,8 +569,7 @@ public class ElasticsearchClientTest {
 
   @Test
   public void testConnectionUrlExtraSlash() {
-    String withExtraSlash = container.getConnectionUrl() + "/";
-    props.put(CONNECTION_URL_CONFIG, withExtraSlash);
+    props.put(CONNECTION_URL_CONFIG, container.getConnectionUrl() + "/");
     config = new ElasticsearchSinkConnectorConfig(props);
     ElasticsearchClient client = new ElasticsearchClient(config, null);
     client.close();


### PR DESCRIPTION
## Problem
The Elasticsearch sink fails if the Elasticsearch URL has a trailing `/` 

## Solution
Strip the ending `/` from given connection URLs

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
