### PR TITLE
Bump elastic search client and kafka dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,12 +102,7 @@
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-cbor</artifactId>
         </dependency>
-        <!-- pin commons-codec for CVE -->
-        <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <version>1.15</version>
-        </dependency>
+
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
@@ -118,12 +113,6 @@
             <artifactId>gson</artifactId>
             <version>${gson.version}</version>
             <scope>test</scope>
-        </dependency>
-        <!-- Force commons-codec (httpclient transitive dependency) version to address CVE CCMSG-835 -->
-        <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <version>1.15</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>6.2.3</version>
+        <version>7.0.12</version>
     </parent>
 
     <artifactId>kafka-connect-elasticsearch</artifactId>
@@ -37,7 +37,7 @@
     </scm>
 
     <properties>
-        <es.version>7.17.1</es.version>
+        <es.version>7.17.13</es.version>
         <hamcrest.version>1.3</hamcrest.version>
         <mockito.version>2.28.2</mockito.version>
         <gson.version>2.9.0</gson.version>
@@ -166,10 +166,9 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
-        <!-- Use a repackaged version of log4j with security patches. Default log4j v1.2 is a transitive dependency of connect-runtime, but it is excluded in common/pom.xml -->
         <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>confluent-log4j</artifactId>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Problem
Fix CVE-2023-31418 and CVE-2023-43642


## Solution
Update elastic search client version and io.confluent:common to fix snappy-java

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests - Tested on docker playground against few of elastic search server versions -  7.12.0, 7.17.0 and 8.11.0

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
The fix will be released to CP first and then fixed in cloud.
The patch will be backported to older branches after some additional fixes.
