### PR TITLE
RCCA-7507 : Adding some more logs to understand the exception.

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
@@ -538,6 +538,16 @@ public class ElasticsearchClient {
                   response.getVersion(),
                   response.getIndex()
           );
+
+          log.trace("{} version conflict for operation {} on document '{}' version {}"
+                          + " in index '{}' and stacktrace '{}'",
+                  request != null ? request.versionType() : "UNKNOWN",
+                  response.getOpType(),
+                  response.getId(),
+                  response.getVersion(),
+                  response.getIndex(),
+                  response.getFailure().getCause().getStackTrace()
+          );
           // Maybe this was a race condition?  Put it in the DLQ in case someone
           // wishes to investigate.
           reportBadRecord(response, executionId);

--- a/src/main/java/io/confluent/connect/elasticsearch/RetryUtil.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/RetryUtil.java
@@ -170,9 +170,9 @@ public class RetryUtil {
 
         log.warn("Failed to {} due to {}. Retrying attempt ({}/{}) after backoff of {} ms",
             description, e.getCause(), attempt, maxTotalAttempts, backoff);
-        log.trace("Failed to {} due to {} and stacktrace {}. "
-                         + "Retrying attempt ({}/{}) after backoff of {} ms",
-                         description, e.getCause(), e.getStackTrace(), attempt,
+        log.trace("Failed to {} due to exception :: {} and its stacktrace {}  "
+                        + "Retrying attempt ({}/{}) after backoff of {} ms",
+                         description, e, e.getStackTrace(), attempt,
                          maxTotalAttempts, backoff);
         clock.sleep(backoff);
       }

--- a/src/main/java/io/confluent/connect/elasticsearch/RetryUtil.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/RetryUtil.java
@@ -170,6 +170,10 @@ public class RetryUtil {
 
         log.warn("Failed to {} due to {}. Retrying attempt ({}/{}) after backoff of {} ms",
             description, e.getCause(), attempt, maxTotalAttempts, backoff);
+        log.trace("Failed to {} due to {} and stacktrace {}. "
+                         + "Retrying attempt ({}/{}) after backoff of {} ms",
+                         description, e.getCause(), e.getStackTrace(), attempt,
+                         maxTotalAttempts, backoff);
         clock.sleep(backoff);
       }
     }


### PR DESCRIPTION
## Problem
lcc-gq1xgm Elasticsearch Sink Connector getting document already exists errors

## Solution
Enabling more logging to understand the NPE 

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
