### PR TITLE
Revert "RCCA - 7507  :  inc-lcc-gq1xgm-elasticsearch-sink-connector-getting-document-already-exists-err"

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
@@ -659,13 +659,6 @@ public class ElasticsearchClient {
    */
   private synchronized void reportBadRecord(BulkItemResponse response,
                                             long executionId) {
-
-    // RCCA-7507 : Don't push to DLQ if we receive Internal version conflict on data streams
-    if (response.getFailureMessage().contains(VERSION_CONFLICT_EXCEPTION)
-            && config.isDataStream()) {
-      log.info("Skipping DLQ insertion for DataStream type.");
-      return;
-    }
     if (reporter != null) {
       List<SinkRecordAndOffset> sinkRecords =
           inFlightRequests.getOrDefault(executionId, new ArrayList<>());


### PR DESCRIPTION
Reverts confluentinc/kafka-connect-elasticsearch#643

changes need to be merged to 11.1.x