### PR TITLE
CCMSG-1612: Update ElasticSearch client to 7.15.2 with associated fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,10 +5,9 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>6.0.3</version>
+        <version>6.1.4</version>
     </parent>
 
-    <groupId>io.confluent</groupId>
     <artifactId>kafka-connect-elasticsearch</artifactId>
     <version>12.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
@@ -41,15 +40,15 @@
         <es.version>7.15.2</es.version>
         <hamcrest.version>1.3</hamcrest.version>
         <mockito.version>2.28.2</mockito.version>
-        <gson.version>2.8.6</gson.version>
-        <test.containers.version>1.15.0</test.containers.version>
+        <gson.version>2.9.0</gson.version>
+        <test.containers.version>1.16.3</test.containers.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
-        <hadoop.version>3.3.0</hadoop.version>
+        <hadoop.version>3.3.1</hadoop.version>
         <apacheds-jdbm1.version>2.0.0-M2</apacheds-jdbm1.version>
         <jackson.databind.version>2.10.5.1</jackson.databind.version>
         <!-- temporary fix by pinning the version until we upgrade to a version of common that contains this or newer version.
-            See https://github.com/confluentinc/common/pull/332 for details -->
+            See https://github.com/confluentinc/common/pull/332 for details (common-parent 7.0.0-0) -->
         <dependency.check.version>6.1.6</dependency.check.version>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
         <commons.codec.version>1.15</commons.codec.version>
@@ -149,13 +148,17 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.hamcrest</groupId>
                     <artifactId>hamcrest-core</artifactId>
                 </exclusion>
             </exclusions>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     </scm>
 
     <properties>
-        <es.version>7.9.3</es.version>
+        <es.version>7.15.2</es.version>
         <hamcrest.version>1.3</hamcrest.version>
         <mockito.version>2.28.2</mockito.version>
         <gson.version>2.8.6</gson.version>

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
@@ -59,7 +59,7 @@ import org.elasticsearch.client.indices.GetMappingsRequest;
 import org.elasticsearch.client.indices.GetMappingsResponse;
 import org.elasticsearch.client.indices.PutMappingRequest;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
-import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.VersionType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -114,6 +114,7 @@ public class ElasticsearchClient {
   private final Lock inFlightRequestLock = new ReentrantLock();
   private final Condition inFlightRequestsUpdated = inFlightRequestLock.newCondition();
 
+  @SuppressWarnings("deprecation")
   public ElasticsearchClient(
       ElasticsearchSinkConnectorConfig config,
       ErrantRecordReporter reporter,

--- a/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticSearchMockUtil.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticSearchMockUtil.java
@@ -1,0 +1,105 @@
+package io.confluent.connect.elasticsearch.helper;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import org.apache.kafka.connect.errors.ConnectException;
+
+import java.io.IOException;
+
+import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
+
+/**
+ * Some utility functions to help mocking ElasticSearch via WireMock
+ */
+public class ElasticSearchMockUtil {
+  public static final ObjectMapper MAPPER = new ObjectMapper();
+
+  /**
+   * Add standard ElasticSearch version info to a JSON object
+   * @param response The json object (usually a response) to
+   *                 which to add the version info
+   * @return The update JSON object node
+   */
+  static public ObjectNode addStandardVersionInfo(ObjectNode response) {
+    // Note that "version.number" is somewhat arbitrary for our testing purposes,
+    // although for some version (i.e. [7.0,7.14]) it checks for other fields,
+    // so the mock might fail in that case.
+    response.put("name", "KafkaESClusterNodeold_1")
+        .put("cluster_name", "KafkaESCluster")
+        .put("cluster_uuid", "83EJmDNrRVirBWcZDgs9ew")
+        .put("tagline", "You Know, for Search")
+        .putObject("version")
+        .put("number", "7.15.2")
+        .put("build_hash", "83EJmDNrRVirBWcZDgs9ew")
+        .put("build_date", "2018-04-12T16:25:14.838Z")
+        .put("build_snapshot", "false")
+        .put("lucene_version", "6.6.1")
+        .put("minimum_wire_compatibility_version", "1.1.1")
+        .put("minimum_index_compatibility_version", "2.2.2");
+    return response;
+  }
+
+  /**
+   * Add the minimal response headers required by ElasticSearch client
+   * @param builder The response builder for WireMock
+   * @return Updated ResponseBuilder
+   */
+  static public ResponseDefinitionBuilder addMinimalHeaders(ResponseDefinitionBuilder builder) {
+    // Now header [X-Elastic-Product]
+    return builder
+        .withHeader("X-Elastic-Product", "Elasticsearch")
+        .withHeader(CONTENT_TYPE, "application/json");
+  }
+
+  /**
+   * Add standard ElasticSearch version info to a JSON string
+   * @param jsonText String serialization of a json object
+   * @return The string updated with insertion of the version information
+   *         at the top level of the Json text, re-serialized to text.
+   */
+  static public String addStandardVersionInfo(String jsonText) {
+    try {
+      JsonParser parser = MAPPER.getFactory().createParser(jsonText);
+      JsonNode node = MAPPER.readTree(parser);
+      ObjectNode objectNode = node.deepCopy();
+      return MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(
+          addStandardVersionInfo(objectNode)
+      );
+    } catch (IOException e) {
+      throw new ConnectException("Could not parse JSON text: \"" + jsonText + "\"");
+    }
+  }
+
+  /**
+   * A standard "empty" response from ElasticSearch which includes the required version
+   * information in the json body.
+   * @return The minimum-allowable response from ElasticSearch for responses to calls such
+   *         as "ping"
+   */
+  public static String minimumResponseJson() {
+    try {
+      return MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(
+          addStandardVersionInfo(MAPPER.createObjectNode())
+      );
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(
+          "Error writing default output json to string: " + e.getMessage(), e
+      );
+    }
+  }
+
+  /**
+   * Convenience drop-in replacement for static import of WireMock.ok()
+   * @return ResponseDefinitionBuilder necessary for a valid "OK" response from
+   *         ElasticSearch.
+   */
+  public static ResponseDefinitionBuilder basicEmptyOk() {
+    return addMinimalHeaders(WireMock.ok().withBody(minimumResponseJson()));
+  }
+
+}

--- a/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticSearchMockUtil.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticSearchMockUtil.java
@@ -1,15 +1,10 @@
 package io.confluent.connect.elasticsearch.helper;
 
-import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.client.WireMock;
-import org.apache.kafka.connect.errors.ConnectException;
-
-import java.io.IOException;
 
 import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
 
@@ -54,25 +49,6 @@ public class ElasticSearchMockUtil {
     return builder
         .withHeader("X-Elastic-Product", "Elasticsearch")
         .withHeader(CONTENT_TYPE, "application/json");
-  }
-
-  /**
-   * Add standard ElasticSearch version info to a JSON string
-   * @param jsonText String serialization of a json object
-   * @return The string updated with insertion of the version information
-   *         at the top level of the Json text, re-serialized to text.
-   */
-  static public String addStandardVersionInfo(String jsonText) {
-    try {
-      JsonParser parser = MAPPER.getFactory().createParser(jsonText);
-      JsonNode node = MAPPER.readTree(parser);
-      ObjectNode objectNode = node.deepCopy();
-      return MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(
-          addStandardVersionInfo(objectNode)
-      );
-    } catch (IOException e) {
-      throw new ConnectException("Could not parse JSON text: \"" + jsonText + "\"");
-    }
   }
 
   /**

--- a/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchContainer.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchContainer.java
@@ -67,7 +67,7 @@ public class ElasticsearchContainer
   /**
    * Default Elasticsearch version.
    */
-  public static final String DEFAULT_ES_VERSION = "7.9.3";
+  public static final String DEFAULT_ES_VERSION = "7.15.2";
 
   /**
    * Default Elasticsearch port.
@@ -355,6 +355,9 @@ public class ElasticsearchContainer
       builder
           .copy("instances.yml", CONFIG_SSL_PATH + "/instances.yml")
           .copy("start-elasticsearch.sh", CONFIG_SSL_PATH + "/start-elasticsearch.sh")
+          // On the 7.15.2 ElasticSearch container, yum is not working by default, so enable it
+          .run("sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*")
+          .run("sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*")
           // OpenSSL and Java's Keytool used to generate the certs, so install them
           .run("yum -y install openssl")
           .run("chmod +x " + CONFIG_SSL_PATH + "/start-elasticsearch.sh")

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorBaseIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorBaseIT.java
@@ -250,13 +250,14 @@ public class ElasticsearchConnectorBaseIT extends BaseConnectorIT {
         .indices("*")
         .privileges("create_index", "read", "write", "view_index_metadata")
         .build();
-    Builder builder = Role.builder();
-    builder = forDataStream ? builder.clusterPrivileges("monitor") : builder;
-    Role role = builder
+    // Historically (i.e. ES the previous test base version 7.9.3), ES_SINK_CONNECTOR_ROLE would not require the
+    // "monitor" cluster privilege.  However, this has changed for 7.15.2, although leaving the surrounding
+    // logic in place in the case that future ES versions or tests wish to diverge the permissions.
+    return Role.builder()
         .name(forDataStream ? ES_SINK_CONNECTOR_DS_ROLE : ES_SINK_CONNECTOR_ROLE)
         .indicesPrivileges(indicesPrivileges)
+        .clusterPrivileges("monitor")
         .build();
-    return role;
   }
 
   private static User getMinimalPrivilegesUser(boolean forDataStream) {

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorIT.java
@@ -284,6 +284,21 @@ public class ElasticsearchConnectorIT extends ElasticsearchConnectorBaseIT {
   }
 
   @Test
+  public void testBackwardsCompatibilityDataStream2() throws Exception {
+    container.close();
+    container = ElasticsearchContainer.withESVersion("7.9.3");
+    container.start();
+    setupFromContainer();
+
+    runSimpleTest(props);
+
+    helperClient = null;
+    container.close();
+    container = ElasticsearchContainer.fromSystemProperties();
+    container.start();
+  }
+
+  @Test
   public void testRoutingSmtSynchronousMode() throws Exception {
     index = addRoutingSmt("YYYYMM", "route-it-to-here-${topic}-at-${timestamp}");
     props.put(FLUSH_SYNCHRONOUSLY_CONFIG, "true");

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorKerberosIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorKerberosIT.java
@@ -24,7 +24,6 @@ public class ElasticsearchConnectorKerberosIT extends ElasticsearchConnectorBase
 
   private static File baseDir;
   private static MiniKdc kdc;
-  private static String esPrincipal;
   protected static String esKeytab;
   private static String userPrincipal;
   private static String userKeytab;
@@ -67,7 +66,6 @@ public class ElasticsearchConnectorKerberosIT extends ElasticsearchConnectorBase
     File keytabFile = new File(baseDir, es + ".keytab");
     esKeytab = keytabFile.getAbsolutePath();
     kdc.createPrincipal(keytabFile, es + "/localhost", "HTTP/localhost");
-    esPrincipal = es + "/localhost@" + kdc.getRealm();
 
     String user = "connect-es";
     keytabFile = new File(baseDir, user + ".keytab");

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchSinkTaskIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchSinkTaskIT.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.stream.IntStream;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
@@ -53,7 +54,6 @@ import io.confluent.connect.elasticsearch.ElasticsearchSinkTask;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.any;
 import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
-import static com.github.tomakehurst.wiremock.client.WireMock.ok;
 import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
@@ -70,9 +70,7 @@ import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfi
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.WRITE_METHOD_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.WriteMethod;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.*;
-import static io.confluent.connect.elasticsearch.integration.ElasticsearchConnectorNetworkIT.errorBulkResponse;
-import static java.util.stream.Collectors.toList;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.*;
+import static io.confluent.connect.elasticsearch.helper.ElasticSearchMockUtil.basicEmptyOk;
 import static io.confluent.connect.elasticsearch.integration.ElasticsearchConnectorNetworkIT.errorBulkResponse;
 import static java.util.stream.Collectors.toList;
 import static org.apache.kafka.connect.json.JsonConverterConfig.SCHEMAS_ENABLE_CONFIG;
@@ -114,6 +112,11 @@ public class ElasticsearchSinkTaskIT {
     this.synchronousFlush = synchronousFlush;
   }
 
+  // Convenience drop-in replacement for static import of WireMock.ok()
+  private static ResponseDefinitionBuilder ok() {
+    return basicEmptyOk();
+  }
+
   @Before
   public void setup() {
     stubFor(any(anyUrl()).atPriority(10).willReturn(ok()));
@@ -121,6 +124,8 @@ public class ElasticsearchSinkTaskIT {
 
   @Test
   public void testOffsetCommit() {
+    wireMockRule.stubFor(post(urlPathEqualTo("/"))
+        .willReturn(ok().withFixedDelay(10_000)));
     wireMockRule.stubFor(post(urlPathEqualTo("/_bulk"))
             .willReturn(ok().withFixedDelay(60_000)));
 


### PR DESCRIPTION
## Problem

ElasticSearch client < 7.14.0 have vulnerabilities (CVE).

## Solution

Upgrade client to 7.15.2 ("oldest" branch tag >= 7.14.0 still on elasticsearch-java repo).

This is intentionally cut against master, which we can cut a new 13.0.x branch.

Changes to the backing elasticsearch client are nontrivial and we may want to let it "bake" in a new version (13.0.x) before backporting.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
