### PR TITLE
CCMSG-1203: Update Data Stream Happy Path IT to include monitor privilege.

### DIFF
--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorIT.java
@@ -41,7 +41,6 @@ import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -54,8 +53,8 @@ public class ElasticsearchConnectorIT extends ElasticsearchConnectorBaseIT {
 
   @BeforeClass
   public static void setupBeforeAll() {
-    Map<User, String> users = Collections.singletonMap(getMinimalPrivilegesUser(), getMinimalPrivilegesPassword());
-    List<Role> roles = Collections.singletonList(getMinimalPrivilegesRole());
+    Map<User, String> users = getUsers();
+    List<Role> roles = getRoles();
     container = ElasticsearchContainer.fromSystemProperties().withBasicAuth(users, roles);
     container.start();
   }

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorSslIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorSslIT.java
@@ -46,9 +46,8 @@ public class ElasticsearchConnectorSslIT extends ElasticsearchConnectorBaseIT {
 
   @BeforeClass
   public static void setupBeforeAll() {
-    Map<User, String> users = Collections
-        .singletonMap(getMinimalPrivilegesUser(), getMinimalPrivilegesPassword());
-    List<Role> roles = Collections.singletonList(getMinimalPrivilegesRole());
+    Map<User, String> users = getUsers();
+    List<Role> roles = getRoles();
     container = ElasticsearchContainer.fromSystemProperties().withSslEnabled(true).withBasicAuth(users, roles);
     container.start();
   }


### PR DESCRIPTION
## Problem
After the latest merge to 11.1.x that specified role privileges, the data stream happy path IT failed with the error message 

`org.apache.kafka.connect.runtime.rest.errors.ConnectRestException: Could not execute PUT request. Error response: {"error_code":500,"message":"Elasticsearch exception [type=security_exception, reason=action [cluster:monitor/main] is unauthorized for user [frank]]"}`

## Solution
In the IT, a user with the `monitor` privilege needs to be added and used when data streams is enabled.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
