### PR TITLE
Ignore empty ssl truststore/keystore configs.

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -36,6 +36,13 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 
 import static org.apache.kafka.common.config.ConfigDef.Range.between;
 import static org.apache.kafka.common.config.SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG;
+import static org.apache.kafka.common.config.SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG;
+import static org.apache.kafka.common.config.SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG;
+import static org.apache.kafka.common.config.SslConfigs.SSL_KEYSTORE_TYPE_CONFIG;
+import static org.apache.kafka.common.config.SslConfigs.SSL_KEY_PASSWORD_CONFIG;
+import static org.apache.kafka.common.config.SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG;
+import static org.apache.kafka.common.config.SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG;
+import static org.apache.kafka.common.config.SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG;
 import static org.apache.kafka.common.config.SslConfigs.addClientSslSupport;
 
 public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
@@ -996,7 +1003,23 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   public Map<String, Object> sslConfigs() {
     ConfigDef sslConfigDef = new ConfigDef();
     addClientSslSupport(sslConfigDef);
-    return sslConfigDef.parse(originalsWithPrefix(SSL_CONFIG_PREFIX));
+    Map<String, Object> sslConfigs = originalsWithPrefix(SSL_CONFIG_PREFIX);
+    // if empty path is provided for the keystore/truststore location remove it and associated
+    // passwords, otherwise it will lead to an exception while creating the ssl context
+    if (sslConfigs.getOrDefault(SSL_CONFIG_PREFIX + SSL_KEYSTORE_LOCATION_CONFIG, "")
+        .toString().isEmpty()) {
+      sslConfigs.remove(SSL_CONFIG_PREFIX + SSL_KEYSTORE_LOCATION_CONFIG);
+      sslConfigs.remove(SSL_CONFIG_PREFIX + SSL_KEYSTORE_PASSWORD_CONFIG);
+      sslConfigs.remove(SSL_CONFIG_PREFIX + SSL_KEY_PASSWORD_CONFIG);
+      sslConfigs.remove(SSL_CONFIG_PREFIX + SSL_KEYSTORE_TYPE_CONFIG);
+    }
+    if (sslConfigs.getOrDefault(SSL_CONFIG_PREFIX + SSL_TRUSTSTORE_LOCATION_CONFIG, "")
+        .toString().isEmpty()) {
+      sslConfigs.remove(SSL_CONFIG_PREFIX + SSL_TRUSTSTORE_LOCATION_CONFIG);
+      sslConfigs.remove(SSL_CONFIG_PREFIX + SSL_TRUSTSTORE_PASSWORD_CONFIG);
+      sslConfigs.remove(SSL_CONFIG_PREFIX + SSL_TRUSTSTORE_TYPE_CONFIG);
+    }
+    return sslConfigDef.parse(sslConfigs);
   }
 
   public String username() {

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -1006,18 +1006,16 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
     Map<String, Object> sslConfigs = originalsWithPrefix(SSL_CONFIG_PREFIX);
     // if empty path is provided for the keystore/truststore location remove it and associated
     // passwords, otherwise it will lead to an exception while creating the ssl context
-    if (sslConfigs.getOrDefault(SSL_CONFIG_PREFIX + SSL_KEYSTORE_LOCATION_CONFIG, "")
-        .toString().isEmpty()) {
-      sslConfigs.remove(SSL_CONFIG_PREFIX + SSL_KEYSTORE_LOCATION_CONFIG);
-      sslConfigs.remove(SSL_CONFIG_PREFIX + SSL_KEYSTORE_PASSWORD_CONFIG);
-      sslConfigs.remove(SSL_CONFIG_PREFIX + SSL_KEY_PASSWORD_CONFIG);
-      sslConfigs.remove(SSL_CONFIG_PREFIX + SSL_KEYSTORE_TYPE_CONFIG);
+    if (sslConfigs.getOrDefault(SSL_KEYSTORE_LOCATION_CONFIG, "").toString().isEmpty()) {
+      sslConfigs.remove(SSL_KEYSTORE_LOCATION_CONFIG);
+      sslConfigs.remove(SSL_KEYSTORE_PASSWORD_CONFIG);
+      sslConfigs.remove(SSL_KEY_PASSWORD_CONFIG);
+      sslConfigs.remove(SSL_KEYSTORE_TYPE_CONFIG);
     }
-    if (sslConfigs.getOrDefault(SSL_CONFIG_PREFIX + SSL_TRUSTSTORE_LOCATION_CONFIG, "")
-        .toString().isEmpty()) {
-      sslConfigs.remove(SSL_CONFIG_PREFIX + SSL_TRUSTSTORE_LOCATION_CONFIG);
-      sslConfigs.remove(SSL_CONFIG_PREFIX + SSL_TRUSTSTORE_PASSWORD_CONFIG);
-      sslConfigs.remove(SSL_CONFIG_PREFIX + SSL_TRUSTSTORE_TYPE_CONFIG);
+    if (sslConfigs.getOrDefault(SSL_TRUSTSTORE_LOCATION_CONFIG, "").toString().isEmpty()) {
+      sslConfigs.remove(SSL_TRUSTSTORE_LOCATION_CONFIG);
+      sslConfigs.remove(SSL_TRUSTSTORE_PASSWORD_CONFIG);
+      sslConfigs.remove(SSL_TRUSTSTORE_TYPE_CONFIG);
     }
     return sslConfigDef.parse(sslConfigs);
   }


### PR DESCRIPTION
## Problem
If empty ssl truststore/keystore configs are given in the configuration it fails to create the ssl context.

## Solution
If such configs are preset ignore them while creating the ssl context. 

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
