### PR TITLE
[CC-20333] CVE fix for jackson package

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,4 +4,5 @@ common {
   upstreamProjects = 'confluentinc/common'
   pintMerge = true
   downStreamValidate = false
+  nodeLabel = 'docker-debian-jdk8'
 }

--- a/pom.xml
+++ b/pom.xml
@@ -48,8 +48,8 @@
         <hadoop.version>3.3.0</hadoop.version>
         <apacheds-jdbm1.version>2.0.0-M2</apacheds-jdbm1.version>
         <!-- TODO: Remove the version pin after releasing https://github.com/confluentinc/common/pull/494 -->
-        <jackson.databind.version>2.14.0</jackson.databind.version>
-        <jackson.version>2.14.0</jackson.version>
+        <jackson.databind.version>2.15.0</jackson.databind.version>
+        <jackson.version>2.15.0</jackson.version>
         <!-- temporary fix by pinning the version until we upgrade to a version of common that contains this or newer version.
             See https://github.com/confluentinc/common/pull/332 for details -->
         <dependency.check.version>6.1.6</dependency.check.version>

--- a/pom.xml
+++ b/pom.xml
@@ -37,11 +37,10 @@
         <tag>11.1.x</tag>
     </scm>
 
-    
     <properties>
         <es.version>7.9.3</es.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <mockito.version>2.28.2</mockito.version>
+        <mockito.version>5.2.0</mockito.version>
         <gson.version>2.8.6</gson.version>
         <test.containers.version>1.15.0</test.containers.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <properties>
         <es.version>7.9.3</es.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <mockito.version>5.2.0</mockito.version>
+        <mockito.version>2.28.2</mockito.version>
         <gson.version>2.8.6</gson.version>
         <test.containers.version>1.15.0</test.containers.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
         <tag>11.1.x</tag>
     </scm>
 
+    
     <properties>
         <es.version>7.9.3</es.version>
         <hamcrest.version>1.3</hamcrest.version>


### PR DESCRIPTION
## Problem
https://confluentinc.atlassian.net/browse/CC-20333

## Solution
Fixed to 2.15.0 version 
<img width="1164" alt="Screenshot 2023-07-31 at 6 43 05 PM" src="https://github.com/confluentinc/kafka-connect-elasticsearch/assets/121012039/d1e8d3ae-b62b-4afb-96b7-2b79d75f317b">




<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [x] Manual tests
              - Docker Playground
          
```
Creating Elasticsearch Sink connector (Elasticsearch version is 7.0.0)
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   634  100   334  100   300   5220   4688 --:--:-- --:--:-- --:--:-- 10745
{
  "name": "elasticsearch-sink",
  "config": {
    "connector.class": "io.confluent.connect.elasticsearch.ElasticsearchSinkConnector",
    "tasks.max": "1",
    "topics": "test-elasticsearch-sink",
    "key.ignore": "true",
    "connection.url": "http://elasticsearch:9200",
    "name": "elasticsearch-sink"
  },
  "tasks": [
    {
      "connector": "elasticsearch-sink",
      "task": 0
    }
  ],
  "type": "sink"
}
Sending messages to topic test-elasticsearch-sink
11:16:31 ℹ️ 🔮 schema was identified as avro
11:16:31 ℹ️ ✨ generating data...
11:16:31 ℹ️ ☢️ --forced-value is set
11:16:31 ℹ️ ✨ 10 records were generated based on --forced-value  (only showing first 10), took: 0min 1sec
{"f1":"value1"}
{"f1":"value2"}
{"f1":"value3"}
{"f1":"value4"}
{"f1":"value5"}
{"f1":"value6"}
{"f1":"value7"}
{"f1":"value8"}
{"f1":"value9"}
{"f1":"value10"}
11:16:35 ℹ️ 💯 Get number of records in topic test-elasticsearch-sink
0
11:16:35 ℹ️ 🛡️ Set compatibility for subject test-elasticsearch-sink-value to NONE
{"compatibility":"NONE"}11:16:35 ℹ️ 📤 producing 10 records to topic test-elasticsearch-sink
11:16:37 ℹ️ 📤 produced 10 records to topic test-elasticsearch-sink, took: 0min 2sec
11:16:37 ℹ️ 💯 Get number of records in topic test-elasticsearch-sink
10
Check that the data is available in Elasticsearch
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2446  100  2446    0     0  32522      0 --:--:-- --:--:-- --:--:-- 34942
{
  "took" : 54,
  "timed_out" : false,
  "_shards" : {
    "total" : 1,
    "successful" : 1,
    "skipped" : 0,
    "failed" : 0
  },
  "hits" : {
    "total" : {
      "value" : 10,
      "relation" : "eq"
    },
    "max_score" : 1.0,
    "hits" : [
      {
        "_index" : "test-elasticsearch-sink",
        "_type" : "_doc",
        "_id" : "test-elasticsearch-sink+0+0",
        "_score" : 1.0,
        "_source" : {
          "f1" : "value1"
        }
      },
      {
        "_index" : "test-elasticsearch-sink",
        "_type" : "_doc",
        "_id" : "test-elasticsearch-sink+0+1",
        "_score" : 1.0,
        "_source" : {
          "f1" : "value2"
        }
      },
      {
        "_index" : "test-elasticsearch-sink",
        "_type" : "_doc",
        "_id" : "test-elasticsearch-sink+0+2",
        "_score" : 1.0,
        "_source" : {
          "f1" : "value3"
        }
      },
      {
        "_index" : "test-elasticsearch-sink",
        "_type" : "_doc",
        "_id" : "test-elasticsearch-sink+0+3",
        "_score" : 1.0,
        "_source" : {
          "f1" : "value4"
        }
      },
      {
        "_index" : "test-elasticsearch-sink",
        "_type" : "_doc",
        "_id" : "test-elasticsearch-sink+0+4",
        "_score" : 1.0,
        "_source" : {
          "f1" : "value5"
        }
      },
      {
        "_index" : "test-elasticsearch-sink",
        "_type" : "_doc",
        "_id" : "test-elasticsearch-sink+0+5",
        "_score" : 1.0,
        "_source" : {
          "f1" : "value6"
        }
      },
      {
        "_index" : "test-elasticsearch-sink",
        "_type" : "_doc",
        "_id" : "test-elasticsearch-sink+0+6",
        "_score" : 1.0,
        "_source" : {
          "f1" : "value7"
        }
      },
      {
        "_index" : "test-elasticsearch-sink",
        "_type" : "_doc",
        "_id" : "test-elasticsearch-sink+0+7",
        "_score" : 1.0,
        "_source" : {
          "f1" : "value8"
        }
      },
      {
        "_index" : "test-elasticsearch-sink",
        "_type" : "_doc",
        "_id" : "test-elasticsearch-sink+0+8",
        "_score" : 1.0,
        "_source" : {
          "f1" : "value9"
        }
      },
      {
        "_index" : "test-elasticsearch-sink",
        "_type" : "_doc",
        "_id" : "test-elasticsearch-sink+0+9",
        "_score" : 1.0,
        "_source" : {
          "f1" : "value10"
        }
      }
    ]
  }
}
          "f1" : "value1"
          "f1" : "value10"
          "f1" : "value10"
          
``` 


## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
