### PR TITLE
Adds routing support, configurable via 'routing.field.name'

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -256,6 +256,14 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   private static final String WRITE_METHOD_DISPLAY = "Write Method";
   private static final String WRITE_METHOD_DEFAULT = WriteMethod.INSERT.name();
 
+  public static final String ROUTING_FIELD_NAME_CONFIG = "routing.field.name";
+  private static final String ROUTING_FIELD_NAME_DOC =
+       "Specify which filed should be used for routing, "
+       + "supports nested fields through dot notion (`this.is.my.nested.path`). "
+       + "If configured, the field is mandatory and must always resolve to a non-blank String.";
+  private static final String ROUTING_FIELD_NAME_DISPLAY = "Routing field name";
+  private static final String ROUTING_FIELD_NAME_DEFAULT = "";
+
   // Proxy group
   public static final String PROXY_HOST_CONFIG = "proxy.host";
   private static final String PROXY_HOST_DISPLAY = "Proxy Host";
@@ -660,6 +668,16 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
             Width.SHORT,
             WRITE_METHOD_DISPLAY,
             new EnumRecommender<>(WriteMethod.class)
+        ).define(
+            ROUTING_FIELD_NAME_CONFIG,
+            Type.STRING,
+            ROUTING_FIELD_NAME_DEFAULT,
+            Importance.LOW,
+            ROUTING_FIELD_NAME_DOC,
+            DATA_CONVERSION_GROUP,
+            ++order,
+            Width.SHORT,
+            ROUTING_FIELD_NAME_DISPLAY
     );
   }
 
@@ -987,6 +1005,10 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
 
   public WriteMethod writeMethod() {
     return WriteMethod.valueOf(getString(WRITE_METHOD_CONFIG).toUpperCase());
+  }
+
+  public String routingFieldName() {
+    return getString(ROUTING_FIELD_NAME_CONFIG);
   }
 
   private static class DataStreamDatasetValidator implements Validator {

--- a/src/test/java/io/confluent/connect/elasticsearch/DataConverterTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/DataConverterTest.java
@@ -492,6 +492,21 @@ public class DataConverterTest {
     assertEquals(VersionType.INTERNAL, actualRecord.versionType());
   }
 
+  @Test
+  public void testDoAddRoutingValueForConfiguredPath() {
+    Map<String, String> propsWithRouting = new HashMap<>(props);
+    propsWithRouting.put(ElasticsearchSinkConnectorConfig.ROUTING_FIELD_NAME_CONFIG, "string");
+    converter = new DataConverter(new ElasticsearchSinkConnectorConfig(propsWithRouting));
+    Schema preProcessedSchema = converter.preProcessSchema(schema);
+    String routingFieldValue = "routeTo";
+    Struct struct = new Struct(preProcessedSchema).put("string", routingFieldValue);
+    SinkRecord sinkRecord = createSinkRecordWithValue(struct);
+
+    IndexRequest actualRecord = (IndexRequest) converter.convertRecord(sinkRecord, index);
+
+    assertEquals(routingFieldValue, actualRecord.routing());
+  }
+
   private void configureDataStream() {
     props.put(ElasticsearchSinkConnectorConfig.DATA_STREAM_TYPE_CONFIG, "logs");
     props.put(ElasticsearchSinkConnectorConfig.DATA_STREAM_DATASET_CONFIG, "dataset");

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorIT.java
@@ -15,14 +15,7 @@
 
 package io.confluent.connect.elasticsearch.integration;
 
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BATCH_SIZE_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_PASSWORD_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_USERNAME_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_KEY_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.LINGER_MS_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BULK_SIZE_BYTES_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.WRITE_METHOD_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.*;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG;
 import static org.junit.Assert.assertEquals;
 
@@ -30,12 +23,14 @@ import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.Behav
 import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.WriteMethod;
 import io.confluent.connect.elasticsearch.helper.ElasticsearchContainer;
 
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.kafka.connect.storage.StringConverter;
 import org.apache.kafka.test.IntegrationTest;
 import org.elasticsearch.client.security.user.User;
 import org.elasticsearch.client.security.user.privileges.Role;
 import org.elasticsearch.search.SearchHit;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
@@ -198,5 +193,13 @@ public class ElasticsearchConnectorIT extends ElasticsearchConnectorBaseIT {
     container.close();
     container = ElasticsearchContainer.fromSystemProperties();
     container.start();
+  }
+
+  @Ignore
+  @Test
+  public void testRouting() throws Exception {
+    props.put(ROUTING_FIELD_NAME_CONFIG, "doc_num");
+    // TODO this might require massive test data refactoring, discuss in PR first...
+    throw new NotImplementedException("");
   }
 }


### PR DESCRIPTION
Refs:
- https://github.com/confluentinc/kafka-connect-elasticsearch/issues/223
- https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-routing-field.html
- https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html#bulk-routing
- https://www.elastic.co/guide/en/elasticsearch/reference/current/parent-join.html

## Problem
ElasticSearch `_routing` field currently is not supported.

## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?
Parent/Child relationships -> join field type

## Test Strategy
`DataConverterTest` has been added.   
Integration test might require refactoring of existing tests.
`ElasticsearchConnectorIT` / `ElasticsearchConnectorBaseIT` seems to use a very basic schema / payload.
Also `ElasticsearchHelperClient` would need to be improved to also support __routing_.

**Please advise** how to approach.

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
* New feature
* Non-breaking change
* New config fields are optional
* Does not require any change or migration upon upgrade
