### PR TITLE
Update ES version (#5)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     </scm>
 
     <properties>
-        <es.version>7.17.21</es.version>
+        <es.version>7.17.23</es.version>
         <hamcrest.version>1.3</hamcrest.version>
         <mockito.version>2.28.2</mockito.version>
         <gson.version>2.9.0</gson.version>


### PR DESCRIPTION
Refer to these tickets for details: 
https://confluentinc.atlassian.net/browse/CC-28348
https://confluentinc.atlassian.net/browse/CC-28219


Maven output

```
mvn dependency:tree -Dincludes=org.eclipse.parsson:parsson,org.elasticsearch:elasticsearch
[INFO] Scanning for projects...
[INFO] ------------------------------------------------------------------------
[INFO] Detecting the operating system and CPU architecture
[INFO] ------------------------------------------------------------------------
[INFO] os.detected.name: osx
[INFO] os.detected.arch: aarch_64
[INFO] os.detected.version: 13.6
[INFO] os.detected.version.major: 13
[INFO] os.detected.version.minor: 6
[INFO] os.detected.classifier: osx-aarch_64
[INFO]
[INFO] --------------< io.confluent:kafka-connect-elasticsearch >--------------
[INFO] Building kafka-connect-elasticsearch 14.0.18-SNAPSHOT
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- dependency:3.1.2:tree (default-cli) @ kafka-connect-elasticsearch ---
[INFO] io.confluent:kafka-connect-elasticsearch:jar:14.0.18-SNAPSHOT
[INFO] +- org.elasticsearch:elasticsearch:jar:7.17.23:compile
[INFO] \- co.elastic.clients:elasticsearch-java:jar:8.12.2:compile
[INFO]    \- org.eclipse.parsson:parsson:jar:1.0.5:compile
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.329 s
[INFO] Finished at: 2024-08-02T18:04:45+05:30
[INFO] ------------------------------------------------------------------------
[WARNING]
[WARNING] Plugin validation issues were detected in 2 plugin(s)
[WARNING]
[WARNING]  * org.apache.maven.plugins:maven-dependency-plugin:3.1.2
[WARNING]  * org.apache.maven.plugins:maven-site-plugin:3.9.0
[WARNING]
[WARNING] For more or less details, use 'maven.plugin.validation' property with one of the values (case insensitive): [BRIEF, DEFAULT, VERBOSE]
[WARNING]
```