### PR TITLE
Use a synchronous flush by default.

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -121,7 +121,7 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
             + " penalty and makes the connector less responsive but allows for topic-mutating SMTs"
             + " (e.g. RegexRouter or TimestampRouter)";
   private static final String FLUSH_SYNCHRONOUSLY_DISPLAY = "Flush synchronously";
-  private static final boolean FLUSH_SYNCHRONOUSLY_DEFAULT = true;
+  private static final boolean FLUSH_SYNCHRONOUSLY_DEFAULT = false;
 
   public static final String MAX_RETRIES_CONFIG = "max.retries";
   private static final String MAX_RETRIES_DOC =

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
@@ -47,6 +47,12 @@ public class ElasticsearchSinkConnectorConfigTest {
   }
 
   @Test
+  public void testDefaultFlushSynchronously() {
+    ElasticsearchSinkConnectorConfig config = new ElasticsearchSinkConnectorConfig(props);
+    assertEquals(false, config.flushSynchronously());
+  }
+
+  @Test
   public void testSetHttpTimeoutsConfig() {
     props.put(READ_TIMEOUT_MS_CONFIG, "10000");
     props.put(CONNECTION_TIMEOUT_MS_CONFIG, "15000");


### PR DESCRIPTION
## Problem
This change https://github.com/confluentinc/kafka-connect-elasticsearch/pull/589 introduced a new configuration parameter - `flush.synchronously`, the default value was set to `true` to avoid a breaking change.
We released this change in a minor release - `v11.1.4`.
But, the synchronous mode has worse performance than asynchronous and it's only needed for a subset of users, who use ES sink with routing SMTs(those that mutate the topic's name).

Original discussion - https://github.com/confluentinc/kafka-connect-elasticsearch/pull/589/files#r735739916

## Solution
Make asynchronous mode default(`flush.synchronously`=`false`) and have a major release, since this is a breaking change for users, who have routing SMTs.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
Doing a major `12.0.0` release.
