### PR TITLE
feat: added version.ignore field

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -264,6 +264,15 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   private static final String WRITE_METHOD_DISPLAY = "Write Method";
   private static final String WRITE_METHOD_DEFAULT = WriteMethod.INSERT.name();
 
+  public static final String IGNORE_VERSION_CONFIG = "version.ignore";
+  private static final String IGNORE_VERSION_DOC =
+      "Whether to use kafka record offset as Elasticsearch document EXTERNAL version."
+          + " When this is set to ``true``, kafka records with offset lower than previously"
+          + " indexed will overwrite the document. When set to ``false``, the kafka record with"
+          + " offset lower than one previously indexed will be ignored.";
+  private static final String IGNORE_VERSION_DISPLAY = "Ignore Version mode";
+  private static final boolean IGNORE_VERSION_DEFAULT = false;
+
   // Proxy group
   public static final String PROXY_HOST_CONFIG = "proxy.host";
   private static final String PROXY_HOST_DISPLAY = "Proxy Host";
@@ -678,6 +687,16 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
             Width.SHORT,
             WRITE_METHOD_DISPLAY,
             new EnumRecommender<>(WriteMethod.class)
+        ).define(
+            IGNORE_VERSION_CONFIG,
+            Type.BOOLEAN,
+            IGNORE_VERSION_DEFAULT,
+            Importance.LOW,
+            IGNORE_VERSION_DOC,
+            DATA_CONVERSION_GROUP,
+            ++order,
+            Width.SHORT,
+            IGNORE_VERSION_DISPLAY
     );
   }
 
@@ -1009,6 +1028,10 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
 
   public WriteMethod writeMethod() {
     return WriteMethod.valueOf(getString(WRITE_METHOD_CONFIG).toUpperCase());
+  }
+
+  public boolean shouldIgnoreVersion() {
+    return getBoolean(IGNORE_VERSION_CONFIG);
   }
 
   private static class DataStreamDatasetValidator implements Validator {


### PR DESCRIPTION
## Problem
Should be able to control if `INTERNAL` version is used for requests when `key.ignore` is set to false. The general scenario is duplicate records being indexed and the worst case scenario is out-of-order messages being indexed which is not as likely.

## Solution
Created `version.ignore` config.
true -> `INTERNAL`
false -> `EXTERNAL`

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy
Testing if INTERNAL version is used for `version.ignore` set to true and also check if any error is thrown with duplicate messages.

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
