### PR TITLE
Support for max retry backoff time (#750)

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
@@ -491,7 +491,8 @@ public class ElasticsearchClient {
         description,
         function,
         config.maxRetries() + 1,
-        config.retryBackoffMs()
+        config.retryBackoffMs(),
+        config.maxRetryDurationMs()
     );
   }
 

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
@@ -226,6 +226,27 @@ public class ElasticsearchSinkConnectorConfigTest {
     keytab.toFile().delete();
   }
 
+  @Test
+  public void maxRetryDurationValueCheck() {
+    // Allowed
+    props.put(RETRY_BACKOFF_MS_CONFIG, "10");
+    props.put(MAX_RETRY_DURATION_MS_CONFIG, "100");
+    ElasticsearchSinkConnectorConfig config = new ElasticsearchSinkConnectorConfig(props);
+    assertEquals(100, config.maxRetryDurationMs());
+
+    // maxRetryDuration = initialBackoff. Not allowed. Takes default
+    props.put(RETRY_BACKOFF_MS_CONFIG, "100");
+    props.put(MAX_RETRY_DURATION_MS_CONFIG, "100");
+    config = new ElasticsearchSinkConnectorConfig(props);
+    assertEquals(MAX_RETRY_TIME_MS, config.maxRetryDurationMs());
+
+    // maxRetryDuration < initialBackoff. Not allowed. Takes default
+    props.put(RETRY_BACKOFF_MS_CONFIG, "100");
+    props.put(MAX_RETRY_DURATION_MS_CONFIG, "10");
+    config = new ElasticsearchSinkConnectorConfig(props);
+    assertEquals(MAX_RETRY_TIME_MS, config.maxRetryDurationMs());
+  }
+
   public static Map<String, String> addNecessaryProps(Map<String, String> props) {
     if (props == null) {
       props = new HashMap<>();
@@ -233,6 +254,7 @@ public class ElasticsearchSinkConnectorConfigTest {
     props.put(ElasticsearchSinkConnectorConfig.CONNECTION_URL_CONFIG, "http://localhost:8080");
     return props;
   }
+
   @Test
   public void testLogSensitiveData(){
     ElasticsearchSinkConnectorConfig config = new ElasticsearchSinkConnectorConfig(props);


### PR DESCRIPTION
## Problem

The current max retry back off time is set at a constant of 24 hours. This duration is too long to be practical.

## Solution

Making the duration configurable by creating a new property `max.retry.duration.ms`. This property has the following features 
- It has a default value of 24 hours (just like before). 
- It must have a value greater than the value of `retry.backoff.ms` (initial backoff time). If a smaller or equal value is set, a warning message is thrown and the default value is selected instead.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
