### PR TITLE
CCMSG-2073: Throw data exception when non json object payload is present.

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
@@ -207,8 +207,8 @@ public class DataConverter {
       JsonNode jsonNode = objectMapper.readTree(payload);
 
       if (!jsonNode.isObject()) {
-        throw new DataException("Top level payload contains data of Json type " +
-            jsonNode.getNodeType() + ". Required Json object.");
+        throw new DataException("Top level payload contains data of Json type "
+            + jsonNode.getNodeType() + ". Required Json object.");
       }
 
       if (!config.dataStreamTimestampField().isEmpty()) {

--- a/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
@@ -29,6 +29,7 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.sink.SinkRecord;
@@ -210,9 +211,18 @@ public class DataConverter {
           if (jsonNode.has(timestampField)) {
             ((ObjectNode) jsonNode).put(TIMESTAMP_FIELD, jsonNode.get(timestampField).asText());
             return objectMapper.writeValueAsString(jsonNode);
+          } else {
+            log.debug("Timestamp field {} is not present in payload. This record may be skipped",
+                timestampField);
           }
         }
       } else {
+
+        if (!jsonNode.isObject()) {
+          throw new DataException("Required json object. Payload contains data of json type " +
+              jsonNode.getNodeType());
+        }
+
         ((ObjectNode) jsonNode).put(TIMESTAMP_FIELD, timestamp);
         return objectMapper.writeValueAsString(jsonNode);
       }

--- a/src/test/java/io/confluent/connect/elasticsearch/DataConverterTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/DataConverterTest.java
@@ -478,6 +478,16 @@ public class DataConverterTest {
     assertEquals(timestamp, actualRecord.sourceAsMap().get(TIMESTAMP_FIELD));
   }
 
+  @Test(expected = DataException.class)
+  public void testExceptionWhenNonObjectPayloadInDataStream() {
+    configureDataStream();
+    converter = new DataConverter(new ElasticsearchSinkConnectorConfig(props));
+    SinkRecord record = new SinkRecord("t", 0, Schema.STRING_SCHEMA, key,
+        SchemaBuilder.array(Schema.STRING_SCHEMA).build(), Arrays.asList("a", "b"), offset,
+        recordTimestamp, TimestampType.CREATE_TIME);
+    converter.convertRecord(record, index);
+  }
+
   @Test
   public void testDoNotAddExternalVersioningIfDataStream() {
     configureDataStream();


### PR DESCRIPTION
## Problem
If a non json object is preset in the payload, during data stream insert we end up throwing a `ClassCastException`, while trying to insert the record timestamp if not user given timestamp field is not used. 

Note that if the user is trying to obtain the timestamp from the payload the `jsonNode.has` condition returns null if `jsonNode` is not an `ObjectNode` so the cast is not executed. In such cases, it will most likely fail to be inserted as ES only supports Json Objects as top level elements. This is the current behaviour and is left unchanged. 

## Solution
Do an explicit check and throw a data exception if not an object node. Also in the previous condition if the json node does not have the user given timestamp field the resulting record may be skipped entirely so added some debug statements for future debugging ease.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
