### PR TITLE
Add RequestAcceptEncoding interceptor for compression

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ConfigCallbackHandler.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ConfigCallbackHandler.java
@@ -38,6 +38,7 @@ import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.config.AuthSchemes;
 import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.protocol.RequestAcceptEncoding;
 import org.apache.http.config.Lookup;
 import org.apache.http.config.Registry;
 import org.apache.http.config.RegistryBuilder;
@@ -91,6 +92,8 @@ public class ConfigCallbackHandler implements HttpClientConfigCallback, RequestC
     builder.setConnectionManager(connectionManager);
     builder.setMaxConnPerRoute(config.maxInFlightRequests());
     builder.setMaxConnTotal(config.maxInFlightRequests());
+
+    builder.addInterceptorLast(new RequestAcceptEncoding());
 
     configureAuthentication(builder);
 


### PR DESCRIPTION
## Problem
Currently, the compression flag(`connection.compression`) is not working due to the missing of `RequestAcceptEncoding` interceptor in HTTP client.

## Solution
This PR added `RequestAcceptEncoding` interceptor in HTTP client builder to apply `Accept-Encoding: gzip,deflate` header.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?
This interceptor should affect all requests to ElasticSearch which used the `ConfigCallbackHandler` handler.

## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
