### PR TITLE
Add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
## Problem

Keeping the dependencies up to date is crucial to ensure that the project stays secure and updated. 

## Solution

See https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?

Any repository with dependencies should aim to keep the dependencies up to date automatically

