### PR TITLE
RCCA - 7507  :  inc-lcc-gq1xgm-elasticsearch-sink-connector-getting-document-already-exists-err

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
@@ -660,7 +660,8 @@ public class ElasticsearchClient {
                                             long executionId) {
 
     // RCCA-7507 : Don't push to DLQ if we receive Internal version conflict on data streams
-    if (config.isDataStream()) {
+    if (response.getFailureMessage().contains(VERSION_CONFLICT_EXCEPTION)
+            && config.isDataStream()) {
       log.info("Skipping DLQ insertion for DataStream type.");
       return;
     }

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
@@ -658,6 +658,12 @@ public class ElasticsearchClient {
    */
   private synchronized void reportBadRecord(BulkItemResponse response,
                                             long executionId) {
+
+    // RCCA-7507 : Don't push to DLQ if we receive Internal version conflict on data streams
+    if (config.isDataStream()) {
+      log.info("Skipping DLQ insertion for DataStream type.");
+      return;
+    }
     if (reporter != null) {
       List<SinkRecordAndOffset> sinkRecords =
           inFlightRequests.getOrDefault(executionId, new ArrayList<>());


### PR DESCRIPTION

## Problem
inc-lcc-gq1xgm-elasticsearch-sink-connector-getting-document-already-exists-err


## Solution
Due to ES version compat issue, we are seeing a lot of reprocessing error in bulk processing , hence switching off the DLQ mechanism for datastream until we roll out ES 8 compatibility.

since ES 8 is not yet compatible, it throws NPE while processing bulkrequests response and due to bulk req failure , retry mechanism will get triggered and client would try to index already processed records which triggers "INTERNAL version conflict for operation CREATE" error and successfully indexed records will also get redirected to DLQ



<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests
1. setup ES 8.x.x
2. start datagen connector to send data to a topic x.
3. start ES connector to read from x with following config :
{
  "name": "ElasticsearchSinkConnectorConnector_0",
  "config": {
    "key.converter.schemas.enable": "false",
    "value.converter.schemas.enable": "false",
    "name": "ElasticsearchSinkConnectorConnector_0",
    "connector.class": "io.confluent.connect.elasticsearch.ElasticsearchSinkConnector",
    "tasks.max": "1",
    "key.converter": "org.apache.kafka.connect.json.JsonConverter",
    "value.converter": "org.apache.kafka.connect.json.JsonConverter",
    "topics": "pageviews",
    "connection.url": "http://localhost:9200",
    "key.ignore": "true",
    "schema.ignore": "true",
    "drop.invalid.message": "true",
    "behavior.on.null.values": "fail",
    "behavior.on.malformed.documents": "fail",
    "write.method": "insert",
    "data.stream.dataset": "confluent",
    "data.stream.type": "logs"
  }
}
4-observe logs, since ES 8 is not yet compatible, it throws NPE while processing bulkrequests response and due to bulk req failure , retry mechanism will get triggered and client would try to index already processed records which triggers "INTERNAL version conflict for operation CREATE" error and successfully indexed records will also get redirected to DLQ. 
instead of pushing it to DLQ, there should be a log 👍:
"Skipping DLQ insertion for DataStream type"

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
