### PR TITLE
Add logic check seen in 11.1.x IT for # responses > # requests

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
@@ -352,7 +352,8 @@ public class ElasticsearchClient {
         List<DocWriteRequest<?>> requests = request.requests();
         int idx = 0;
         for (BulkItemResponse bulkItemResponse : response) {
-          handleResponse(bulkItemResponse, requests.get(idx), executionId);
+          DocWriteRequest<?> req = idx < requests.size() ? requests.get(idx) : null;
+          handleResponse(bulkItemResponse, req, executionId);
           idx++;
         }
         removeFromInFlightRequests(executionId);
@@ -434,10 +435,10 @@ public class ElasticsearchClient {
         // the version conflict is due to a repeated or out-of-order message offset
         // and thus can be ignored, since the newer value (higher offset) should
         // remain the key's value in any case.
-        if (request.versionType() != VersionType.EXTERNAL) {
+        if (request == null || request.versionType() != VersionType.EXTERNAL) {
           log.warn("{} version conflict for operation {} on document '{}' version {}"
                           + " in index '{}'.",
-                  request.versionType(),
+                  request != null ? request.versionType() : "UNKNOWN",
                   response.getOpType(),
                   response.getId(),
                   response.getVersion(),


### PR DESCRIPTION
## Problem

It was seen in a couple of 11.1.x integration tests that # responses can be larger than # requetss.  This check already exists in the 11.1.x codebase, so backported this "idx" logic to 11.0.x.  

I looked into trying to bring in the IT from 11.1.x, but it would pull in a lot of other changes, which seemed too drastic, since the logic change in this PR is isolated.

## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
