### PR TITLE
FIX: Invalid configs can lead to validation throwing a 500 error. 

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/Validator.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/Validator.java
@@ -117,9 +117,9 @@ public class Validator {
       } catch (IOException e) {
         log.warn("Closing the client failed.", e);
       } catch (Throwable e) {
-        log.error("Validation failed ", e);
+        log.error("Failed to create client to verify connection. ", e);
         addErrorMessage(CONNECTION_URL_CONFIG, "Failed to create client to verify connection. "
-            + "Error: " + e.getMessage());
+            + e.getMessage());
       }
     }
 

--- a/src/main/java/io/confluent/connect/elasticsearch/Validator.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/Validator.java
@@ -100,25 +100,27 @@ public class Validator {
       return new Config(validations);
     }
 
-    try (RestHighLevelClient client = clientFactory.client()) {
-      validateCredentials();
-      validateDataStreamConfigs();
-      validateIgnoreConfigs();
-      validateKerberos();
-      validateLingerMs();
-      validateMaxBufferedRecords();
-      validateProxy();
-      validateSsl();
+    validateCredentials();
+    validateDataStreamConfigs();
+    validateIgnoreConfigs();
+    validateKerberos();
+    validateLingerMs();
+    validateMaxBufferedRecords();
+    validateProxy();
+    validateSsl();
 
-      if (!hasErrors()) {
-        // no point if previous configs are invalid
+    if (!hasErrors()) {
+      // no point in connection validation if previous ones fails
+      try (RestHighLevelClient client = clientFactory.client()) {
         validateConnection(client);
-      }
-      if (!hasErrors()) {
         validateVersion(client);
+      } catch (IOException e) {
+        log.warn("Closing the client failed.", e);
+      } catch (Throwable e) {
+        log.error("Validation failed ", e);
+        addErrorMessage(CONNECTION_URL_CONFIG, "Failed to create client to verify connection. "
+            + "Error: " + e.getMessage());
       }
-    } catch (IOException e) {
-      log.warn("Closing the client failed.", e);
     }
 
     return new Config(validations);


### PR DESCRIPTION
## Problem
The `ConfigCallbackHandler` has a set of initialisation steps in `customizeHttpClient` which uses some of the configs. If any of the configs are incorrect It will bubble up an uncaught exception in the validator while creating the `HighLevelRestClient`, which internally initialises the handler. The validation will fail with an internal server error. Example
```
{"error_code":500,"message":"Failed to load SSL keystore  of type JKS"}
```
Although the error message is returned this should ideally have the correct response code and proper formatted output.
```
{"error_code":400,"message":"Connector configuration is invalid and contains the following 1 error(s):\nFailed to create client to verify connection. Error: Failed to load SSL keystore  of type JKS\nYou can also find the above list of errors at the endpoint `/connector-plugins/{connectorType}/config/validate`"}
```

## Solution
Capture any exceptions thrown while creating the client and return a proper exception to the user while simultaneously logging the stack trace. 

Also I have moved some of the validation that do not require the client to be initialised out of the client creation try catch block .

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
