### PR TITLE
add 'data.stream.namespace' configuration property

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
@@ -520,7 +520,7 @@ public class ElasticsearchClient {
   /**
    * Creates a data stream. Will not recreate the data stream if it already exists.
    *
-   * @param dataStream the data stream to create given in the form {type}-{dataset}-{topic}
+   * @param dataStream the data stream to create given in the form {type}-{dataset}-{namespace}
    * @return true if the data stream was created, false if it already exists
    */
   private boolean createDataStream(String dataStream) {

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -182,8 +182,9 @@ public class ElasticsearchSinkTask extends SinkTask {
   }
 
   /**
-   * Returns the converted index name from a given topic name in the form {type}-{dataset}-{topic}.
-   * For the <code>topic</code>, Elasticsearch accepts:
+   * Returns the converted datastream name from a given topic name in the form:
+   * {type}-{dataset}-{namespace}
+   * For the <code>namespace</code> (that can contain topic), Elasticsearch accepts:
    * <ul>
    *   <li>all lowercase</li>
    *   <li>no longer than 100 bytes</li>
@@ -191,22 +192,23 @@ public class ElasticsearchSinkTask extends SinkTask {
    * (<a href="https://github.com/elastic/ecs/blob/master/rfcs/text/0009-data_stream-fields.md#restrictions-on-values">ref</a>_.)
    */
   private String convertTopicToDataStreamName(String topic) {
-    topic = topic.toLowerCase();
-    if (topic.length() > 100) {
-      topic = topic.substring(0, 100);
+    String namespace = config.dataStreamNamespace();
+    namespace = namespace.replace("${topic}", topic.toLowerCase());
+    if (namespace.length() > 100) {
+      namespace = namespace.substring(0, 100);
     }
     String dataStream = String.format(
         "%s-%s-%s",
         config.dataStreamType().name().toLowerCase(),
         config.dataStreamDataset(),
-        topic
+        namespace
     );
     return dataStream;
   }
 
   /**
    * Returns the converted index name from a given topic name. If writing to a data stream,
-   * returns the index name in the form {type}-{dataset}-{topic}. For both cases, Elasticsearch
+   * returns the index name in the form {type}-{dataset}-{namespace}. For both cases, Elasticsearch
    * accepts:
    * <ul>
    *   <li>all lowercase</li>

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
@@ -52,6 +52,12 @@ public class ElasticsearchSinkConnectorConfigTest {
   }
 
   @Test
+  public void shouldAllowValidChractersDataStreamNamespace() {
+    props.put(DATA_STREAM_NAMESPACE_CONFIG, "a_valid.namespace123");
+    new ElasticsearchSinkConnectorConfig(props);
+  }
+
+  @Test
   public void shouldAllowValidChractersDataStreamDataset() {
     props.put(DATA_STREAM_DATASET_CONFIG, "a_valid.dataset123");
     new ElasticsearchSinkConnectorConfig(props);
@@ -70,8 +76,20 @@ public class ElasticsearchSinkConnectorConfigTest {
   }
 
   @Test(expected = ConfigException.class)
+  public void shouldNotAllowInvalidCaseDataStreamNamespace() {
+    props.put(DATA_STREAM_NAMESPACE_CONFIG, "AN_INVALID.namespace123");
+    new ElasticsearchSinkConnectorConfig(props);
+  }
+
+  @Test(expected = ConfigException.class)
   public void shouldNotAllowInvalidCaseDataStreamDataset() {
     props.put(DATA_STREAM_DATASET_CONFIG, "AN_INVALID.dataset123");
+    new ElasticsearchSinkConnectorConfig(props);
+  }
+
+  @Test(expected = ConfigException.class)
+  public void shouldNotAllowInvalidCharactersDataStreamNamespace() {
+    props.put(DATA_STREAM_NAMESPACE_CONFIG, "not-valid?");
     new ElasticsearchSinkConnectorConfig(props);
   }
 
@@ -84,6 +102,12 @@ public class ElasticsearchSinkConnectorConfigTest {
   @Test(expected = ConfigException.class)
   public void shouldNotAllowInvalidDataStreamType() {
     props.put(DATA_STREAM_TYPE_CONFIG, "notLogOrMetrics");
+    new ElasticsearchSinkConnectorConfig(props);
+  }
+
+  @Test(expected = ConfigException.class)
+  public void shouldNotAllowLongDataStreamNamespace() {
+    props.put(DATA_STREAM_NAMESPACE_CONFIG, String.format("%d%100d", 1, 1));
     new ElasticsearchSinkConnectorConfig(props);
   }
 


### PR DESCRIPTION
## Problem
Currently, we cannot fully customize the target data stream.
More precisely, the namespace part of the data stream is necessarily the topic.
This is especially a problem, when you want that a connector consumes several topics for only one target data stream.
More simply, I want to be able to define target data stream name, regardless of the input topic name.

## Solution
This PR aims to add a new configuration property named 'data.stream.namespace'.
This property aims to customize data stream "namespace" part (as its name says).
This is an optional setting, that have `${topic}` as default value ; so that, by default, it works as currently, no breaking change.
By the way, user is able to define a custom namespace that contains topic name like that:
`my_prefix_${topic}`

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
I guess that you (Confluent Inc.) is responsible for release plan.
<!-- Are you backporting or merging to master? -->
I am merging to master
<!-- If you are reverting or rolling back, is it safe? --> 
It is safe to revert or rollback
