### PR TITLE
support STRUCT message keys

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
@@ -108,6 +108,8 @@ public class DataConverter {
       case INT64:
       case STRING:
         return String.valueOf(key);
+      case STRUCT:
+        return key.toString();
       default:
         throw new DataException(schemaType.name() + " is not supported as the document id.");
     }

--- a/src/test/java/io/confluent/connect/elasticsearch/DataConverterTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/DataConverterTest.java
@@ -365,6 +365,31 @@ public class DataConverterTest {
     }
   }
 
+  @Test
+  public void structKey() {
+    props.put(ElasticsearchSinkConnectorConfig.IGNORE_KEY_CONFIG, "false");
+    props.put(ElasticsearchSinkConnectorConfig.IGNORE_SCHEMA_CONFIG, "false");
+    converter = new DataConverter(new ElasticsearchSinkConnectorConfig(props));
+
+    Schema schema = SchemaBuilder.struct().field("field1", Schema.STRING_SCHEMA).field("field2", Schema.STRING_SCHEMA).build();
+    Struct key = new Struct(schema).put("field1", "value1").put("field2", "value2");
+    Struct value = new Struct(schema).put("field1", "value1").put("field2", "value2");
+
+    SinkRecord sinkRecord = new SinkRecord(
+         topic,
+         partition,
+         schema,
+         key,
+         schema,
+         value,
+         offset,
+         recordTimestamp,
+         TimestampType.CREATE_TIME
+    );
+    IndexRequest actualRecord = (IndexRequest) converter.convertRecord(sinkRecord, index);
+    assertEquals(actualRecord.id(), "Struct{field1=value1,field2=value2}");
+  }
+
   public SinkRecord createSinkRecordWithValue(Object value) {
     return new SinkRecord(
          topic, 


### PR DESCRIPTION
## Problem

There is currently no way to sink messages with composite keys without ignoring those keys.

Error "STRUCT is not supported as the document id."

 https://github.com/confluentinc/kafka-connect-elasticsearch/issues/193

## Solution

Convert message key STRUCT to a string for the doucment id.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

## Test Strategy

unit test provided for DataConverter

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan