### PR TITLE
CCMSG-2140: Handle bigdecimal defaults.

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/Mapping.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/Mapping.java
@@ -15,6 +15,7 @@
 
 package io.confluent.connect.elasticsearch;
 
+import java.math.BigDecimal;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Field;
@@ -215,7 +216,8 @@ public class Mapping {
       case Timestamp.LOGICAL_NAME:
         return inferPrimitive(builder, DATE_TYPE, schema.defaultValue());
       case Decimal.LOGICAL_NAME:
-        return inferPrimitive(builder, DOUBLE_TYPE, schema.defaultValue());
+        return inferPrimitive(builder, DOUBLE_TYPE, ((BigDecimal) schema.defaultValue())
+            .doubleValue());
       default:
         // User-defined type or unknown built-in
         return null;

--- a/src/main/java/io/confluent/connect/elasticsearch/Mapping.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/Mapping.java
@@ -216,8 +216,9 @@ public class Mapping {
       case Timestamp.LOGICAL_NAME:
         return inferPrimitive(builder, DATE_TYPE, schema.defaultValue());
       case Decimal.LOGICAL_NAME:
-        return inferPrimitive(builder, DOUBLE_TYPE, ((BigDecimal) schema.defaultValue())
-            .doubleValue());
+        Double defaultValue = schema.defaultValue() != null ? ((BigDecimal) schema.defaultValue())
+            .doubleValue() : null;
+        return inferPrimitive(builder, DOUBLE_TYPE, defaultValue);
       default:
         // User-defined type or unknown built-in
         return null;

--- a/src/test/java/io/confluent/connect/elasticsearch/MappingTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/MappingTest.java
@@ -15,15 +15,19 @@
 
 package io.confluent.connect.elasticsearch;
 
+import com.github.tomakehurst.wiremock.common.Json;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.util.HashMap;
+import org.apache.kafka.connect.data.ConnectSchema;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Schema.Type;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
@@ -119,6 +123,15 @@ public class MappingTest {
     JsonObject result = runTest(schema);
 
     assertNull(result.getAsJsonObject("properties").getAsJsonObject("string").get("null_value"));
+  }
+
+  @Test
+  public void testDecimalTypeMapping() throws Exception {
+    Schema schema = new ConnectSchema(Type.INT64, true, BigDecimal.valueOf(100),
+        Decimal.LOGICAL_NAME, 1, "");
+    JsonObject result = runTest(schema);
+    assertEquals("double", result.get("type").getAsString());
+    assertEquals(100, result.get("null_value").getAsInt());
   }
 
   private Schema createSchema() {


### PR DESCRIPTION
## Problem
The connector converts bigdecimal data types to double types. However during the creation of the mapping, the default value of the bigdecimal is simply casted to a double value. This ends up causing a class cast exception if the bigdecimal has a default value. 

## Solution
Use the correct way to convert to a a double value given in this PR. 

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
