### PR TITLE
revert back to confluent-log4j because parent common is fixed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,9 +156,10 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
-       <dependency>
-            <groupId>ch.qos.reload4j</groupId>
-            <artifactId>reload4j</artifactId>
+        <!-- Use a repackaged version of log4j with security patches. Default log4j v1.2 is a transitive dependency of connect-runtime, but it is excluded in common/pom.xml -->
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>confluent-log4j</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Problem
revert back to confluent-log4j because parent common is fixed (not SNAPSHOT version) , and it doesn't have reload4j version tagged. 

## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
