### PR TITLE
Allow to specify index name as a configuration property

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -71,6 +71,11 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   private static final String CONNECTION_PASSWORD_DISPLAY = "Connection Password";
   private static final String CONNECTION_PASSWORD_DEFAULT = null;
 
+  public static final String INDEX_NAME_CONFIG = "index.name";
+  private static final String INDEX_NAME_DOC = "Target index name";
+  private static final String INDEX_NAME_DISPLAY = "Index name";
+
+
   public static final String BATCH_SIZE_CONFIG = "batch.size";
   private static final String BATCH_SIZE_DOC =
       "The number of records to process as a batch when writing to Elasticsearch.";
@@ -480,6 +485,16 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
             ++order,
             Width.SHORT,
             CONNECTION_PASSWORD_DISPLAY
+        ).define(
+            INDEX_NAME_CONFIG,
+            Type.STRING,
+            null,
+            Importance.HIGH,
+            INDEX_NAME_DOC,
+            CONNECTOR_GROUP,
+            ++order,
+            Width.SHORT,
+            INDEX_NAME_DISPLAY
         ).define(
             BATCH_SIZE_CONFIG,
             Type.INT,
@@ -1048,6 +1063,10 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
 
   public Password password() {
     return getPassword(CONNECTION_PASSWORD_CONFIG);
+  }
+
+  public String indexName() {
+    return getString(INDEX_NAME_CONFIG);
   }
 
   public String proxyHost() {

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -15,12 +15,7 @@
 
 package io.confluent.connect.elasticsearch;
 
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-import java.util.function.BooleanSupplier;
-
+import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BehaviorOnNullValues;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.errors.ConnectException;
@@ -33,7 +28,11 @@ import org.elasticsearch.action.DocWriteRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BehaviorOnNullValues;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BooleanSupplier;
 
 @SuppressWarnings("checkstyle:ClassDataAbstractionCoupling")
 public class ElasticsearchSinkTask extends SinkTask {
@@ -218,6 +217,12 @@ public class ElasticsearchSinkTask extends SinkTask {
    * (<a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html#indices-create-api-path-params">ref</a>_.)
    */
   private String createIndexName(String topic) {
+    String indexName = config.indexName();
+
+    if (indexName != null && !indexName.isEmpty()) {
+      return indexName;
+    }
+
     return config.isDataStream()
         ? convertTopicToDataStreamName(topic)
         : convertTopicToIndexName(topic);


### PR DESCRIPTION
## Problem

Currently as per limitations its not possible to use `RegexRouter` to specify the target index name without compromising on performance ( asynchronous writes must be disabled ). 

## Solution

Allow to specify the index name directly in the configuration.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan

Simple configuration change.
