### PR TITLE
added traces to DataStreamType enum

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -377,6 +377,7 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   public enum DataStreamType {
     LOGS,
     METRICS,
+    TRACES,
     NONE
   }
 


### PR DESCRIPTION
## Problem

There is no support for data stream type 'Traces' within the stream name format
## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [x] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
