### PR TITLE
MINOR: Fix Javadoc warnings.

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/OffsetTracker.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/OffsetTracker.java
@@ -30,6 +30,8 @@ public interface OffsetTracker {
 
   /**
    * Method that return a total number of offset entries, that is in memory
+   *
+   * @return number of offset entries
    */
   default long numOffsetStateEntries() {
     return 0;

--- a/src/main/java/io/confluent/connect/elasticsearch/SyncOffsetTracker.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/SyncOffsetTracker.java
@@ -24,7 +24,7 @@ import org.apache.kafka.connect.sink.SinkRecord;
 
 /**
  * It's a synchronous offset tracker to use with <code>FLUSH_SYNCHRONOUSLY_CONFIG=true</code>,
- * that will block on {@link #offsets()}.
+ * that will block on {@link SyncOffsetTracker#offsets(Map<TopicPartition, OffsetAndMetadata>)}.
  *
  */
 public class SyncOffsetTracker implements OffsetTracker {

--- a/src/main/java/io/confluent/connect/elasticsearch/SyncOffsetTracker.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/SyncOffsetTracker.java
@@ -24,7 +24,7 @@ import org.apache.kafka.connect.sink.SinkRecord;
 
 /**
  * It's a synchronous offset tracker to use with <code>FLUSH_SYNCHRONOUSLY_CONFIG=true</code>,
- * that will block on {@link SyncOffsetTracker#offsets(Map<TopicPartition, OffsetAndMetadata>)}.
+ * that will block on {@link SyncOffsetTracker#offsets(Map)}.
  *
  */
 public class SyncOffsetTracker implements OffsetTracker {


### PR DESCRIPTION
## Problem
Release dry-run fails:
```
mvn -Pjenkins -f kafka-connect-elasticsearch --batch-mode -DdryRun=true -DskipTests=false -Darguments=-DskipTests=false '-DpreparationGoals=clean install javadoc:javadoc' release:prepare
...
21:09:15  [INFO] [INFO] ------------------------------------------------------------------------
21:09:15  [INFO] [INFO] BUILD FAILURE
21:09:15  [INFO] [INFO] ------------------------------------------------------------------------
21:09:15  [INFO] [INFO] Total time:  11:51 min
21:09:15  [INFO] [INFO] Finished at: 2021-11-04T04:09:15Z
21:09:15  [INFO] [INFO] ------------------------------------------------------------------------
21:09:15  [INFO] [ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.3.1:javadoc (default-cli) on project kafka-connect-elasticsearch: An error has occurred in Javadoc report generation: 
21:09:15  [INFO] [ERROR] Exit code: 1 - /home/jenkins/kafka-connect-elasticsearch/src/main/java/io/confluent/connect/elasticsearch/OffsetTracker.java:34: warning: no @return
21:09:15  [INFO] [ERROR]   default long numOffsetStateEntries() {
21:09:15  [INFO] [ERROR]                ^
21:09:15  [INFO] [ERROR] /home/jenkins/kafka-connect-elasticsearch/src/main/java/io/confluent/connect/elasticsearch/SyncOffsetTracker.java:27: error: reference not found
21:09:15  [INFO] [ERROR]  * that will block on {@link #offsets()}.
21:09:15  [INFO] [ERROR]                              ^
21:09:15  [INFO] [ERROR] /home/jenkins/kafka-connect-elasticsearch/src/main/java/io/confluent/connect/elasticsearch/SyncOffsetTracker.java:30: warning - Tag @link: can't find offsets() in io.confluent.connect.elasticsearch.SyncOffsetTracker
21:09:15  [INFO] [ERROR] 
21:09:15  [INFO] [ERROR] Command line was: /usr/lib/jvm/java-8-oracle/jre/../bin/javadoc @options @packages
21:09:15  [INFO] [ERROR] 
21:09:15  [INFO] [ERROR] Refer to the generated Javadoc files in '/home/jenkins/kafka-connect-elasticsearch/target/site/apidocs' dir.
21:09:15  [INFO] [ERROR] -> [Help 1]
21:09:15  [INFO] [ERROR] 
21:09:15  [INFO] [ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
21:09:15  [INFO] [ERROR] Re-run Maven using the -X switch to enable full debug logging.
21:09:15  [INFO] [ERROR] 
21:09:15  [INFO] [ERROR] For more information about the errors and possible solutions, please read the following articles:
21:09:15  [INFO] [ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```


## Solution
Fix Javadoc warnings.


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
