### PR TITLE
CCMSG-2220: Updated jackson dependency to resolve CVE-2022-42003 and CVE-2022-42004

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,8 @@
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
         <hadoop.version>3.3.0</hadoop.version>
         <apacheds-jdbm1.version>2.0.0-M2</apacheds-jdbm1.version>
-        <jackson.databind.version>2.13.2.1</jackson.databind.version>
-        <jackson.version>2.13.2</jackson.version>
+        <jackson.databind.version>2.14.0</jackson.databind.version>
+        <jackson.version>2.14.0</jackson.version>
         <!-- temporary fix by pinning the version until we upgrade to a version of common that contains this or newer version.
             See https://github.com/confluentinc/common/pull/332 for details -->
         <dependency.check.version>6.1.6</dependency.check.version>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
         <hadoop.version>3.3.0</hadoop.version>
         <apacheds-jdbm1.version>2.0.0-M2</apacheds-jdbm1.version>
+        <!-- TODO: Remove the version pin after releasing https://github.com/confluentinc/common/pull/494 -->
         <jackson.databind.version>2.14.0</jackson.databind.version>
         <jackson.version>2.14.0</jackson.version>
         <!-- temporary fix by pinning the version until we upgrade to a version of common that contains this or newer version.


### PR DESCRIPTION
## Problem
https://confluentinc.atlassian.net/browse/CCMSG-2220

## Solution
Updated jackson dependency to resolve CVE-2022-42003 and CVE-2022-42004

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [x] Manual tests

```
➜  connect-elasticsearch-sink git:(master) ✗ CONNECTOR_ZIP=/Users/ajain/projects/kafka-connect-elasticsearch/target/components/packages/confluentinc-kafka-connect-elasticsearch-11.1.14-SNAPSHOT.zip ./elasticsearch-sink.sh
13:53:12 ℹ️ 💫 Using default CP version 7.3.0
13:53:12 ℹ️ 🎓 set TAG environment variable to specify different version, see https://kafka-docker-playground.io/#/how-to-use?id=🎯-for-confluent-platform-cp
13:53:15 ℹ️ 👷🛠 Re-building Docker image vdesabou/kafka-docker-playground-connect:7.3.0 to include confluentinc/kafka-connect-elasticsearch:latest
[+] Building 24.3s (6/6) FINISHED                                                                                                                                                                                                       
 => [internal] load build definition from Dockerfile                                                                                                                                                                               0.3s
 => => transferring dockerfile: 182B                                                                                                                                                                                               0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                  0.2s
 => => transferring context: 2B                                                                                                                                                                                                    0.0s
 => [internal] load metadata for docker.io/vdesabou/kafka-docker-playground-connect:7.3.0                                                                                                                                          0.0s
 => CACHED [1/2] FROM docker.io/vdesabou/kafka-docker-playground-connect:7.3.0                                                                                                                                                     0.0s
 => [2/2] RUN confluent-hub install --no-prompt confluentinc/kafka-connect-elasticsearch:latest                                                                                                                                   22.2s
 => exporting to image                                                                                                                                                                                                             0.5s
 => => exporting layers                                                                                                                                                                                                            0.4s
 => => writing image sha256:f4cd8c66f627aec27e958534b1c7f29d6abd16e08926707dd95e799b87ed1112                                                                                                                                       0.0s 
 => => naming to docker.io/vdesabou/kafka-docker-playground-connect:7.3.0                                                                                                                                                          0.0s 

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
13:53:52 ℹ️ 🎯 CONNECTOR_ZIP is set with /Users/ajain/projects/kafka-connect-elasticsearch/target/components/packages/confluentinc-kafka-connect-elasticsearch-11.1.14-SNAPSHOT.zip
13:53:52 ℹ️ 👷 Building Docker image vdesabou/kafka-docker-playground-connect:CP-7.3.0-confluentinc-kafka-connect-elasticsearch-11.1.14-SNAPSHOT.zip
[+] Building 4.6s (8/8) FINISHED                                                                                                                                                                                                        
 => [internal] load build definition from Dockerfile                                                                                                                                                                               0.0s
 => => transferring dockerfile: 297B                                                                                                                                                                                               0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                  0.0s
 => => transferring context: 2B                                                                                                                                                                                                    0.0s
 => [internal] load metadata for docker.io/vdesabou/kafka-docker-playground-connect:7.3.0                                                                                                                                          0.0s
 => [internal] load build context                                                                                                                                                                                                  0.7s
 => => transferring context: 27.74MB                                                                                                                                                                                               0.7s
 => [1/3] FROM docker.io/vdesabou/kafka-docker-playground-connect:7.3.0                                                                                                                                                            0.2s
 => [2/3] COPY --chown=appuser:appuser confluentinc-kafka-connect-elasticsearch-11.1.14-SNAPSHOT.zip /tmp                                                                                                                          0.3s
 => [3/3] RUN confluent-hub install --no-prompt /tmp/confluentinc-kafka-connect-elasticsearch-11.1.14-SNAPSHOT.zip                                                                                                                 3.1s
 => exporting to image                                                                                                                                                                                                             0.3s 
 => => exporting layers                                                                                                                                                                                                            0.2s
 => => writing image sha256:8534ca4c4b742a5958f492543ab61b8c5f333b10e790c28a8c60b50e7262839e                                                                                                                                       0.0s
 => => naming to docker.io/vdesabou/kafka-docker-playground-connect:CP-7.3.0-confluentinc-kafka-connect-elasticsearch-11.1.14-SNAPSHOT.zip                                                                                         0.0s

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
13:54:00 ℹ️ 🛑 Grafana is disabled
13:54:00 ℹ️ 🛑 kcat is disabled
13:54:00 ℹ️ 🛑 conduktor is disabled
zookeeper uses an image, skipping
elasticsearch uses an image, skipping
broker uses an image, skipping
schema-registry uses an image, skipping
connect uses an image, skipping
Stopping ksqldb-cli      ... done
Stopping control-center  ... done
Stopping ksqldb-server   ... done
Stopping connect         ... done
Stopping schema-registry ... done
Stopping zookeeper       ... done
Stopping broker          ... done
Stopping elasticsearch   ... done
Removing ksqldb-cli      ... done
Removing control-center  ... done
Removing ksqldb-server   ... done
Removing connect         ... done
Removing schema-registry ... done
Removing zookeeper       ... done
Removing broker          ... done
Removing elasticsearch   ... done
Removing network plaintext_default
Creating network "plaintext_default" with the default driver
Creating broker        ... done
Creating zookeeper     ... done
Creating elasticsearch ... done
Creating schema-registry ... done
Creating connect         ... done
Creating control-center  ... done
Creating ksqldb-server   ... done
Creating ksqldb-cli      ... done
13:54:32 ℹ️ 📝 To see the actual properties file, use ../../scripts/get-properties.sh <container>
13:54:32 ℹ️ ✨ If you modify a docker-compose file and want to re-create the container(s), run ../../scripts/recreate-containers.sh or use this command:
13:54:32 ℹ️ ✨ source ../../scripts/utils.sh && docker-compose -f ../../environment/plaintext/docker-compose.yml -f /Users/ajain/projects/kafka-docker-playground/connect/connect-elasticsearch-sink/docker-compose.plaintext.yml --profile control-center --profile ksqldb      up -d
13:54:32 ℹ️ ⌛ Waiting up to 480 seconds for connect to start
13:58:45 ℹ️ 🚦 connect is started!
13:58:45 ℹ️ 🔧 You can use ksqlDB with CLI using:
13:58:46 ℹ️ docker exec -i ksqldb-cli ksql http://ksqldb-server:8088
13:58:46 ℹ️ 📊 JMX metrics are available locally on those ports:
13:58:46 ℹ️     - zookeeper       : 9999
13:58:46 ℹ️     - broker          : 10000
13:58:46 ℹ️     - schema-registry : 10001
13:58:46 ℹ️     - connect         : 10002
13:58:46 ℹ️     - ksqldb-server   : 10003
13:58:46 ℹ️ Creating Elasticsearch Sink connector (Elasticsearch version is 7.12.0)
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   664  100   319  100   345     12     13  0:00:26  0:00:25  0:00:01    71
{
  "name": "elasticsearch-sink",
  "config": {
    "connector.class": "io.confluent.connect.elasticsearch.ElasticsearchSinkConnector",
    "tasks.max": "1",
    "topics": "test-elasticsearch-sink",
    "key.ignore": "true",
    "connection.url": "http://elasticsearch:9200",
    "type.name": "kafka-connect",
    "name": "elasticsearch-sink"
  },
  "tasks": [],
  "type": "sink"
}
13:59:12 ℹ️ Sending messages to topic test-elasticsearch-sink
13:59:35 ℹ️ Check that the data is available in Elasticsearch
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2447  100  2447    0     0   4660      0 --:--:-- --:--:-- --:--:--  4660
{
  "took" : 389,
  "timed_out" : false,
  "_shards" : {
    "total" : 1,
    "successful" : 1,
    "skipped" : 0,
    "failed" : 0
  },
  "hits" : {
    "total" : {
      "value" : 10,
      "relation" : "eq"
    },
    "max_score" : 1.0,
    "hits" : [
      {
        "_index" : "test-elasticsearch-sink",
        "_type" : "_doc",
        "_id" : "test-elasticsearch-sink+0+1",
        "_score" : 1.0,
        "_source" : {
          "f1" : "value2"
        }
      },
      {
        "_index" : "test-elasticsearch-sink",
        "_type" : "_doc",
        "_id" : "test-elasticsearch-sink+0+0",
        "_score" : 1.0,
        "_source" : {
          "f1" : "value1"
        }
      },
      {
        "_index" : "test-elasticsearch-sink",
        "_type" : "_doc",
        "_id" : "test-elasticsearch-sink+0+2",
        "_score" : 1.0,
        "_source" : {
          "f1" : "value3"
        }
      },
      {
        "_index" : "test-elasticsearch-sink",
        "_type" : "_doc",
        "_id" : "test-elasticsearch-sink+0+3",
        "_score" : 1.0,
        "_source" : {
          "f1" : "value4"
        }
      },
      {
        "_index" : "test-elasticsearch-sink",
        "_type" : "_doc",
        "_id" : "test-elasticsearch-sink+0+4",
        "_score" : 1.0,
        "_source" : {
          "f1" : "value5"
        }
      },
      {
        "_index" : "test-elasticsearch-sink",
        "_type" : "_doc",
        "_id" : "test-elasticsearch-sink+0+5",
        "_score" : 1.0,
        "_source" : {
          "f1" : "value6"
        }
      },
      {
        "_index" : "test-elasticsearch-sink",
        "_type" : "_doc",
        "_id" : "test-elasticsearch-sink+0+6",
        "_score" : 1.0,
        "_source" : {
          "f1" : "value7"
        }
      },
      {
        "_index" : "test-elasticsearch-sink",
        "_type" : "_doc",
        "_id" : "test-elasticsearch-sink+0+7",
        "_score" : 1.0,
        "_source" : {
          "f1" : "value8"
        }
      },
      {
        "_index" : "test-elasticsearch-sink",
        "_type" : "_doc",
        "_id" : "test-elasticsearch-sink+0+8",
        "_score" : 1.0,
        "_source" : {
          "f1" : "value9"
        }
      },
      {
        "_index" : "test-elasticsearch-sink",
        "_type" : "_doc",
        "_id" : "test-elasticsearch-sink+0+9",
        "_score" : 1.0,
        "_source" : {
          "f1" : "value10"
        }
      }
    ]
  }
}
          "f1" : "value1"
          "f1" : "value10"
          "f1" : "value10"

```

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
