### PR TITLE
Adding upgrade test for ElasticSearch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ common {
 }
 
 def upgradeConnectorTest(body) {
-    build job: "confluentinc/connect-comprehensive-test-framework/PR-3/", parameters: [
+    build job: "confluentinc/connect-comprehensive-test-framework/master/", parameters: [
                         string(name: 'PLUGIN_NAME', value: 'kafka-connect-elasticsearch'),
                         string(name: 'BRANCH_TO_TEST', value: env.CHANGE_BRANCH)
                     ], wait: true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ common {
 }
 
 def upgradeConnectorTest(body) {
-    build job: "confluentinc-pr/connect-comprehensive-test-framework/PR-3/", parameters: [
+    build job: "confluentinc/connect-comprehensive-test-framework/PR-3/", parameters: [
                         string(name: 'PLUGIN_NAME', value: 'kafka-connect-elasticsearch'),
                         string(name: 'BRANCH_TO_TEST', value: env.CHANGE_BRANCH)
                     ], wait: true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,5 +13,4 @@ def upgradeConnectorTest(body) {
                         string(name: 'BRANCH_TO_TEST', value: env.CHANGE_BRANCH)
                     ], wait: true
 }
-
 upgradeConnectorTest{}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,4 +4,14 @@ common {
   upstreamProjects = 'confluentinc/common'
   pintMerge = true
   downStreamValidate = false
+  nodeLabel = 'docker-debian-jdk8'
 }
+
+def call(body) {
+    build job: "confluentinc-pr/connect-comprehensive-test-framework/PR-3/", parameters: [
+                        string(name: 'PLUGIN_NAME', value: 'kafka-connect-elasticsearch'),
+                        string(name: 'BRANCH_TO_TEST', value: env.CHANGE_BRANCH)
+                    ], wait: true
+}
+
+call{}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,11 +7,11 @@ common {
   nodeLabel = 'docker-debian-jdk8'
 }
 
-def call(body) {
+def upgradeConnectorTest(body) {
     build job: "confluentinc-pr/connect-comprehensive-test-framework/PR-3/", parameters: [
                         string(name: 'PLUGIN_NAME', value: 'kafka-connect-elasticsearch'),
                         string(name: 'BRANCH_TO_TEST', value: env.CHANGE_BRANCH)
                     ], wait: true
 }
 
-call{}
+upgradeConnectorTest{}


### PR DESCRIPTION
## Problem
https://github.com/confluentinc/connect-comprehensive-test-framework/pull/3
Enabling Upgrade Connector Test. For each PR and merge commit a build will trigger on connect-comprehensive-test-framework Jenkins, which will run the latest tag connector for that ff branch and the PR changes, mimicking the upgrade scenario.





## Test Strategy
https://jenkins.confluent.io/job/Confluent%20Public%20Repo%20PR%20builder/job/kafka-connect-elasticsearch/view/change-requests/job/PR-705/5/
Auto triggered a build on connect-comprehensive-test-framework
https://jenkins.confluent.io/job/confluentinc/job/connect-comprehensive-test-framework/job/master/12/consoleFull


