### PR TITLE
Added Spans to  DataStreamType

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -377,6 +377,7 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   public enum DataStreamType {
     LOGS,
     METRICS,
+    SPANS,
     NONE
   }
 


### PR DESCRIPTION
## Problem

As traces are common data type in the field of observability / telemetric data, it must be added as data type. The main use case is spans from Open Telemetry source Kafka topic.
Just for the general knowledge, a trace is a collection of operations that represents a unique transaction handled by an application and its constituent services. A span is a single operation within a trace, so Span is the building block of a tracing platform.

## Solution

Enable Spans in the DataStreamType Enum



<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [x] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
