### PR TITLE
index templates other than logs and metrics when using data streams

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -350,7 +350,8 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
           + "The default is %s which indicates the connector will write "
           + "to regular indices instead. If set, this configuration will "
           + "be used alongside %s to construct the data stream name in the form of "
-          + "{``%s``}-{``%s``}-{topic}.",
+          + "{``%s``}-{``%s``}-{topic}. Custom index templates defined in the destination "
+          + "cluster are supported.",
       DataStreamType.NONE.name(),
       DATA_STREAM_DATASET_CONFIG,
       DATA_STREAM_TYPE_CONFIG,
@@ -834,7 +835,6 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
             DATA_STREAM_TYPE_CONFIG,
             Type.STRING,
             DATA_STREAM_TYPE_DEFAULT.name(),
-            new EnumRecommender<>(DataStreamType.class),
             Importance.LOW,
             DATA_STREAM_TYPE_DOC,
             DATA_STREAM_GROUP,
@@ -870,7 +870,8 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   }
 
   public boolean isDataStream() {
-    return dataStreamType() != DataStreamType.NONE && !dataStreamDataset().isEmpty();
+    return !dataStreamType().toUpperCase().equals(DataStreamType.NONE.name())
+            && !dataStreamDataset().isEmpty();
   }
 
   public boolean isProxyWithAuthenticationConfigured() {
@@ -946,8 +947,8 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
     return getString(DATA_STREAM_DATASET_CONFIG);
   }
 
-  public DataStreamType dataStreamType() {
-    return DataStreamType.valueOf(getString(DATA_STREAM_TYPE_CONFIG).toUpperCase());
+  public String dataStreamType() {
+    return getString(DATA_STREAM_TYPE_CONFIG);
   }
 
   public List<String> dataStreamTimestampField() {

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -197,7 +197,7 @@ public class ElasticsearchSinkTask extends SinkTask {
     }
     String dataStream = String.format(
         "%s-%s-%s",
-        config.dataStreamType().name().toLowerCase(),
+        config.dataStreamType().toLowerCase(),
         config.dataStreamDataset(),
         topic
     );

--- a/src/main/java/io/confluent/connect/elasticsearch/Validator.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/Validator.java
@@ -138,7 +138,8 @@ public class Validator {
   }
 
   private void validateDataStreamConfigs() {
-    if (config.dataStreamType() == DataStreamType.NONE ^ config.dataStreamDataset().isEmpty()) {
+    if (config.dataStreamType().toUpperCase().equals(DataStreamType.NONE.name())
+            ^ config.dataStreamDataset().isEmpty()) {
       String errorMessage = String.format(
           "Either both or neither '%s' and '%s' must be set.",
           DATA_STREAM_DATASET_CONFIG,

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
@@ -82,12 +82,6 @@ public class ElasticsearchSinkConnectorConfigTest {
   }
 
   @Test(expected = ConfigException.class)
-  public void shouldNotAllowInvalidDataStreamType() {
-    props.put(DATA_STREAM_TYPE_CONFIG, "notLogOrMetrics");
-    new ElasticsearchSinkConnectorConfig(props);
-  }
-
-  @Test(expected = ConfigException.class)
   public void shouldNotAllowLongDataStreamDataset() {
     props.put(DATA_STREAM_DATASET_CONFIG, String.format("%d%100d", 1, 1));
     new ElasticsearchSinkConnectorConfig(props);


### PR DESCRIPTION
index templates other than logs and metrics when using data streams #751 

## Problem
In most real world scenarios a user is not in control over the default index templates "logs" and "metrics". There are many usecases where the user wants to define a custom template. In my case I want to use the data retention feature to delete messages stored in elasticsearch after a certain amount of time.

Currently this connector is able to use the predefined index templates "logs" and "metrics" when data streams are enabled. User created templates are not supported yet.

## Solution
Defining the type of the data stream as String to make it flexible for custom inputs. The enum will not be removed to still be able to use the recommender when deploying the connector via control-center.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no


## Test Strategy
Started a local cluster via docker-compose (cp-quickstart and elastic+kibana) and installed the connector.zip in the cluster. Both connectors with "logs" and connectors with "custom" as data stream types were running perfectly fine after creating the "custom" index template in Kibana. 

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [x] System tests
- [x] Manual tests