### PR TITLE
[CC-19730] Revert to old logging behavior via optional config param

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
@@ -96,6 +96,7 @@ public class ElasticsearchClient {
       )
   );
 
+  private final boolean logSensitiveData;
   protected final AtomicInteger numRecords;
   private final AtomicReference<ConnectException> error;
   protected final BulkProcessor bulkProcessor;
@@ -119,6 +120,7 @@ public class ElasticsearchClient {
     this.config = config;
     this.reporter = reporter;
     this.clock = Time.SYSTEM;
+    this.logSensitiveData = config.shouldLogSensitiveData();
 
     ConfigCallbackHandler configCallbackHandler = new ConfigCallbackHandler(config);
     this.client = new RestHighLevelClient(
@@ -371,6 +373,25 @@ public class ElasticsearchClient {
   }
 
   /**
+   * Returns the formatted error message based on customers need to
+   * log exception traces.
+   * @param response The BulkItemResponse returned from Elasticsearch
+   * @param logSensitiveData Boolean flag to identify if customer needs to
+   *                         log exception traces for debugging
+   * @return String Formatted error message
+   */
+  private String getErrorMessage(BulkItemResponse response, boolean logSensitiveData) {
+    if (logSensitiveData) {
+      return response.getFailureMessage();
+    }
+    return String.format("Response status: '%s',\n"
+            + "Index: '%s',\n Document Id: '%s'. \n",
+            response.getFailure().getStatus(),
+            response.getFailure().getIndex(),
+            response.getFailure().getId());
+  }
+
+  /**
    * Calls the specified function with retries and backoffs until the retries are exhausted or the
    * function succeeds.
    *
@@ -467,7 +488,8 @@ public class ElasticsearchClient {
 
       error.compareAndSet(
           null,
-          new ConnectException("Indexing record failed.", response.getFailure().getCause())
+          new ConnectException("Indexing record failed.",
+                  new Throwable(getErrorMessage(response, logSensitiveData)))
       );
     }
   }
@@ -479,14 +501,8 @@ public class ElasticsearchClient {
    * @param response the failed response from ES
    */
   private void handleMalformedDocResponse(BulkItemResponse response) {
-    String errorMsg = String.format(
-        "Encountered an illegal document error -> Response status: '%s',\n"
-                + "Index: '%s',\n Document Id: '%s'. \n"
-                + "Ignoring and will not index record.",
-        response.getFailure().getStatus(),
-        response.getFailure().getIndex(),
-        response.getFailure().getId()
-    );
+    String errorMsg = String.format("Encountered an illegal document error '%s'."
+            + " Ignoring and will not index record." , getErrorMessage(response, logSensitiveData));
     switch (config.behaviorOnMalformedDoc()) {
       case IGNORE:
         log.debug(errorMsg);
@@ -496,24 +512,17 @@ public class ElasticsearchClient {
         return;
       case FAIL:
       default:
-        log.error(
-            "Encountered an illegal document error -> Response status: '{}',\n "
-                    + "Index: '{}',\n Document Id: '{}'\n"
-                    + " To ignore future records like this,"
-                    + " change the configuration '{}' to '{}'.",
-            response.getFailure().getStatus(),
-            response.getFailure().getIndex(),
-            response.getFailure().getId(),
-            ElasticsearchSinkConnectorConfig.BEHAVIOR_ON_MALFORMED_DOCS_CONFIG,
-            BehaviorOnMalformedDoc.IGNORE
+        log.error(String.format("Encountered an illegal document error '%s'."
+              + " To ignore future records like this,"
+              + " change the configuration '%s' to '%s'.",
+              getErrorMessage(response, logSensitiveData),
+              ElasticsearchSinkConnectorConfig.BEHAVIOR_ON_MALFORMED_DOCS_CONFIG,
+              BehaviorOnMalformedDoc.IGNORE)
         );
         error.compareAndSet(
             null,
             new ConnectException(
-                    "Indexing record failed -> Response status: "
-                    + response.getFailure().getStatus()
-                    + ",\n Index: " + response.getFailure().getIndex()
-                    + ",\n Document Id: " + response.getFailure().getId())
+                    "Indexing record failed -> " + getErrorMessage(response, logSensitiveData))
         );
     }
   }
@@ -566,13 +575,9 @@ public class ElasticsearchClient {
           ? sinkRecords.get(response.getItemId())
           : null;
       if (original != null) {
-        // log only status, index and document id for record failure
         reporter.report(
             original,
-            new ReportingException(
-                    "Indexing failed -> Response status: " + response.getFailure().getStatus()
-                    + ",\n Index: " + response.getFailure().getIndex()
-                    + ",\n Document Id: " + response.getFailure().getId())
+            new ReportingException("Indexing failed: " + getErrorMessage(response,logSensitiveData))
         );
       }
     }

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -246,6 +246,13 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   );
   private static final String WRITE_METHOD_DISPLAY = "Write Method";
   private static final String WRITE_METHOD_DEFAULT = WriteMethod.INSERT.name();
+  public static final String LOG_SENSITIVE_DATA_CONFIG = "log.sensitive.data";
+  private static final String LOG_SENSITIVE_DATA_DISPLAY = "Log Sensitive data";
+  private static final String LOG_SENSITIVE_DATA_DOC = "If true, logs sensitive data "
+          + "(such as exception traces containing sensitive data). "
+          + "Set this to true only in exceptional scenarios where logging sensitive data "
+          + "is acceptable and is necessary for troubleshooting.";
+  private static final Boolean LOG_SENSITIVE_DATA_DEFAULT = Boolean.FALSE;
 
   // Proxy group
   public static final String PROXY_HOST_CONFIG = "proxy.host";
@@ -485,6 +492,16 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
             ++order,
             Width.SHORT,
             READ_TIMEOUT_MS_DISPLAY
+        ).define(
+            LOG_SENSITIVE_DATA_CONFIG,
+            Type.BOOLEAN,
+            LOG_SENSITIVE_DATA_DEFAULT,
+            Importance.LOW,
+            LOG_SENSITIVE_DATA_DOC,
+            CONNECTOR_GROUP,
+            ++order,
+            Width.SHORT,
+            LOG_SENSITIVE_DATA_DISPLAY
     );
   }
 
@@ -743,6 +760,10 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
 
   public boolean compression() {
     return getBoolean(CONNECTION_COMPRESSION_CONFIG);
+  }
+
+  public boolean shouldLogSensitiveData() {
+    return getBoolean(LOG_SENSITIVE_DATA_CONFIG);
   }
 
   public int connectionTimeoutMs() {

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
@@ -1,15 +1,6 @@
 package io.confluent.connect.elasticsearch;
 
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_TIMEOUT_MS_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.CONNECTION_URL_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.KERBEROS_KEYTAB_PATH_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.PROXY_HOST_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.PROXY_PASSWORD_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.PROXY_PORT_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.PROXY_USERNAME_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.READ_TIMEOUT_MS_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SECURITY_PROTOCOL_CONFIG;
-import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SSL_CONFIG_PREFIX;
+import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.*;
 import static org.apache.kafka.common.config.SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -193,5 +184,18 @@ public class ElasticsearchSinkConnectorConfigTest {
     }
     props.put(ElasticsearchSinkConnectorConfig.CONNECTION_URL_CONFIG, "http://localhost:8080");
     return props;
+  }
+  @Test
+  public void testLogSensitiveData(){
+    ElasticsearchSinkConnectorConfig config = new ElasticsearchSinkConnectorConfig(props);
+    assertFalse(config.shouldLogSensitiveData());
+
+    props.put(LOG_SENSITIVE_DATA_CONFIG, "true");
+    config = new ElasticsearchSinkConnectorConfig(props);
+    assertTrue(config.shouldLogSensitiveData());
+
+    props.put(LOG_SENSITIVE_DATA_CONFIG, "false");
+    config = new ElasticsearchSinkConnectorConfig(props);
+    assertFalse(config.shouldLogSensitiveData());
   }
 }


### PR DESCRIPTION
## Problem
https://confluentinc.atlassian.net/browse/CC-19730

## Solution
https://confluent.slack.com/archives/C04V57GCUCS/p1679999708348829?thread_ts=1679509372.002709&cid=C04V57GCUCS

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [x] System tests
- [x] Manual tests
        -  Tested via docker playground
            Logs before log.sensitive.data is enabled: <img width="1067" alt="Screenshot 2023-03-29 at 5 09 54 PM" src="https://user-images.githubusercontent.com/121012039/228527591-e8ca822d-e573-4b5b-9fc6-b9b0afb6badc.png">
            Logs after log.sensitive.data is enabled: <img width="1106" alt="Screenshot 2023-03-29 at 5 11 40 PM" src="https://user-images.githubusercontent.com/121012039/228527771-ffa78618-038b-474a-904c-8b3ee652f2e0.png">

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
