### PR TITLE
MINOR: Re-add Guava as compile time dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,12 +134,10 @@
             <version>${lucene.version}</version>
             <scope>test</scope>
         </dependency>
-        <!--Require newer version than inherited-->
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>27.0.1-jre</version>
-            <scope>test</scope>
+            <version>${guava.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>


### PR DESCRIPTION
## Problem
Guava is incorrectly marked as scope dependency. The issue won't surface as long as guava is included with CP

## Solution
Add the compile time dep

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
