### PR TITLE
Bump up the log4j dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,12 +83,6 @@
             <groupId>org.elasticsearch</groupId>
             <artifactId>elasticsearch</artifactId>
             <version>${es.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.logging.log4j</groupId>
-                    <artifactId>log4j-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.15.0</version>
+        </dependency>
         <!-- pin jackson-dataformat-cbor for CVE - the version comes from confluentinc/common -->
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,12 @@
             <groupId>org.elasticsearch</groupId>
             <artifactId>elasticsearch</artifactId>
             <version>${es.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- pin jackson-dataformat-cbor for CVE - the version comes from confluentinc/common -->
         <dependency>


### PR DESCRIPTION
## Problem
Security team uncovered a vulnerability for log4j v2.14.0 (RCCA-5119). versions 2.15.0 or more are good to use.
The log4j dependency is coming as transitive dependency from `org.elasticsearch:elasticsearch`.

## Solution
Overridden the log4j dependency coming from `org.elasticsearch:elasticsearch` by explicitly adding v2.15.0.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
