### PR TITLE
CCMSG-1958: Elasticsearch 8 support through compatibility mode.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,11 @@
             <artifactId>snakeyaml</artifactId>
             <version>1.27</version>
         </dependency>
+        <dependency>
+            <groupId>co.elastic.clients</groupId>
+            <artifactId>elasticsearch-java</artifactId>
+            <version>8.2.2</version>
+        </dependency>
         <!-- pin httpclient for CVE -->
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     </scm>
 
     <properties>
-        <es.version>7.16.3</es.version>
+        <es.version>7.17.3</es.version>
         <hamcrest.version>1.3</hamcrest.version>
         <mockito.version>2.28.2</mockito.version>
         <gson.version>2.9.0</gson.version>

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
@@ -148,7 +148,7 @@ public class ElasticsearchClient {
     RestHighLevelClientBuilder clientBuilder = new RestHighLevelClientBuilder(client);
 
     if (shouldSetCompatibilityToES8()) {
-      log.info("Staring client in es 8 compatibility mode");
+      log.info("Staring client in ES 8 compatibility mode");
       clientBuilder.setApiCompatibilityMode(true);
     }
 

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
@@ -173,7 +173,7 @@ public class ElasticsearchClient {
    */
   private boolean shouldSetCompatibilityToES8() {
     return !version().equals(UNKNOWN_VERSION_TAG) &&
-        Integer.parseInt(version().split("\\.", 1)[0]) >= 8;
+        Integer.parseInt(version().split("\\.")[0]) >= 8;
   }
 
   private String getServerVersion(RestClient client) {

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
@@ -52,6 +52,7 @@ import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.RestHighLevelClientBuilder;
 import org.elasticsearch.client.indices.CreateDataStreamRequest;
 import org.elasticsearch.client.indices.CreateIndexRequest;
 import org.elasticsearch.client.indices.GetIndexRequest;
@@ -130,17 +131,16 @@ public class ElasticsearchClient {
     this.clock = Time.SYSTEM;
 
     ConfigCallbackHandler configCallbackHandler = new ConfigCallbackHandler(config);
-    this.client = new RestHighLevelClient(
-        RestClient
-            .builder(
-                config.connectionUrls()
-                    .stream()
-                    .map(HttpHost::create)
-                    .collect(toList())
-                    .toArray(new HttpHost[config.connectionUrls().size()])
-            )
-            .setHttpClientConfigCallback(configCallbackHandler)
-    );
+    RestClient client = RestClient
+        .builder(
+            config.connectionUrls()
+                .stream()
+                .map(HttpHost::create)
+                .collect(toList())
+                .toArray(new HttpHost[config.connectionUrls().size()])
+        ).setHttpClientConfigCallback(configCallbackHandler).build();
+    this.client = new RestHighLevelClientBuilder(client).setApiCompatibilityMode(true).build();
+
     this.bulkProcessor = BulkProcessor
         .builder(buildConsumer(), buildListener(afterBulkCallback))
         .setBulkActions(config.batchSize())

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
@@ -148,6 +148,7 @@ public class ElasticsearchClient {
     RestHighLevelClientBuilder clientBuilder = new RestHighLevelClientBuilder(client);
 
     if (shouldSetCompatibilityToES8()) {
+      log.info("Staring client in es 8 compatibility mode");
       clientBuilder.setApiCompatibilityMode(true);
     }
 
@@ -179,7 +180,7 @@ public class ElasticsearchClient {
   private String getServerVersion(RestClient client) {
     RestHighLevelClient highLevelClient = new RestHighLevelClientBuilder(client).build();
     MainResponse response;
-    String esVersionNumber = "Unknown";
+    String esVersionNumber = UNKNOWN_VERSION_TAG;
     try {
       response = highLevelClient.info(RequestOptions.DEFAULT);
       esVersionNumber = response.getVersion().getNumber();
@@ -188,12 +189,6 @@ public class ElasticsearchClient {
       // Insufficient privileges to validate the version number if caught
       // ElasticsearchStatusException.
       log.warn("Failed to get ES server version", e);
-    } finally {
-      try {
-        highLevelClient.close();
-      } catch (Exception e) {
-        log.warn("Failed to close high level client", e);
-      }
     }
     return esVersionNumber;
   }

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
@@ -173,8 +173,8 @@ public class ElasticsearchClient {
    * HLRC 7.17 to talk to ES.
    */
   private boolean shouldSetCompatibilityToES8() {
-    return !version().equals(UNKNOWN_VERSION_TAG) &&
-        Integer.parseInt(version().split("\\.")[0]) >= 8;
+    return !version().equals(UNKNOWN_VERSION_TAG)
+        && Integer.parseInt(version().split("\\.")[0]) >= 8;
   }
 
   private String getServerVersion(RestClient client) {
@@ -281,6 +281,7 @@ public class ElasticsearchClient {
   public String version() {
     return esVersion;
   }
+
   /**
    * Triggers a flush of any buffered records.
    */

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -20,9 +20,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BooleanSupplier;
-import java.util.stream.Collectors;
 
-import org.apache.http.HttpHost;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.errors.ConnectException;
@@ -32,10 +30,6 @@ import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTask;
 import org.apache.kafka.connect.sink.SinkTaskContext;
 import org.elasticsearch.action.DocWriteRequest;
-import org.elasticsearch.client.RequestOptions;
-import org.elasticsearch.client.RestClient;
-import org.elasticsearch.client.RestHighLevelClient;
-import org.elasticsearch.client.core.MainResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -95,7 +95,7 @@ public class ElasticsearchSinkTask extends SinkTask {
     }
 
     log.info("Started ElasticsearchSinkTask. Connecting to ES server version: {}",
-        getServerVersion());
+        this.client.version());
   }
 
   @Override
@@ -153,39 +153,6 @@ public class ElasticsearchSinkTask extends SinkTask {
       log.debug("Caching mapping for index '{}' locally.", index);
       existingMappings.add(index);
     }
-  }
-
-  private String getServerVersion() {
-    ConfigCallbackHandler configCallbackHandler = new ConfigCallbackHandler(config);
-    RestHighLevelClient highLevelClient = new RestHighLevelClient(
-        RestClient
-            .builder(
-                config.connectionUrls()
-                    .stream()
-                    .map(HttpHost::create)
-                    .collect(Collectors.toList())
-                    .toArray(new HttpHost[config.connectionUrls().size()])
-            )
-            .setHttpClientConfigCallback(configCallbackHandler)
-    );
-    MainResponse response;
-    String esVersionNumber = "Unknown";
-    try {
-      response = highLevelClient.info(RequestOptions.DEFAULT);
-      esVersionNumber = response.getVersion().getNumber();
-    } catch (Exception e) {
-      // Same error messages as from validating the connection for IOException.
-      // Insufficient privileges to validate the version number if caught
-      // ElasticsearchStatusException.
-      log.warn("Failed to get ES server version", e);
-    } finally {
-      try {
-        highLevelClient.close();
-      } catch (Exception e) {
-        log.warn("Failed to close high level client", e);
-      }
-    }
-    return esVersionNumber;
   }
 
   /**

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
@@ -116,7 +116,9 @@ public class ElasticsearchClientTest {
     props.put(LINGER_MS_CONFIG, "1000");
     config = new ElasticsearchSinkConnectorConfig(props);
     converter = new DataConverter(config);
-    helperClient = new ElasticsearchHelperClient(container.getConnectionUrl(), config);
+    helperClient = new ElasticsearchHelperClient(container.getConnectionUrl(), config,
+        container.shouldStartClientInCompatibilityMode());
+    helperClient.waitForConnection(30000);
     offsetTracker = mock(OffsetTracker.class);
   }
 
@@ -711,7 +713,8 @@ public class ElasticsearchClientTest {
     converter = new DataConverter(config);
 
     ElasticsearchClient client = new ElasticsearchClient(config, null, () -> offsetTracker.updateOffsets());
-    helperClient = new ElasticsearchHelperClient(address, config);
+    helperClient = new ElasticsearchHelperClient(address, config,
+        container.shouldStartClientInCompatibilityMode());
     client.createIndexOrDataStream(index);
 
     writeRecord(sinkRecord(0), client);

--- a/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchContainer.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchContainer.java
@@ -379,7 +379,7 @@ public class ElasticsearchContainer
           .user("root")
           .copy("instances.yml", CONFIG_SSL_PATH + "/instances.yml")
           .copy("start-elasticsearch.sh", CONFIG_SSL_PATH + "/start-elasticsearch.sh");
-      if (versionsInt.get(0) == 8 || versionsInt.get(0) == 7 && versionsInt.get(1) >= 15) {
+      if (versionsInt.get(0) == 8 || (versionsInt.get(0) == 7 && versionsInt.get(1) >= 15)) {
         // Install keytool from java 1.8 since our connector is built with
         // java 1.8 and the cert algoritm's won;t be compatible when using the newer
         // java version on the container

--- a/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchContainer.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchContainer.java
@@ -308,7 +308,7 @@ public class ElasticsearchContainer
     } else if (isBasicAuthEnabled()) {
       return "/basic/" + resourceName;
     } else {
-      return resourceName;
+      return "/none/" + resourceName;
     }
   }
 
@@ -321,10 +321,10 @@ public class ElasticsearchContainer
             .withStartupTimeout(Duration.ofMinutes(5))
     );
 
-    if (!isSslEnabled() && !isKerberosEnabled() && !isBasicAuthEnabled()) {
-      setImage(new RemoteDockerImage(DockerImageName.parse(imageName)));
-      return;
-    }
+//    if (!isSslEnabled() && !isKerberosEnabled() && !isBasicAuthEnabled()) {
+//      setImage(new RemoteDockerImage(DockerImageName.parse(imageName)));
+//      return;
+//    }
 
     ImageFromDockerfile image = new ImageFromDockerfile()
         // Copy the Elasticsearch config file
@@ -386,9 +386,10 @@ public class ElasticsearchContainer
       ArrayList<Integer> versionsInt = getImageVersion();
       log.info("Building Elasticsearch image with SSL configuration");
       builder
+          .user("root")
           .copy("instances.yml", CONFIG_SSL_PATH + "/instances.yml")
           .copy("start-elasticsearch.sh", CONFIG_SSL_PATH + "/start-elasticsearch.sh");
-      if (versionsInt.get(0) >= 7 && versionsInt.get(1) >= 15) {
+      if (versionsInt.get(0) == 8 || versionsInt.get(0) == 7 && versionsInt.get(1) >= 15) {
         // Install keytool from java 1.8 since our connector is built with
         // java 1.8 and the cert algoritm's won;t be compatible when using the newer
         // java version on the container

--- a/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchContainer.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchContainer.java
@@ -321,11 +321,6 @@ public class ElasticsearchContainer
             .withStartupTimeout(Duration.ofMinutes(5))
     );
 
-//    if (!isSslEnabled() && !isKerberosEnabled() && !isBasicAuthEnabled()) {
-//      setImage(new RemoteDockerImage(DockerImageName.parse(imageName)));
-//      return;
-//    }
-
     ImageFromDockerfile image = new ImageFromDockerfile()
         // Copy the Elasticsearch config file
         .withFileFromClasspath("elasticsearch.yml", getFullResourcePath("elasticsearch.yml"))

--- a/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchContainer.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchContainer.java
@@ -193,11 +193,6 @@ public class ElasticsearchContainer
 
   private void createUsersAndRoles(ElasticsearchHelperClient helperClient ) {
     try {
-      Thread.sleep(10000);
-    } catch (Exception e) {
-      //
-    }
-    try {
       for (Role role: this.rolesToCreate) {
         helperClient.createRole(role);
       }

--- a/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchHelperClient.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/helper/ElasticsearchHelperClient.java
@@ -15,12 +15,18 @@
 
 package io.confluent.connect.elasticsearch.helper;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.indices.GetDataStreamRequest.Builder;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
 import org.apache.http.HttpHost;
+import org.apache.kafka.test.TestUtils;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.RestHighLevelClientBuilder;
 import org.elasticsearch.client.core.CountRequest;
 import org.elasticsearch.client.indices.CreateIndexRequest;
 import org.elasticsearch.client.indices.DataStream;
@@ -53,15 +59,36 @@ public class ElasticsearchHelperClient {
 
   private static final Logger log = LoggerFactory.getLogger(ElasticsearchHelperClient.class);
 
+  private final String url;
+  private final ElasticsearchSinkConnectorConfig config;
   private RestHighLevelClient client;
 
-  public ElasticsearchHelperClient(String url, ElasticsearchSinkConnectorConfig config) {
+  public ElasticsearchHelperClient(String url, ElasticsearchSinkConnectorConfig config,
+      boolean compatibilityMode) {
     ConfigCallbackHandler configCallbackHandler = new ConfigCallbackHandler(config);
-    this.client = new RestHighLevelClient(
+    this.url = url;
+    this.config = config;
+    this.client = new RestHighLevelClientBuilder(
         RestClient
             .builder(HttpHost.create(url))
             .setHttpClientConfigCallback(configCallbackHandler)
-    );
+        .build()
+        // compatibility mode should be true for 7.17 high level rest clients while talking to ES 8.
+    ).setApiCompatibilityMode(compatibilityMode).build();
+  }
+
+  public ElasticsearchHelperClient(String url, ElasticsearchSinkConnectorConfig config) {
+    this(url, config, false);
+  }
+
+  public ElasticsearchClient getNewJavaAPIClient() {
+    ConfigCallbackHandler configCallbackHandler = new ConfigCallbackHandler(config);
+    RestClient client = RestClient
+        .builder(HttpHost.create(url))
+        .setHttpClientConfigCallback(configCallbackHandler)
+        .build();
+    return new ElasticsearchClient(new RestClientTransport(
+        client, new JacksonJsonpMapper()));
   }
 
   public void deleteIndex(String index, boolean isDataStream) throws IOException {
@@ -80,6 +107,18 @@ public class ElasticsearchHelperClient {
         .getDataStream(request, RequestOptions.DEFAULT)
         .getDataStreams();
     return datastreams.size() == 0 ? null : datastreams.get(0);
+  }
+
+  public co.elastic.clients.elasticsearch.indices.DataStream getDataStreamWithJavaAPIClient(
+      String dataStream
+  ) throws IOException {
+    List<co.elastic.clients.elasticsearch.indices.DataStream> dataStreams =
+        getNewJavaAPIClient().indices().getDataStream(
+            new Builder()
+                .name(dataStream)
+                .build()
+        ).dataStreams();
+    return dataStreams.size() == 0 ? null : dataStreams.get(0);
   }
 
   public long getDocCount(String index) throws IOException {
@@ -126,6 +165,14 @@ public class ElasticsearchHelperClient {
     PutUserResponse putUserResponse = client.security().putUser(putUserRequest, RequestOptions.DEFAULT);
     if (!putUserResponse.isCreated()) {
       throw new RuntimeException(String.format("Failed to create a user %s", userToPassword.getKey().getUsername()));
+    }
+  }
+
+  public void waitForConnection(long timeMs) {
+    try {
+      TestUtils.retryOnExceptionWithTimeout(timeMs, () -> client.info(RequestOptions.DEFAULT));
+    } catch (InterruptedException e) {
+      // do nothing
     }
   }
 

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorBaseIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorBaseIT.java
@@ -178,7 +178,8 @@ public class ElasticsearchConnectorBaseIT extends BaseConnectorIT {
     props.put(CONNECTION_URL_CONFIG, address);
     helperClient = new ElasticsearchHelperClient(
         props.get(CONNECTION_URL_CONFIG),
-        new ElasticsearchSinkConnectorConfig(props)
+        new ElasticsearchSinkConnectorConfig(props),
+        container.shouldStartClientInCompatibilityMode()
     );
   }
 

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorIT.java
@@ -209,7 +209,11 @@ public class ElasticsearchConnectorIT extends ElasticsearchConnectorBaseIT {
 
     runSimpleTest(props);
 
-    assertEquals(index, helperClient.getDataStream(index).getName());
+    if (container.esMajorVersion() == 8) {
+      assertEquals(index, helperClient.getDataStreamWithJavaAPIClient(index).name());
+    } else {
+      assertEquals(index, helperClient.getDataStream(index).getName());
+    }
   }
 
   @Test
@@ -271,6 +275,7 @@ public class ElasticsearchConnectorIT extends ElasticsearchConnectorBaseIT {
   private void testBackwardsCompatibilityDataStreamVersionHelper(
       String version
   ) throws Exception {
+    // since we require older ES container we close the current one and set it back up
     container.close();
     container = ElasticsearchContainer.withESVersion(version);
     container.start();
@@ -280,8 +285,7 @@ public class ElasticsearchConnectorIT extends ElasticsearchConnectorBaseIT {
 
     helperClient = null;
     container.close();
-    container = ElasticsearchContainer.fromSystemProperties();
-    container.start();
+    setupBeforeAll();
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorIT.java
@@ -299,6 +299,11 @@ public class ElasticsearchConnectorIT extends ElasticsearchConnectorBaseIT {
   }
 
   @Test
+  public void testBackwardsCompatibility() throws Exception {
+    testBackwardsCompatibilityDataStreamVersionHelper("7.16.3");
+  }
+
+  @Test
   public void testRoutingSmtSynchronousMode() throws Exception {
     index = addRoutingSmt("YYYYMM", "route-it-to-here-${topic}-at-${timestamp}");
     props.put(FLUSH_SYNCHRONOUSLY_CONFIG, "true");

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorKerberosIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchConnectorKerberosIT.java
@@ -14,6 +14,7 @@ import java.util.Properties;
 import org.apache.hadoop.minikdc.MiniKdc;
 import org.apache.kafka.connect.errors.ConnectException;
 import io.confluent.common.utils.IntegrationTest;
+import org.apache.kafka.test.TestUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -49,6 +50,7 @@ public class ElasticsearchConnectorKerberosIT extends ElasticsearchConnectorBase
   public void testKerberos() throws Exception {
     addKerberosConfigs(props);
     helperClient = container.getHelperClient(props);
+    helperClient.waitForConnection(60000);
     runSimpleTest(props);
   }
 

--- a/src/test/resources/basic/elasticsearch.yml
+++ b/src/test/resources/basic/elasticsearch.yml
@@ -3,3 +3,4 @@ network.host: 0.0.0.0
 
 xpack.license.self_generated.type: trial
 xpack.security.enabled: true
+xpack.security.http.ssl.enabled: false

--- a/src/test/resources/both/elasticsearch.yml
+++ b/src/test/resources/both/elasticsearch.yml
@@ -5,6 +5,7 @@ transport.host: 0.0.0.0
 
 node.store.allow_mmap: false
 cluster.routing.allocation.disk.threshold_enabled: false
+discovery.type: single-node
 
 xpack.license.self_generated.type: trial
 xpack.security.enabled: true

--- a/src/test/resources/both/start-elasticsearch.sh
+++ b/src/test/resources/both/start-elasticsearch.sh
@@ -91,6 +91,12 @@ fi
 # of the system-installed java
 export PATH=/usr/share/elasticsearch/jdk/bin/:$SAVE_PATH
 
+echo "Elasticsearch Configuration"
+cat /usr/share/elasticsearch/config/elasticsearch.yml
+
 echo
 echo "Starting Elasticsearch with SSL and Kerberos enabled ..."
-/usr/local/bin/docker-entrypoint.sh
+su - elasticsearch<<EOF
+ /usr/local/bin/docker-entrypoint.sh
+EOF
+

--- a/src/test/resources/kerberos/elasticsearch.yml
+++ b/src/test/resources/kerberos/elasticsearch.yml
@@ -7,6 +7,8 @@ node.store.allow_mmap: false
 cluster.routing.allocation.disk.threshold_enabled: false
 
 xpack.license.self_generated.type: trial
+xpack.security.enabled: true
+xpack.security.http.ssl.enabled: false
 
 # Kerberos realm
 xpack.security.authc.realms.kerberos.kerb1:

--- a/src/test/resources/none/elasticsearch.yml
+++ b/src/test/resources/none/elasticsearch.yml
@@ -3,7 +3,6 @@ network.host: 0.0.0.0
 
 xpack.license.self_generated.type: trial
 xpack.security.enabled: false
-xpack.security.enrollment.enabled: false
 
 xpack.security.http.ssl.enabled: false
 

--- a/src/test/resources/none/elasticsearch.yml
+++ b/src/test/resources/none/elasticsearch.yml
@@ -1,0 +1,10 @@
+cluster.name: "docker-cluster"
+network.host: 0.0.0.0
+
+xpack.license.self_generated.type: trial
+xpack.security.enabled: false
+xpack.security.enrollment.enabled: false
+
+xpack.security.http.ssl.enabled: false
+
+xpack.security.transport.ssl.enabled: false

--- a/src/test/resources/none/instances.yml
+++ b/src/test/resources/none/instances.yml
@@ -1,0 +1,18 @@
+instances:
+  - name: elasticsearch
+    dns:
+      - elasticsearch
+    ip:
+      - ipAddress
+  - name: kibana
+    dns:
+      - kibana
+      - localhost
+    ip:
+      - ipAddress
+  - name: logstash
+    dns:
+      - logstash
+      - localhost
+    ip:
+      - ipAddress

--- a/src/test/resources/ssl/Dockerfile
+++ b/src/test/resources/ssl/Dockerfile
@@ -4,16 +4,16 @@
 # This image can be used for local testing and exploration, but strictly speaking
 # is not used in the integration tests.
 
-FROM docker.elastic.co/elasticsearch/elasticsearch:7.0.0
-
-# We require these to generate certs
-RUN yum -y install openssl
+FROM docker.elastic.co/elasticsearch/elasticsearch:8.2.2
 
 # Install our script to generate certs
 ENV STORE_PASSWORD=asdfasdf
 ENV ELASTIC_PASSWORD=elastic
 
+USER root
+
 RUN mkdir -p /usr/share/elasticsearch/config/certs
+COPY ./elasticsearch.yml /usr/share/elasticsearch/config/elasticsearch.yml
 COPY ./instances.yml /usr/share/elasticsearch/config/ssl/instances.yml
 COPY ./start-elasticsearch.sh /usr/share/elasticsearch/config/ssl/start-elasticsearch.sh
 RUN chmod +x /usr/share/elasticsearch/config/ssl/start-elasticsearch.sh

--- a/src/test/resources/ssl/elasticsearch.yml
+++ b/src/test/resources/ssl/elasticsearch.yml
@@ -5,6 +5,7 @@ transport.host: 0.0.0.0
 
 node.store.allow_mmap: false
 cluster.routing.allocation.disk.threshold_enabled: false
+discovery.type: single-node
 
 xpack.license.self_generated.type: trial
 xpack.security.enabled: true

--- a/src/test/resources/ssl/start-elasticsearch.sh
+++ b/src/test/resources/ssl/start-elasticsearch.sh
@@ -13,6 +13,7 @@ if [[ -z "${IP_ADDRESS}" ]]; then
     IP_ADDRESS=$(hostname -I)
 fi
 
+chmod 777 ${ES_DIR}
 echo
 echo "Replacing the ip address in the ${ES_DIR}/config/ssl/instances.yml file with ${IP_ADDRESS}"
 sed -i "s/ipAddress/${IP_ADDRESS}/g" ${ES_DIR}/config/ssl/instances.yml
@@ -91,6 +92,11 @@ fi
 # of the system-installed java
 export PATH=/usr/share/elasticsearch/jdk/bin/:$SAVE_PATH
 
+echo "Elasticsearch Configuration"
+cat /usr/share/elasticsearch/config/elasticsearch.yml
+
 echo
 echo "Starting Elasticsearch with SSL enabled ..."
-/usr/local/bin/docker-entrypoint.sh
+su - elasticsearch<<EOF
+ /usr/local/bin/docker-entrypoint.sh
+EOF


### PR DESCRIPTION
## Problem
The current version of the connector does not support  ES 8 and above. 

## Solution
The High level rest client 7.17 has a compatibility mode which adds some headers to work with ES 8. When using ES 8 and above set this compatibility mode as true. 

Although elastic does not explicitly say that the HLRC in compatibility mode won't work with older elastic versions (7.11 and lower) they do mention [here](https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/java-rest-high-compatibility.html) that, under compatibility mode HLRC can also work with 7.11 and higher versions. Its best to only enable compatibility mode only with major version as 8 and above. 

The connector already the ability to retrieve the version so we are using it to selectively turn on compatibility mode support (or otherwise) based on the version.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
