### PR TITLE
CCMSG-1548 - Update log4j to 2.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.15.0</version>
+            <version>2.16.0</version>
         </dependency>
         <!-- pin jackson-dataformat-cbor for CVE - the version comes from confluentinc/common -->
         <dependency>


### PR DESCRIPTION
## Problem

https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45046

## Solution

Update log4j to 2.16.0.
Similar to https://github.com/confluentinc/kafka-connect-elasticsearch/pull/604

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan

Release a new 11.1.x
Backwards compatible.