### PR TITLE
fix confluent-version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
         <dependency.check.version>6.1.6</dependency.check.version>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
         <commons.codec.version>1.15</commons.codec.version>
+        <confluent.version>${io.confluent.common.version}</confluent.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
## Problem
${confluent.version} is absent in common 6.2.3. 

## Solution
Use ${io.confluent.common.version} instead.

