### PR TITLE
FIX(cherry-pick): Invalid configs can lead to validation throwing a 500 error.

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/Validator.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/Validator.java
@@ -117,9 +117,9 @@ public class Validator {
       } catch (IOException e) {
         log.warn("Closing the client failed.", e);
       } catch (Throwable e) {
-        log.error("Validation failed ", e);
+        log.error("Failed to create client to verify connection. ", e);
         addErrorMessage(CONNECTION_URL_CONFIG, "Failed to create client to verify connection. "
-            + "Error: " + e.getMessage());
+            + e.getMessage());
       }
     }
 

--- a/src/main/java/io/confluent/connect/elasticsearch/Validator.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/Validator.java
@@ -100,25 +100,27 @@ public class Validator {
       return new Config(validations);
     }
 
-    try (RestHighLevelClient client = clientFactory.client()) {
-      validateCredentials();
-      validateDataStreamConfigs();
-      validateIgnoreConfigs();
-      validateKerberos();
-      validateLingerMs();
-      validateMaxBufferedRecords();
-      validateProxy();
-      validateSsl();
+    validateCredentials();
+    validateDataStreamConfigs();
+    validateIgnoreConfigs();
+    validateKerberos();
+    validateLingerMs();
+    validateMaxBufferedRecords();
+    validateProxy();
+    validateSsl();
 
-      if (!hasErrors()) {
-        // no point if previous configs are invalid
+    if (!hasErrors()) {
+      // no point in connection validation if previous ones fails
+      try (RestHighLevelClient client = clientFactory.client()) {
         validateConnection(client);
-      }
-      if (!hasErrors()) {
         validateVersion(client);
+      } catch (IOException e) {
+        log.warn("Closing the client failed.", e);
+      } catch (Throwable e) {
+        log.error("Validation failed ", e);
+        addErrorMessage(CONNECTION_URL_CONFIG, "Failed to create client to verify connection. "
+            + "Error: " + e.getMessage());
       }
-    } catch (IOException e) {
-      log.warn("Closing the client failed.", e);
     }
 
     return new Config(validations);


### PR DESCRIPTION
Cherry pick https://github.com/confluentinc/kafka-connect-elasticsearch/pull/626 to 11.1.x.


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
