### PR TITLE
[CC-27487] Error Reporting in Elasticsearch via Errant Reporter

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
@@ -696,6 +696,13 @@ public class ElasticsearchClient {
    * @param executionId the execution id of the request associated with the response
    */
   private synchronized void reportBadRecordAndError(BulkItemResponse response, long executionId) {
+
+    // RCCA-7507 : Don't push to DLQ if we receive Internal version conflict on data streams
+    if (response.getFailureMessage().contains(VERSION_CONFLICT_EXCEPTION)
+            && config.isDataStream()) {
+      log.debug("Skipping DLQ insertion for DataStream type.");
+      return;
+    }
     if (reporter != null) {
       List<SinkRecordAndOffset> sinkRecords =
           inFlightRequests.getOrDefault(executionId, new ArrayList<>());

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -277,13 +277,6 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   );
   private static final String WRITE_METHOD_DISPLAY = "Write Method";
   private static final String WRITE_METHOD_DEFAULT = WriteMethod.INSERT.name();
-  public static final String LOG_SENSITIVE_DATA_CONFIG = "log.sensitive.data";
-  private static final String LOG_SENSITIVE_DATA_DISPLAY = "Log Sensitive data";
-  private static final String LOG_SENSITIVE_DATA_DOC = "If true, logs sensitive data "
-          + "(such as exception traces containing sensitive data). "
-          + "Set this to true only in exceptional scenarios where logging sensitive data "
-          + "is acceptable and is necessary for troubleshooting.";
-  private static final Boolean LOG_SENSITIVE_DATA_DEFAULT = Boolean.FALSE;
 
   // Proxy group
   public static final String PROXY_HOST_CONFIG = "proxy.host";
@@ -597,16 +590,6 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
             ++order,
             Width.SHORT,
             READ_TIMEOUT_MS_DISPLAY
-        ).define(
-            LOG_SENSITIVE_DATA_CONFIG,
-            Type.BOOLEAN,
-            LOG_SENSITIVE_DATA_DEFAULT,
-            Importance.LOW,
-            LOG_SENSITIVE_DATA_DOC,
-            CONNECTOR_GROUP,
-            ++order,
-            Width.SHORT,
-            LOG_SENSITIVE_DATA_DISPLAY
     );
   }
 
@@ -922,10 +905,6 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
 
   public boolean compression() {
     return getBoolean(CONNECTION_COMPRESSION_CONFIG);
-  }
-
-  public boolean shouldLogSensitiveData() {
-    return getBoolean(LOG_SENSITIVE_DATA_CONFIG);
   }
 
   public int connectionTimeoutMs() {

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -95,7 +95,6 @@ public class ElasticsearchSinkTask extends SinkTask {
   @Override
   public void put(Collection<SinkRecord> records) throws ConnectException {
     log.debug("Putting {} records to Elasticsearch.", records.size());
-
     client.throwIfFailed();
     partitionPauser.maybeResumePartitions();
 

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
@@ -233,17 +233,4 @@ public class ElasticsearchSinkConnectorConfigTest {
     props.put(ElasticsearchSinkConnectorConfig.CONNECTION_URL_CONFIG, "http://localhost:8080");
     return props;
   }
-  @Test
-  public void testLogSensitiveData(){
-    ElasticsearchSinkConnectorConfig config = new ElasticsearchSinkConnectorConfig(props);
-    assertFalse(config.shouldLogSensitiveData());
-
-    props.put(LOG_SENSITIVE_DATA_CONFIG, "true");
-    config = new ElasticsearchSinkConnectorConfig(props);
-    assertTrue(config.shouldLogSensitiveData());
-
-    props.put(LOG_SENSITIVE_DATA_CONFIG, "false");
-    config = new ElasticsearchSinkConnectorConfig(props);
-    assertFalse(config.shouldLogSensitiveData());
-  }
 }


### PR DESCRIPTION
Changes: 

- Only exceptions from Elasticsearch will be logged in DLQ and all connector level errors will be logged as before. 

- When behavior.on.malformed.documents is set to:
IGNORE - Report errors to DLQ and the connector keep running and processes other records.
FAIL - Report errors to DLQ and the connector fails.

- Support for log.sensitive.data is removed. In case of any errors, the log points the customer to check DLQ topic for errors.

- Since this affect UX for on-prem customers, it will be released as a minor version change. 