### PR TITLE
External version (topic offset) conflict records should skip DLQ

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
@@ -189,7 +189,7 @@ public class DataConverter {
 
   /**
    * In many cases, we explicitly set the record version using the topic's offset.
-   * This version will, in turn, be checked by ElasticSearch and will throw a versioning
+   * This version will, in turn, be checked by Elasticsearch and will throw a versioning
    * error if the request represents an equivalent or older version of the record.
    *
    * @param request the request currently being constructed for `record`

--- a/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
@@ -187,6 +187,15 @@ public class DataConverter {
     return new String(rawJsonPayload, StandardCharsets.UTF_8);
   }
 
+  /**
+   * In many cases, we explicitly set the record version using the topic's offset
+   * This version will, in turn, be checked by ElasticSearch and will throw a versioning
+   * error if the request represents an equivalent or older version of the record.
+   *
+   * @param request the request currently being constructed for `record`
+   * @param record the record to be processed
+   * @return the (possibly modified) request which was passed in
+   */
   private DocWriteRequest<?> maybeAddExternalVersioning(
       DocWriteRequest<?> request,
       SinkRecord record

--- a/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
@@ -188,7 +188,7 @@ public class DataConverter {
   }
 
   /**
-   * In many cases, we explicitly set the record version using the topic's offset
+   * In many cases, we explicitly set the record version using the topic's offset.
    * This version will, in turn, be checked by ElasticSearch and will throw a versioning
    * error if the request represents an equivalent or older version of the record.
    *

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
@@ -454,7 +454,7 @@ public class ElasticsearchClient {
           // but we have the actual version number for this record because we set it in
           // the request.
           log.debug("Ignoring EXTERNAL version conflict for operation {} on"
-                  + " document '{}' version {} in index '{}'.",
+                          + " document '{}' version {} in index '{}'.",
                   response.getOpType(),
                   response.getId(),
                   request.version(),

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
@@ -418,7 +418,7 @@ public class ElasticsearchClient {
    * @param request     the request which generated the response
    * @param executionId the execution id of the request
    */
-  private void handleResponse(BulkItemResponse response, DocWriteRequest<?> request,
+  protected void handleResponse(BulkItemResponse response, DocWriteRequest<?> request,
                               long executionId) {
     if (response.isFailed()) {
       for (String error : MALFORMED_DOC_ERRORS) {

--- a/src/main/java/io/confluent/connect/elasticsearch/Validator.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/Validator.java
@@ -1,18 +1,17 @@
-/**
+/*
  * Copyright 2020 Confluent Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.confluent.io/confluent-community-license
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- **/
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 
 package io.confluent.connect.elasticsearch;
 

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
@@ -512,7 +512,7 @@ public class ElasticsearchClientTest {
   /**
    * Cause a version conflict error.
    * Assumes that Elasticsearch VersionType is 'EXTERNAL' for the records
-   * @param client
+   * @param client The Elasticsearch client object to which to send records
    */
   private void causeExternalVersionConflictError(ElasticsearchClient client) throws InterruptedException {
     client.createIndex(INDEX);

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
@@ -529,7 +529,7 @@ public class ElasticsearchClientTest {
     // At the end of the day, it's just one record being overwritten
     waitUntilRecordsInES(3);
 
-    // Now duplcate the last and then the one before that
+    // Now duplicate the last and then the one before that
     writeRecord(sinkRecord("key0", 2), client);
     writeRecord(sinkRecord("key0", 1), client);
     client.flush();

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
@@ -535,8 +535,8 @@ public class ElasticsearchClientTest {
     client.flush();
 
     // Make sure that no error was reported for either offset [1, 2] record(s)
-    verify(reporter, never()).report(eq(sinkRecord(1)), any(Throwable.class));
-    verify(reporter, never()).report(eq(sinkRecord(2)), any(Throwable.class));
+    verify(reporter, never()).report(eq(sinkRecord("key0", 1)), any(Throwable.class));
+    verify(reporter, never()).report(eq(sinkRecord("key0", 2)), any(Throwable.class));
     client.close();
   }
 

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
@@ -61,6 +61,9 @@ import org.apache.kafka.connect.sink.ErrantRecordReporter;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.test.TestUtils;
 import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.action.DocWriteRequest;
+import org.elasticsearch.action.bulk.BulkItemResponse;
+import org.elasticsearch.index.VersionType;
 import org.elasticsearch.search.SearchHit;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -505,67 +508,14 @@ public class ElasticsearchClientTest {
     client.close();
   }
 
-  /**
-   * If the record version is set to VersionType.EXTERNAL (normal case for non-streaming),
-   * then same or less
-   * @throws Exception will be thrown if the test fails
-   */
-//  @Test
-//  public void testIgnoreKeyInternalVersionConflictReporterCalled() throws Exception {
-//    props.put(IGNORE_KEY_CONFIG, "true");
-//    // Suppress asynchronous operations
-//    props.put(MAX_IN_FLIGHT_REQUESTS_CONFIG, "1");
-//    config = new ElasticsearchSinkConnectorConfig(props);
-//
-//    final String keyName = "key0";
-//
-//    // Set the key to being ignored
-//    config.ignoreKeyTopics().add(keyName);
-//
-//    converter = new DataConverter(config);
-//
-//    ErrantRecordReporter reporter = mock(ErrantRecordReporter.class);
-//    ElasticsearchClient client = new ElasticsearchClient(config, reporter);
-//    client.createIndex(INDEX);
-//
-//    // Sequentially increase out record version (which comes from the offset)
-//    writeRecord(sinkRecord(keyName, 0), client);
-//    writeRecord(sinkRecord(keyName, 1), client);
-//    writeRecord(sinkRecord(keyName, 2), client);
-//    client.flush();
-//
-//    // At the end of the day, it's just one record being overwritten
-//    waitUntilRecordsInES(3);
-//
-//    // Now duplicate the last and then the one before that
-//    writeRecord(sinkRecord(keyName, 2), client);
-//    writeRecord(sinkRecord(keyName, 1), client);
-//    client.flush();
-//
-//    // Make sure that no error was reported for either offset [1, 2] record(s)
-//    verify(reporter, never()).report(eq(sinkRecord(keyName, 1)), any(Throwable.class));
-//    verify(reporter, never()).report(eq(sinkRecord(keyName, 2)), any(Throwable.class));
-//    client.close();
-//  }
 
   /**
-   * If the record version is set to VersionType.EXTERNAL (normal case for non-streaming),
-   * then same or less
-   * @throws Exception will be thrown if the test fails
+   * Cause a version conflict error.
+   * Assumes that Elasticsearch VersionType is 'EXTERNAL' for the records
+   * @param client
    */
-  @Test
-  public void testExternalVersionConflictReporterNotCalled() throws Exception {
-    props.put(IGNORE_KEY_CONFIG, "false");
-    // Suppress asynchronous operations
-    props.put(MAX_IN_FLIGHT_REQUESTS_CONFIG, "1");
-    config = new ElasticsearchSinkConnectorConfig(props);
-    converter = new DataConverter(config);
-
-    ErrantRecordReporter reporter = mock(ErrantRecordReporter.class);
-    ElasticsearchClient client = new ElasticsearchClient(config, reporter);
+  private void causeExternalVersionConflictError(ElasticsearchClient client) throws InterruptedException {
     client.createIndex(INDEX);
-
-    //final String keyName = "key0";
 
     // Sequentially increase out record version (which comes from the offset)
     writeRecord(sinkRecord(0), client);
@@ -580,10 +530,71 @@ public class ElasticsearchClientTest {
     writeRecord(sinkRecord(2), client);
     writeRecord(sinkRecord(1), client);
     client.flush();
+  }
+
+  /**
+   * If the record version is set to VersionType.EXTERNAL (normal case for non-streaming),
+   * then same or less version number will throw a version conflict exception.
+   * @throws Exception will be thrown if the test fails
+   */
+  @Test
+  public void testExternalVersionConflictReporterNotCalled() throws Exception {
+    props.put(IGNORE_KEY_CONFIG, "false");
+    // Suppress asynchronous operations
+    props.put(MAX_IN_FLIGHT_REQUESTS_CONFIG, "1");
+    config = new ElasticsearchSinkConnectorConfig(props);
+    converter = new DataConverter(config);
+
+    ErrantRecordReporter reporter = mock(ErrantRecordReporter.class);
+    ElasticsearchClient client = new ElasticsearchClient(config, reporter);
+
+    causeExternalVersionConflictError(client);
 
     // Make sure that no error was reported for either offset [1, 2] record(s)
     verify(reporter, never()).report(eq(sinkRecord(1)), any(Throwable.class));
     verify(reporter, never()).report(eq(sinkRecord(2)), any(Throwable.class));
+    client.close();
+  }
+
+  /**
+   * If the record version is set to VersionType.INTERNAL (normal case streaming/logging),
+   * then same or less version number will throw a version conflict exception.
+   * In this test, we are checking that the client function `handleResponse`
+   * properly reports an error for seeing the version conflict error along with
+   * VersionType of INTERNAL.  We still actually cause the error via an external
+   * version conflict error, but flip the version type to internal before it is interpreted.
+   * @throws Exception will be thrown if the test fails
+   */
+  @Test
+  public void testHandleResponseInternalVersionConflictReporterCalled() throws Exception {
+    props.put(IGNORE_KEY_CONFIG, "false");
+    // Suppress asynchronous operations
+    props.put(MAX_IN_FLIGHT_REQUESTS_CONFIG, "1");
+    config = new ElasticsearchSinkConnectorConfig(props);
+    converter = new DataConverter(config);
+
+    ErrantRecordReporter reporter = mock(ErrantRecordReporter.class);
+
+    // We will cause a version conflict error, but test that handleResponse()
+    // correctly reports the error when it interprets the version conflict as
+    // "INTERNAL" (version maintained by Elasticsearch) rather than
+    // "EXTERNAL" (version maintained by the connector as kafka offset)
+    ElasticsearchClient client = new ElasticsearchClient(config, reporter) {
+      protected void handleResponse(BulkItemResponse response, DocWriteRequest<?> request,
+                                    long executionId) {
+        // Make it think it was an internal version conflict.
+        // Note that we don't make any attempt to reset the response version number,
+        // which will be -1 here.
+        request.versionType(VersionType.INTERNAL);
+        super.handleResponse(response, request, executionId);
+      }
+    };
+
+    causeExternalVersionConflictError(client);
+
+    // Make sure that no error was reported for either offset [1, 2] record(s)
+    verify(reporter, times(1)).report(eq(sinkRecord(1)), any(Throwable.class));
+    verify(reporter, times(1)).report(eq(sinkRecord(2)), any(Throwable.class));
     client.close();
   }
 

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
@@ -544,6 +544,8 @@ public class ElasticsearchClientTest {
   public void testNoVersionConflict() throws Exception {
     props.put(IGNORE_KEY_CONFIG, "false");
     props.put(WRITE_METHOD_CONFIG, WriteMethod.UPSERT.name());
+    // Suppress asynchronous operations
+    props.put(MAX_IN_FLIGHT_REQUESTS_CONFIG, 1);
     config = new ElasticsearchSinkConnectorConfig(props);
     converter = new DataConverter(config);
 

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
@@ -505,6 +505,41 @@ public class ElasticsearchClientTest {
     client.close();
   }
 
+  /**
+   * If the record version is set to VersionType.EXTERNAL (normal case for non-streaming),
+   * then same or less
+   * @throws Exception will be thrown if the test fails
+   */
+  @Test
+  public void testExternalVersionConflictReporterNotCalled() throws Exception {
+    props.put(IGNORE_KEY_CONFIG, "true");
+    config = new ElasticsearchSinkConnectorConfig(props);
+    converter = new DataConverter(config);
+
+    ErrantRecordReporter reporter = mock(ErrantRecordReporter.class);
+    ElasticsearchClient client = new ElasticsearchClient(config, reporter);
+    client.createIndex(INDEX);
+
+    // Sequentially increase out record version (which comes from the offset)
+    writeRecord(sinkRecord("key0", 0), client);
+    writeRecord(sinkRecord("key0", 1), client);
+    writeRecord(sinkRecord("key0", 2), client);
+    client.flush();
+
+    // At the end of the day, it's just one record being overwritten
+    waitUntilRecordsInES(3);
+
+    // Now duplcate the last and then the one before that
+    writeRecord(sinkRecord("key0", 2), client);
+    writeRecord(sinkRecord("key0", 1), client);
+    client.flush();
+
+    // Make sure that no error was reported for either offset [1, 2] record(s)
+    verify(reporter, never()).report(eq(sinkRecord(1)), any(Throwable.class));
+    verify(reporter, never()).report(eq(sinkRecord(2)), any(Throwable.class));
+    client.close();
+  }
+
   @Test
   public void testNoVersionConflict() throws Exception {
     props.put(IGNORE_KEY_CONFIG, "false");

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
@@ -592,7 +592,7 @@ public class ElasticsearchClientTest {
 
     causeExternalVersionConflictError(client);
 
-    // Make sure that no error was reported for either offset [1, 2] record(s)
+    // Make sure that error was reported for either offset [1, 2] record(s)
     verify(reporter, times(1)).report(eq(sinkRecord(1)), any(Throwable.class));
     verify(reporter, times(1)).report(eq(sinkRecord(2)), any(Throwable.class));
     client.close();


### PR DESCRIPTION
## Problem
Resent or out-of-order records for a given topic who have their versions set externally by the ES connector to the topic offset of the message are generating warnings and being added to the DLQ.  This isn't desired because the nature of the offset mismatch dictates that the record is obsolete anyway and may simply being resent when connect is restarted (which is the case which was seen and reproduced).

## Solution
For externally-versioned topic records, simply log to debug log and do not send to DLQ.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
Reproduction via rolling back offset to zero and bringing connect back up, in which case, topics will be resent with "old" versions, which are <= the version in ES.  dlq topic record s are generated.
After change, no dlq topic records are generated.
This re-send of "old" topic record versions are simulated in the added unit test.

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
Merge to 11.1.x, 12.x, master.  There will be an extra test in >= 11.1.x
<!-- Are you backporting or merging to master? -->
Backporting to 11.0.x and then will ping merge to higher versions and finally master
<!-- If you are reverting or rolling back, is it safe? --> 
N/A