### PR TITLE
Add Version Type & Field Configuration

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
@@ -38,7 +38,6 @@ import org.elasticsearch.action.DocWriteRequest.OpType;
 import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.update.UpdateRequest;
-import org.elasticsearch.index.VersionType;
 import org.elasticsearch.xcontent.XContentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -33,6 +33,7 @@ import org.apache.kafka.common.config.ConfigDef.Validator;
 import org.apache.kafka.common.config.ConfigDef.Width;
 import org.apache.kafka.common.config.types.Password;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.index.VersionType;
 
 import static org.apache.kafka.common.config.ConfigDef.Range.between;
 import static org.apache.kafka.common.config.SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG;
@@ -362,7 +363,17 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   private static final String KERBEROS_GROUP = "Kerberos";
   private static final String DATA_STREAM_GROUP = "Data Stream";
 
-  public enum BehaviorOnMalformedDoc {
+  public static final String VERSION_TYPE_CONFIG = "version.type";
+
+  public static final String VERSION_TYPE_DOC = "Elasticsearch version type, will be append when key.ignored is set to false";
+
+  public static final String VERSION_TYPE_DEFAULT = "external_gte";
+
+    public static final String VERSION_TYPE_DISPLAY = "Elasticsearch Version Type";
+
+
+
+    public enum BehaviorOnMalformedDoc {
     IGNORE,
     WARN,
     FAIL
@@ -678,7 +689,19 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
             Width.SHORT,
             WRITE_METHOD_DISPLAY,
             new EnumRecommender<>(WriteMethod.class)
-    );
+        ).define(
+            VERSION_TYPE_CONFIG,
+            Type.STRING,
+            VERSION_TYPE_DEFAULT,
+            new EnumRecommender<>(VersionType.class),
+            Importance.LOW,
+            VERSION_TYPE_DOC,
+            DATA_CONVERSION_GROUP,
+            ++order,
+            Width.SHORT,
+            VERSION_TYPE_DISPLAY,
+            new EnumRecommender<>(VersionType.class)
+            );
   }
 
   private static void addProxyConfigs(ConfigDef configDef) {
@@ -904,7 +927,6 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   public DataStreamType dataStreamType() {
     return DataStreamType.valueOf(getString(DATA_STREAM_TYPE_CONFIG).toUpperCase());
   }
-
   public List<String> dataStreamTimestampField() {
     return getList(DATA_STREAM_TIMESTAMP_CONFIG);
   }
@@ -1009,6 +1031,10 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
 
   public WriteMethod writeMethod() {
     return WriteMethod.valueOf(getString(WRITE_METHOD_CONFIG).toUpperCase());
+  }
+
+  public VersionType versionType() {
+    return VersionType.valueOf(getString(VERSION_TYPE_CONFIG).toUpperCase());
   }
 
   private static class DataStreamDatasetValidator implements Validator {

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -364,13 +364,16 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   private static final String DATA_STREAM_GROUP = "Data Stream";
 
   public static final String VERSION_TYPE_CONFIG = "version.type";
-  public static final String VERSION_TYPE_DOC = "Elasticsearch version type, will be append when key.ignored is set to false";
+  public static final String VERSION_TYPE_DOC = "Elasticsearch version type, "
+          + "will be append when key.ignored is set to false";
   public static final String VERSION_TYPE_DEFAULT = "external_gte";
   public static final String VERSION_TYPE_DISPLAY = "Elasticsearch Version Type";
 
   public static final String VERSION_TYPE_FIELD_CONFIG = "version.type.field";
   public static final String VERSION_TYPE_FIELD_DOC = String.format(
-          "When %s is not set as internal and %s is false, you can set the version to a payload field, if set to empty, will use kafka offset",
+          "When %s is not set as internal and %s is false, "
+                  + "you can set the version to a payload field, if set to empty,"
+                  + " will use kafka offset",
           VERSION_TYPE_FIELD_CONFIG,
           IGNORE_KEY_CONFIG);
   public static final String VERSION_TYPE_FIELD_DEFAULT = "";
@@ -378,7 +381,7 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
 
 
 
-    public enum BehaviorOnMalformedDoc {
+  public enum BehaviorOnMalformedDoc {
     IGNORE,
     WARN,
     FAIL
@@ -716,7 +719,7 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
             ++order,
             Width.SHORT,
             VERSION_TYPE_FIELD_DISPLAY
-        );
+    );
   }
 
   private static void addProxyConfigs(ConfigDef configDef) {
@@ -942,6 +945,7 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   public DataStreamType dataStreamType() {
     return DataStreamType.valueOf(getString(DATA_STREAM_TYPE_CONFIG).toUpperCase());
   }
+
   public List<String> dataStreamTimestampField() {
     return getList(DATA_STREAM_TIMESTAMP_CONFIG);
   }
@@ -1055,6 +1059,7 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   public boolean isVersionTypeFieldConfigured() {
     return !getString(VERSION_TYPE_FIELD_CONFIG).isEmpty();
   }
+
   public String versionTypeField() {
     return getString(VERSION_TYPE_FIELD_CONFIG);
   }

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -364,12 +364,17 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   private static final String DATA_STREAM_GROUP = "Data Stream";
 
   public static final String VERSION_TYPE_CONFIG = "version.type";
-
   public static final String VERSION_TYPE_DOC = "Elasticsearch version type, will be append when key.ignored is set to false";
-
   public static final String VERSION_TYPE_DEFAULT = "external_gte";
+  public static final String VERSION_TYPE_DISPLAY = "Elasticsearch Version Type";
 
-    public static final String VERSION_TYPE_DISPLAY = "Elasticsearch Version Type";
+  public static final String VERSION_TYPE_FIELD_CONFIG = "version.type.field";
+  public static final String VERSION_TYPE_FIELD_DOC = String.format(
+          "When %s is not set as internal and %s is false, you can set the version to a payload field, if set to empty, will use kafka offset",
+          VERSION_TYPE_FIELD_CONFIG,
+          IGNORE_KEY_CONFIG);
+  public static final String VERSION_TYPE_FIELD_DEFAULT = "";
+  public static final String VERSION_TYPE_FIELD_DISPLAY = "Version Type Field In Payload";
 
 
 
@@ -701,7 +706,17 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
             Width.SHORT,
             VERSION_TYPE_DISPLAY,
             new EnumRecommender<>(VersionType.class)
-            );
+        ).define(
+            VERSION_TYPE_FIELD_CONFIG,
+            Type.STRING,
+            VERSION_TYPE_FIELD_DEFAULT,
+            Importance.LOW,
+            VERSION_TYPE_FIELD_DOC,
+            DATA_CONVERSION_GROUP,
+            ++order,
+            Width.SHORT,
+            VERSION_TYPE_FIELD_DISPLAY
+        );
   }
 
   private static void addProxyConfigs(ConfigDef configDef) {
@@ -1035,6 +1050,13 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
 
   public VersionType versionType() {
     return VersionType.valueOf(getString(VERSION_TYPE_CONFIG).toUpperCase());
+  }
+
+  public boolean isVersionTypeFieldConfigured() {
+    return !getString(VERSION_TYPE_FIELD_CONFIG).isEmpty();
+  }
+  public String versionTypeField() {
+    return getString(VERSION_TYPE_FIELD_CONFIG);
   }
 
   private static class DataStreamDatasetValidator implements Validator {

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.config.types.Password;
+import org.elasticsearch.index.VersionType;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -242,6 +243,25 @@ public class ElasticsearchSinkConnectorConfigTest {
   public void shouldNotAllowInvalidVersionType() {
     props.put(VERSION_TYPE_CONFIG, "notInternal");
     new ElasticsearchSinkConnectorConfig(props);
+  }
+
+  @Test
+  public void testVersionTypeDefault() {
+    ElasticsearchSinkConnectorConfig config = new ElasticsearchSinkConnectorConfig(props);
+    assertEquals(config.versionType(), VersionType.EXTERNAL_GTE);
+  }
+
+  @Test
+  public void testVersionTypeFieldDefault() {
+    ElasticsearchSinkConnectorConfig config = new ElasticsearchSinkConnectorConfig(props);
+    assertFalse(config.isVersionTypeFieldConfigured());
+  }
+
+  @Test
+  public void testVersionTypeFieldConfig() {
+    props.put(VERSION_TYPE_FIELD_CONFIG, "version");
+    ElasticsearchSinkConnectorConfig config = new ElasticsearchSinkConnectorConfig(props);
+    assertEquals("version", config.versionTypeField());
   }
 
   public static Map<String, String> addNecessaryProps(Map<String, String> props) {

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
@@ -1,17 +1,6 @@
 package io.confluent.connect.elasticsearch;
 
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_TIMEOUT_MS_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_URL_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_DATASET_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.DATA_STREAM_TYPE_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.KERBEROS_KEYTAB_PATH_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.PROXY_HOST_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.PROXY_PASSWORD_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.PROXY_PORT_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.PROXY_USERNAME_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.READ_TIMEOUT_MS_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SECURITY_PROTOCOL_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SSL_CONFIG_PREFIX;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.*;
 import static org.apache.kafka.common.config.SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -237,6 +226,24 @@ public class ElasticsearchSinkConnectorConfigTest {
     keytab.toFile().delete();
   }
 
+  @Test
+  public void shouldAllowValidVersionType() {
+    props.put(VERSION_TYPE_CONFIG, "internal");
+    new ElasticsearchSinkConnectorConfig(props);
+  }
+
+  @Test
+  public void shouldAllowValidVersionTypeCaseInsensitive() {
+    props.put(VERSION_TYPE_CONFIG, "InTernal");
+    new ElasticsearchSinkConnectorConfig(props);
+  }
+
+  @Test(expected = ConfigException.class)
+  public void shouldNotAllowInvalidVersionType() {
+    props.put(VERSION_TYPE_CONFIG, "notInternal");
+    new ElasticsearchSinkConnectorConfig(props);
+  }
+
   public static Map<String, String> addNecessaryProps(Map<String, String> props) {
     if (props == null) {
       props = new HashMap<>();
@@ -244,4 +251,6 @@ public class ElasticsearchSinkConnectorConfigTest {
     props.put(ElasticsearchSinkConnectorConfig.CONNECTION_URL_CONFIG, "http://localhost:8080");
     return props;
   }
+
+
 }


### PR DESCRIPTION
## Problem
* Not able to custom version type 
* Not able to set custom version when use external version type

## Solution
* add version.type configuration: internal, external, external_gte
* add version.type.field configuration to support read version value from payload 
* use version.type and version.type.field in data convert 

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
Testing if version.type and version.type.field is set, and check if IndexRequest is correct 

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
This feature is backwards compatible.
Merging to master
Rolling back might result in validation error for people that use version.type or version.type.field