### PR TITLE
Allow custom DataStream types

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -378,7 +378,8 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
           + "The default is %s which indicates the connector will write "
           + "to regular indices instead. If set, this configuration will "
           + "be used alongside %s and %s to construct the data stream name in the form of "
-          + "{``%s``}-{``%s``}-{``%s``}.",
+          + "{``%s``}-{``%s``}-{``%s``}. Custom index templates defined in the destination"
+          + " cluster are supported.",
       DataStreamType.NONE.name(),
       DATA_STREAM_DATASET_CONFIG,
       DATA_STREAM_NAMESPACE_CONFIG,
@@ -885,7 +886,6 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
             DATA_STREAM_TYPE_CONFIG,
             Type.STRING,
             DATA_STREAM_TYPE_DEFAULT.name(),
-            new EnumRecommender<>(DataStreamType.class),
             Importance.LOW,
             DATA_STREAM_TYPE_DOC,
             DATA_STREAM_GROUP,
@@ -921,7 +921,8 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   }
 
   public boolean isDataStream() {
-    return dataStreamType() != DataStreamType.NONE && !dataStreamDataset().isEmpty();
+    return !dataStreamType().toUpperCase().equals(DataStreamType.NONE.name())
+            && !dataStreamDataset().isEmpty();
   }
 
   public boolean isProxyWithAuthenticationConfigured() {
@@ -1002,8 +1003,8 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
     return getString(DATA_STREAM_NAMESPACE_CONFIG);
   }
 
-  public DataStreamType dataStreamType() {
-    return DataStreamType.valueOf(getString(DATA_STREAM_TYPE_CONFIG).toUpperCase());
+  public String dataStreamType() {
+    return getString(DATA_STREAM_TYPE_CONFIG);
   }
 
   public List<String> dataStreamTimestampField() {

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -199,7 +199,7 @@ public class ElasticsearchSinkTask extends SinkTask {
     }
     String dataStream = String.format(
         "%s-%s-%s",
-        config.dataStreamType().name().toLowerCase(),
+        config.dataStreamType().toLowerCase(),
         config.dataStreamDataset(),
         namespace
     );

--- a/src/main/java/io/confluent/connect/elasticsearch/Validator.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/Validator.java
@@ -138,7 +138,8 @@ public class Validator {
   }
 
   private void validateDataStreamConfigs() {
-    if (config.dataStreamType() == DataStreamType.NONE ^ config.dataStreamDataset().isEmpty()) {
+    if (config.dataStreamType().toUpperCase().equals(DataStreamType.NONE.name())
+            ^ config.dataStreamDataset().isEmpty()) {
       String errorMessage = String.format(
           "Either both or neither '%s' and '%s' must be set.",
           DATA_STREAM_DATASET_CONFIG,

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
@@ -99,8 +99,8 @@ public class ElasticsearchSinkConnectorConfigTest {
     new ElasticsearchSinkConnectorConfig(props);
   }
 
-  @Test(expected = ConfigException.class)
-  public void shouldNotAllowInvalidDataStreamType() {
+  @Test
+  public void shouldAllowCustomDataStreamType() {
     props.put(DATA_STREAM_TYPE_CONFIG, "notLogOrMetrics");
     new ElasticsearchSinkConnectorConfig(props);
   }


### PR DESCRIPTION
## Problem
Original PR - https://github.com/confluentinc/kafka-connect-elasticsearch/pull/752
PR for template changes - https://github.com/confluentinc/kafka-connect-elasticsearch-private/pull/46

## Solution
Changed type of the data stream as `String` from `DataStreamType` to support custom inputs.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy
Created an index template for the data stream traces-testdataset-ssaraswat: 
```
curl -X PUT "*****/_index_template/traces-testdataset-template" \
-u ****:****** \
-H 'Content-Type: application/json' \
-d '{
  "index_patterns": ["traces-testdataset-*"],
  "data_stream": {},
  "template": {
    "settings": {
      "number_of_shards": 1
    },
    "mappings": {
      "properties": {
        "@timestamp": {
          "type": "date"
        },
        "message": {
          "type": "text"
        }
      }
    }
  },
  "priority": 100
}'
```

Connector config -
```
{
     "connector.class": "io.confluent.connect.elasticsearch.ElasticsearchSinkConnector",
     "tasks.max": "1",
     "topics": "traces-testdataset-ssaraswat",
     "key.ignore": "false",
     "connection.url": "**********",
     "connection.username": "*****",
     "connection.password": "*********",
     "type.name": "kafka-connect",
     "data.stream.namespace": "ssaraswat",
     "use.autogenerated.ids": "true",
     "data.stream.type": "traces",
     "data.stream.dataset": "testdataset"
}
```

Result  -
```
14:30:49 ℹ️ Check that the data is available in Elasticsearch Cloud
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2935  100  2935    0     0   2955      0 --:--:-- --:--:-- --:--:--  2952
{
  "took" : 2,
  "timed_out" : false,
  "_shards" : {
    "total" : 1,
    "successful" : 1,
    "skipped" : 0,
    "failed" : 0
  },
  "hits" : {
    "total" : {
      "value" : 10,
      "relation" : "eq"
    },
    "max_score" : 1.0,
    "hits" : [
      {
        "_index" : ".ds-traces-testdataset-ssaraswat-000001",
        "_type" : "_doc",
        "_id" : "6E7BvZIBCGl5KPmwteaT",
        "_score" : 1.0,
        "_source" : {
          "f1" : "value1",
          "@timestamp" : 1729760438785
        }
      },
      {
        "_index" : ".ds-traces-testdataset-ssaraswat-000001",
        "_type" : "_doc",
        "_id" : "6U7BvZIBCGl5KPmwtubS",
        "_score" : 1.0,
        "_source" : {
          "f1" : "value10",
          "@timestamp" : 1729760438794
        }
      },
      {
        "_index" : ".ds-traces-testdataset-ssaraswat-000001",
        "_type" : "_doc",
        "_id" : "607BvZIBCGl5KPmwt-bQ",
        "_score" : 1.0,
        "_source" : {
          "f1" : "value2",
          "@timestamp" : 1729760438792
        }
      },
      {
        "_index" : ".ds-traces-testdataset-ssaraswat-000001",
        "_type" : "_doc",
        "_id" : "7E7BvZIBCGl5KPmwt-bQ",
        "_score" : 1.0,
        "_source" : {
          "f1" : "value3",
          "@timestamp" : 1729760438793
        }
      },
      {
        "_index" : ".ds-traces-testdataset-ssaraswat-000001",
        "_type" : "_doc",
        "_id" : "7U7BvZIBCGl5KPmwt-bQ",
        "_score" : 1.0,
        "_source" : {
          "f1" : "value4",
          "@timestamp" : 1729760438793
        }
      },
      {
        "_index" : ".ds-traces-testdataset-ssaraswat-000001",
        "_type" : "_doc",
        "_id" : "7k7BvZIBCGl5KPmwt-bQ",
        "_score" : 1.0,
        "_source" : {
          "f1" : "value5",
          "@timestamp" : 1729760438793
        }
      },
      {
        "_index" : ".ds-traces-testdataset-ssaraswat-000001",
        "_type" : "_doc",
        "_id" : "707BvZIBCGl5KPmwt-bQ",
        "_score" : 1.0,
        "_source" : {
          "f1" : "value6",
          "@timestamp" : 1729760438793
        }
      },
      {
        "_index" : ".ds-traces-testdataset-ssaraswat-000001",
        "_type" : "_doc",
        "_id" : "8E7BvZIBCGl5KPmwt-bQ",
        "_score" : 1.0,
        "_source" : {
          "f1" : "value7",
          "@timestamp" : 1729760438794
        }
      },
      {
        "_index" : ".ds-traces-testdataset-ssaraswat-000001",
        "_type" : "_doc",
        "_id" : "6k7BvZIBCGl5KPmwt-bQ",
        "_score" : 1.0,
        "_source" : {
          "f1" : "value8",
          "@timestamp" : 1729760438794
        }
      },
      {
        "_index" : ".ds-traces-testdataset-ssaraswat-000001",
        "_type" : "_doc",
        "_id" : "8U7BvZIBCGl5KPmwt-bS",
        "_score" : 1.0,
        "_source" : {
          "f1" : "value9",
          "@timestamp" : 1729760438794
        }
      }
    ]
  }
}
          "f1" : "value1",
          "f1" : "value10",
          "f1" : "value10",
14:30:50 ℹ️ ####################################################
14:30:50 ℹ️ ✅ RESULT: SUCCESS for elasticsearch-cloud-sink.sh (took: 2min 18sec - )
14:30:50 ℹ️ ####################################################

14:30:54 ℹ️ 🧩 Displaying status for 🌎onprem connector elasticsearch-cloud-sink
Name                           Status       Tasks                                                        Stack Trace                                       
-------------------------------------------------------------------------------------------------------------
elasticsearch-cloud-sink       ✅ RUNNING  0:🟢 RUNNING[connect]        -                                                 
-------------------------------------------------------------------------------------------------------------

```

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
