### PR TITLE
CC-22326 | Bump up jackson version to increase max string value length from 5 to 20 million chars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,8 +48,8 @@
         <hadoop.version>3.3.0</hadoop.version>
         <apacheds-jdbm1.version>2.0.0-M2</apacheds-jdbm1.version>
         <!-- TODO: Remove the version pin after releasing https://github.com/confluentinc/common/pull/494 -->
-        <jackson.databind.version>2.15.0</jackson.databind.version>
-        <jackson.version>2.15.0</jackson.version>
+        <jackson.databind.version>2.15.2</jackson.databind.version>
+        <jackson.version>2.15.2</jackson.version>
         <!-- temporary fix by pinning the version until we upgrade to a version of common that contains this or newer version.
             See https://github.com/confluentinc/common/pull/332 for details -->
         <dependency.check.version>6.1.6</dependency.check.version>


### PR DESCRIPTION
## Problem
Connector fails with payloads > 5MB

## Solution
Bump up jackson dependency to include the following fix https://github.com/FasterXML/jackson-core/commit/0484754660f6576667581fbe55fb4da325633953


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests - Docker Playground.

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
