### PR TITLE
Add timeout for retries

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
@@ -367,7 +367,8 @@ public class ElasticsearchClient {
           description,
           function,
           config.maxRetries(),
-          config.retryBackoffMs()
+          config.retryBackoffMs(),
+          config.connectionTimeoutMs()
       );
     } catch (Exception e) {
       throw new ConnectException("Failed to " + description + ".", e);

--- a/src/main/java/io/confluent/connect/elasticsearch/RetryUtil.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/RetryUtil.java
@@ -15,10 +15,15 @@
 
 package io.confluent.connect.elasticsearch;
 
-import java.io.IOException;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.slf4j.Logger;
@@ -106,6 +111,7 @@ public class RetryUtil {
    * @param function         the function to call; may not be null
    * @param maxAttempts      maximum number of attempts
    * @param initialBackoff   the initial backoff in ms before retrying
+   * @param connectionTimeout The length of time to wait for a response from the server
    * @param <T>              the return type of the function to retry
    * @return the function's return value
    * @throws ConnectException        if the function failed after retries
@@ -115,9 +121,11 @@ public class RetryUtil {
       String description,
       Callable<T> function,
       int maxAttempts,
-      long initialBackoff
+      long initialBackoff,
+      long connectionTimeout
   ) throws Exception {
-    return callWithRetries(description, function, maxAttempts, initialBackoff, Time.SYSTEM);
+    return callWithRetries(description, function, maxAttempts, initialBackoff,
+        connectionTimeout, Time.SYSTEM);
   }
 
   /**
@@ -136,39 +144,43 @@ public class RetryUtil {
    * @param <T>              the return type of the function to retry
    * @return the function's return value
    * @throws ConnectException        if the function failed after retries
-   * @throws Exception               if the function throws an exception
    */
   protected static <T> T callWithRetries(
       String description,
       Callable<T> function,
       int maxAttempts,
       long initialBackoff,
+      long connectionTimeout,
       Time clock
   ) throws Exception {
     assert description != null;
     assert function != null;
-
+    log.warn("in call with retries");
     int attempt = 0;
+    long backoff = computeRandomRetryWaitTimeInMillis(attempt, initialBackoff);
     while (true) {
       ++attempt;
+      ExecutorService executorService = Executors.newSingleThreadExecutor();
       try {
-        log.trace(
+        log.warn(
             "Try {} (attempt {} of {})",
             description,
             attempt,
             maxAttempts
         );
-        return function.call();
-      } catch (IOException e) {
+        Future<T> future = executorService.submit(function);
+        // Wait for connectionTimeout duration until the result is returned
+        return future.get(connectionTimeout, TimeUnit.MILLISECONDS);
+
+      } catch (Exception e) {
         if (attempt >= maxAttempts) {
           log.error("Failed to {} due to {} after total of {} attempt(s)",
               description, e.getCause(), maxAttempts, e.getMessage());
           throw new ConnectException("Failed to " + description, e);
         }
-        // Otherwise it is retriable and we should retry
-        long backoff = computeRandomRetryWaitTimeInMillis(attempt, initialBackoff);
         log.warn("Failed to {} due to {}. Retrying attempt ({}/{}) after backoff of {} ms",
             description, e.getCause(), attempt, maxAttempts, backoff);
+        executorService.shutdown();
         clock.sleep(backoff);
       }
     }

--- a/src/test/java/io/confluent/connect/elasticsearch/RetryUtilTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/RetryUtilTest.java
@@ -72,7 +72,7 @@ public class RetryUtilTest {
     MockTime mockClock = new MockTime();
     long expectedTime = mockClock.milliseconds();
 
-    assertTrue(RetryUtil.callWithRetries("test", () -> testFunction(0), 3, 100, mockClock));
+    assertTrue(RetryUtil.callWithRetries("test", () -> testFunction(0), 3, 100,1000, mockClock));
     assertEquals(expectedTime, mockClock.milliseconds());
   }
 
@@ -80,7 +80,7 @@ public class RetryUtilTest {
   public void testCallWithRetriesSomeRetries() throws Exception {
     MockTime mockClock = spy(new MockTime());
 
-    assertTrue(RetryUtil.callWithRetries("test", () -> testFunction(2), 3, 100, mockClock));
+    assertTrue(RetryUtil.callWithRetries("test", () -> testFunction(2), 3, 100, 1000, mockClock));
     verify(mockClock, times(2)).sleep(anyLong());
   }
 
@@ -88,7 +88,7 @@ public class RetryUtilTest {
   public void testCallWithRetriesExhaustedRetries() throws Exception {
     MockTime mockClock = new MockTime();
 
-    assertTrue(RetryUtil.callWithRetries("test", () -> testFunction(4), 3, 100, mockClock));
+    assertTrue(RetryUtil.callWithRetries("test", () -> testFunction(4), 3, 100, 1000, mockClock));
     verify(mockClock, times(3)).sleep(anyLong());
   }
 

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorBaseIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorBaseIT.java
@@ -29,6 +29,7 @@ import org.junit.AfterClass;
 import org.junit.Before;
 
 import java.io.IOException;
+import java.net.ConnectException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -87,8 +88,13 @@ public class ElasticsearchConnectorBaseIT extends BaseConnectorIT {
     stopConnect();
 
     if (helperClient != null) {
-      helperClient.deleteIndex(TOPIC);
-      helperClient.close();
+      try {
+        helperClient.deleteIndex(TOPIC);
+        helperClient.close();
+      } catch (ConnectException e) {
+        // Server is already down. No need to close
+      }
+
     }
   }
 


### PR DESCRIPTION
## Problem
The retry util does not have a timeout. If the ES server is not reachable, the request never completes and the connector hands indefinitely

## Solution
Add a timeout to the retry util. 

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
