### PR TITLE
Change version logging to work with upgraded client

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -150,7 +150,7 @@ public class ElasticsearchSinkTask extends SinkTask {
     String esVersionNumber = "Unknown";
     try {
       response = highLevelClient.info(RequestOptions.DEFAULT);
-      esVersionNumber = response.getVersion().toString();
+      esVersionNumber = response.getVersion().getNumber();
     } catch (Exception e) {
       // Same error messages as from validating the connection for IOException.
       // Insufficient privileges to validate the version number if caught


### PR DESCRIPTION
## Problem
Once we upgraded ES client to `7.9.3`, the method we were using for logging ES server versions was changed

## Solution
Update to the newer way to getting ES server version

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
