### PR TITLE
CCMSG-1376: offsets are marked as processed for individual record failures

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
@@ -153,9 +153,6 @@ public class DataConverter {
       }
     }
 
-    String payload = getPayload(record);
-    payload = maybeAddTimestamp(payload, record.timestamp());
-
     final String id = config.shouldIgnoreKey(record.topic())
         ? String.format("%s+%d+%d", record.topic(), record.kafkaPartition(), record.kafkaOffset())
         : convertKey(record.keySchema(), record.key());
@@ -164,6 +161,9 @@ public class DataConverter {
     if (record.value() == null) {
       return maybeAddExternalVersioning(new DeleteRequest(index).id(id), record);
     }
+
+    String payload = getPayload(record);
+    payload = maybeAddTimestamp(payload, record.timestamp());
 
     // index
     switch (config.writeMethod()) {
@@ -199,7 +199,7 @@ public class DataConverter {
     return new String(rawJsonPayload, StandardCharsets.UTF_8);
   }
 
-  private String maybeAddTimestamp(String payload, long timestamp) {
+  private String maybeAddTimestamp(String payload, Long timestamp) {
     if (!config.isDataStream()) {
       return payload;
     }

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
@@ -91,6 +91,7 @@ public class ElasticsearchClient {
   private static final String VERSION_CONFLICT_EXCEPTION = "version_conflict_engine_exception";
   private static final Set<String> MALFORMED_DOC_ERRORS = new HashSet<>(
       Arrays.asList(
+          "strict_dynamic_mapping_exception",
           "mapper_parsing_exception",
           "illegal_argument_exception",
           "action_request_validation_exception"
@@ -495,7 +496,9 @@ public class ElasticsearchClient {
       for (String error : MALFORMED_DOC_ERRORS) {
         if (response.getFailureMessage().contains(error)) {
           boolean failed = handleMalformedDocResponse(response);
-          reportBadRecord(response, executionId);
+          if (!failed) {
+            reportBadRecord(response, executionId);
+          }
           return failed;
         }
       }

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -128,7 +128,9 @@ public class ElasticsearchSinkTask extends SinkTask {
     } catch (IllegalStateException e) {
       log.debug("Tried to flush data to Elasticsearch, but BulkProcessor is already closed.", e);
     }
-    return offsetTracker.offsets();
+    Map<TopicPartition, OffsetAndMetadata> offsets = offsetTracker.offsets();
+    log.debug("preCommitting offsets {}", offsets);
+    return offsets;
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -108,6 +108,7 @@ public class ElasticsearchSinkTask extends SinkTask {
 
       if (shouldSkipRecord(record)) {
         logTrace("Ignoring {} with null value.", record);
+        offsetState.markProcessed();
         reportBadRecord(record, new ConnectException("Cannot write null valued record."));
         continue;
       }
@@ -300,6 +301,7 @@ public class ElasticsearchSinkTask extends SinkTask {
 
       if (config.dropInvalidMessage()) {
         log.error("Can't convert {}.", recordString(sinkRecord), convertException);
+        offsetState.markProcessed();
       } else {
         throw convertException;
       }

--- a/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchHelperClient.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchHelperClient.java
@@ -22,6 +22,7 @@ import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.client.core.CountRequest;
+import org.elasticsearch.client.indices.CreateIndexRequest;
 import org.elasticsearch.client.indices.DataStream;
 import org.elasticsearch.client.indices.DeleteDataStreamRequest;
 import org.elasticsearch.client.indices.GetDataStreamRequest;
@@ -36,6 +37,7 @@ import org.elasticsearch.client.security.RefreshPolicy;
 import org.elasticsearch.client.security.user.User;
 import org.elasticsearch.client.security.user.privileges.Role;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.search.SearchHits;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -94,6 +96,11 @@ public class ElasticsearchHelperClient {
   public boolean indexExists(String index) throws IOException {
     GetIndexRequest request = new GetIndexRequest(index);
     return client.indices().exists(request, RequestOptions.DEFAULT);
+  }
+
+  public void createIndex(String index, String jsonMappings) throws IOException {
+    CreateIndexRequest createIndexRequest = new CreateIndexRequest(index).mapping(jsonMappings, XContentType.JSON);
+    client.indices().create(createIndexRequest, RequestOptions.DEFAULT);
   }
 
   public SearchHits search(String index) throws IOException {


### PR DESCRIPTION
## Problem

When individual records in a bulk batch fail to be indexed, we still mark them as processed in OffsetTracker. 
These batches are going to be retried but offsets should not be committed past the failing records.

## Solution

Update logic to avoid marking them as processed.

##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

## Test Strategy


##### Testing done:
- [ ] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan

Patch latest minor release (11.1)
Safe to rollback.