### PR TITLE
Introduce optional external.version.header config

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
@@ -25,10 +25,14 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.header.Header;
 import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.storage.Converter;
+import org.apache.kafka.connect.storage.HeaderConverter;
+import org.apache.kafka.connect.storage.SimpleHeaderConverter;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.index.IndexRequest;
@@ -52,6 +56,7 @@ public class DataConverter {
   private static final Logger log = LoggerFactory.getLogger(DataConverter.class);
 
   private static final Converter JSON_CONVERTER;
+  private static final HeaderConverter HEADER_CONVERTER = new SimpleHeaderConverter();
   protected static final String MAP_KEY = "key";
   protected static final String MAP_VALUE = "value";
 
@@ -202,7 +207,24 @@ public class DataConverter {
   ) {
     if (!config.shouldIgnoreKey(record.topic())) {
       request.versionType(VersionType.EXTERNAL);
-      request.version(record.kafkaOffset());
+      if (config.hasExternalVersionHeader()) {
+        final Header versionHeader = record.headers().lastWithName(config.externalVersionHeader());
+        final byte[] versionValue = HEADER_CONVERTER.fromConnectHeader(
+                record.topic(),
+                versionHeader.key(),
+                versionHeader.schema(),
+                versionHeader.value()
+        );
+        try {
+          //fromConnectHeader byte output is UTF_8
+          request.version(Long.parseLong(new String(versionValue, StandardCharsets.UTF_8)));
+        } catch (NumberFormatException e) {
+          throw new ConnectException("Error converting to long: "
+                  + new String(versionValue, StandardCharsets.UTF_8), e);
+        }
+      } else {
+        request.version(record.kafkaOffset());
+      }
     }
 
     return request;

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -226,6 +226,13 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   private static final BehaviorOnMalformedDoc BEHAVIOR_ON_MALFORMED_DOCS_DEFAULT =
       BehaviorOnMalformedDoc.FAIL;
 
+  public static final String EXTERNAL_VERSION_HEADER_CONFIG = "external.version.header";
+  private static final String EXTERNAL_VERSION_HEADER_DOC = "Header name to pull value for"
+          + " external versioning, defaults to using the kafka record offset.  Must have a numeric"
+          + " value.";
+  private static final String EXTERNAL_VERSION_HEADER_DISPLAY = "External Version Header Name";
+  private static final String EXTERNAL_VERSION_HEADER_DEFAULT = "";
+
   public static final String WRITE_METHOD_CONFIG = "write.method";
   private static final String WRITE_METHOD_DOC = String.format(
       "Method used for writing data to Elasticsearch, and one of %s or %s. The default method is"
@@ -593,6 +600,16 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
             BEHAVIOR_ON_MALFORMED_DOCS_DISPLAY,
             new EnumRecommender<>(BehaviorOnMalformedDoc.class)
         ).define(
+                    EXTERNAL_VERSION_HEADER_CONFIG,
+            Type.STRING,
+                    EXTERNAL_VERSION_HEADER_DEFAULT,
+            Importance.LOW,
+                    EXTERNAL_VERSION_HEADER_DOC,
+            DATA_CONVERSION_GROUP,
+            ++order,
+            Width.SHORT,
+                    EXTERNAL_VERSION_HEADER_DISPLAY
+        ).define(
             WRITE_METHOD_CONFIG,
             Type.STRING,
             WRITE_METHOD_DEFAULT,
@@ -872,6 +889,14 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
 
   public boolean useCompactMapEntries() {
     return getBoolean(COMPACT_MAP_ENTRIES_CONFIG);
+  }
+
+  public boolean hasExternalVersionHeader() {
+    return !getString(EXTERNAL_VERSION_HEADER_CONFIG).isEmpty();
+  }
+
+  public String externalVersionHeader() {
+    return getString(EXTERNAL_VERSION_HEADER_CONFIG);
   }
 
   public WriteMethod writeMethod() {

--- a/src/test/java/io/confluent/connect/elasticsearch/DataConverterTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/DataConverterTest.java
@@ -20,6 +20,7 @@ import org.apache.kafka.connect.data.*;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.elasticsearch.action.delete.DeleteRequest;
+import org.elasticsearch.action.index.IndexRequest;
 import org.junit.Before;
 import org.junit.Test;
 


### PR DESCRIPTION
 Introduce optional external.version.header config to use for ES external version instead of kafka offset for non-datastream indices

## Problem

After changing an index mapping, we need to reindex.  To do this, we create a new index, run a batch job with all the existing input documents, while at the same time streaming realtime updates, ensuring we do not miss any documents.  Today both can't run at the same time because we might overwrite a new streamed update with a batch index.

## Solution

ES external versioning can be used to compare document versions for idempotency.  We will be able to pull a version out of the document into a kafka header and use the same version in the batch job.  We choose header so that deletes with null values are also idempotent.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ x] yes
- [ ] no

##### If yes, where?
There are a couple of other uses cases that may be solved by this control.
https://github.com/confluentinc/kafka-connect-elasticsearch/issues?q=is%3Aissue+is%3Aopen+external+version

## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
If merged, we will run this connector in Confluent Cloud.  Else, we will run the fork.  As an optional feature, with a default that does not affect existing usages, it is backwards compatible.
<!-- Are you backporting or merging to master? -->
master
<!-- If you are reverting or rolling back, is it safe? --> 
n/a

Thank you, and please pick this apart!