### PR TITLE
Add link to Changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Kafka Connect Elasticsearch Connector
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fconfluentinc%2Fkafka-connect-elasticsearch.svg?type=shield)](https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fconfluentinc%2Fkafka-connect-elasticsearch?ref=badge_shield)
 
+Changelog for this connector can be found [here](https://docs.confluent.io/kafka-connect-elasticsearch/current/changelog.html).
 
 kafka-connect-elasticsearch is a [Kafka Connector](http://kafka.apache.org/documentation.html#connect)
 for copying data between Kafka and Elasticsearch.


### PR DESCRIPTION
## Problem
The log has lots of maven-release-plugin and Jenkins automatically generated commits. This makes it difficult to understand or communicate the history of real changes.

## Solution
There is a Changelog on the Confluent website. This adds a link to the existing Changelog.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

## Test Strategy
Click on the link.

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Manual tests