### PR TITLE
Log server version on sink task startup

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
@@ -15,25 +15,6 @@
 
 package io.confluent.connect.elasticsearch;
 
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.FLUSH_TIMEOUT_MS_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.MAX_BUFFERED_RECORDS_CONFIG;
-
-import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BehaviorOnMalformedDoc;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
 import org.apache.http.HttpHost;
 import org.apache.http.nio.conn.NHttpClientConnectionManager;
 import org.apache.kafka.common.utils.Time;
@@ -61,6 +42,27 @@ import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.common.unit.TimeValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BehaviorOnMalformedDoc;
+
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.FLUSH_TIMEOUT_MS_CONFIG;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.MAX_BUFFERED_RECORDS_CONFIG;
 
 public class ElasticsearchClient {
 

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -160,7 +160,7 @@ public class ElasticsearchSinkTask extends SinkTask {
       try {
         highLevelClient.close();
       } catch (Exception e) {
-        log.error("Failed to close high level client");
+        log.warn("Failed to close high level client");
       }
     }
     return esVersionNumber;

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -117,6 +117,11 @@ public class ElasticsearchSinkTask extends SinkTask {
   public void stop() {
     log.debug("Stopping Elasticsearch client.");
     client.close();
+    try {
+      highLevelClient.close();
+    } catch (Exception e) {
+      log.error("Failed to close high level rest client", e);
+    }
   }
 
   @Override
@@ -154,7 +159,8 @@ public class ElasticsearchSinkTask extends SinkTask {
     try {
       response = highLevelClient.info(RequestOptions.DEFAULT);
       esVersionNumber = response.getVersion().toString();
-    } catch (IOException | ElasticsearchStatusException e) {
+    } catch (Exception e) {
+      log.info("Failed to get ES server version", e);
       // Same error messages as from validating the connection for IOException.
       // Insufficient privileges to validate the version number if caught
       // ElasticsearchStatusException.

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -156,11 +156,12 @@ public class ElasticsearchSinkTask extends SinkTask {
       // Insufficient privileges to validate the version number if caught
       // ElasticsearchStatusException.
       log.warn("Failed to get ES server version", e);
-    }
-    try {
-      highLevelClient.close();
-    } catch (Exception e) {
-      log.error("Failed to close high level client");
+    } finally {
+      try {
+        highLevelClient.close();
+      } catch (Exception e) {
+        log.error("Failed to close high level client");
+      }
     }
     return esVersionNumber;
   }

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -119,6 +119,7 @@ public class ElasticsearchSinkTask extends SinkTask {
     client.close();
     try {
       highLevelClient.close();
+      highLevelClient = null;
     } catch (Exception e) {
       log.error("Failed to close high level rest client", e);
     }

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -159,10 +159,10 @@ public class ElasticsearchSinkTask extends SinkTask {
       response = highLevelClient.info(RequestOptions.DEFAULT);
       esVersionNumber = response.getVersion().toString();
     } catch (Exception e) {
-      log.info("Failed to get ES server version", e);
       // Same error messages as from validating the connection for IOException.
       // Insufficient privileges to validate the version number if caught
       // ElasticsearchStatusException.
+      log.warn("Failed to get ES server version", e);
     }
     return esVersionNumber;
   }

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -160,7 +160,7 @@ public class ElasticsearchSinkTask extends SinkTask {
       try {
         highLevelClient.close();
       } catch (Exception e) {
-        log.warn("Failed to close high level client");
+        log.warn("Failed to close high level client", e);
       }
     }
     return esVersionNumber;

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -15,8 +15,6 @@
 
 package io.confluent.connect.elasticsearch;
 
-import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BehaviorOnNullValues;
-
 import org.apache.http.HttpHost;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
@@ -40,6 +38,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BehaviorOnNullValues;
 
 public class ElasticsearchSinkTask extends SinkTask {
 
@@ -72,7 +72,6 @@ public class ElasticsearchSinkTask extends SinkTask {
       if (context.errantRecordReporter() == null) {
         log.info("Errant record reporter not configured.");
       }
-
       // may be null if DLQ not enabled
       reporter = context.errantRecordReporter();
     } catch (NoClassDefFoundError | NoSuchMethodError e) {
@@ -82,7 +81,8 @@ public class ElasticsearchSinkTask extends SinkTask {
 
     this.client = client != null ? client : new ElasticsearchClient(config, reporter);
 
-    log.info("Started ElasticsearchSinkTask. Connecting to ES server version: {}", getServerVersion());
+    log.info("Started ElasticsearchSinkTask. Connecting to ES server version: {}",
+        getServerVersion());
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -25,10 +25,10 @@ import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTask;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.DocWriteRequest;
+import org.elasticsearch.action.main.MainResponse;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
-import org.elasticsearch.client.core.MainResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -153,7 +153,7 @@ public class ElasticsearchSinkTask extends SinkTask {
     String esVersionNumber = "Unknown";
     try {
       response = highLevelClient.info(RequestOptions.DEFAULT);
-      esVersionNumber = response.getVersion().getNumber();
+      esVersionNumber = response.getVersion().toString();
     } catch (IOException | ElasticsearchStatusException e) {
       // Same error messages as from validating the connection for IOException.
       // Insufficient privileges to validate the version number if caught

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -23,7 +23,6 @@ import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.sink.ErrantRecordReporter;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTask;
-import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.main.MainResponse;
 import org.elasticsearch.client.RequestOptions;
@@ -32,7 +31,6 @@ import org.elasticsearch.client.RestHighLevelClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;

--- a/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchHelperClient.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchHelperClient.java
@@ -15,11 +15,6 @@
 
 package io.confluent.connect.elasticsearch.helper;
 
-import io.confluent.connect.elasticsearch.ConfigCallbackHandler;
-import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig;
-import java.io.IOException;
-import java.util.Map.Entry;
-
 import org.apache.http.HttpHost;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.search.SearchRequest;
@@ -41,6 +36,12 @@ import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.search.SearchHits;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Map.Entry;
+
+import io.confluent.connect.elasticsearch.ConfigCallbackHandler;
+import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig;
 
 public class ElasticsearchHelperClient {
 


### PR DESCRIPTION
## Problem
We need to know what version of ES server our customers are running in cloud so we can determine if it's safe to upgrade
## Solution
Log ES server version on sink task startup


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
