### PR TITLE
Convert org.apache.kafka.connect.data.Date to epoch millis before sending to Elasticsearch

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
@@ -295,10 +295,11 @@ public class DataConverter {
       switch (schemaName) {
         case Decimal.LOGICAL_NAME:
           return copySchemaBasics(schema, SchemaBuilder.float64()).build();
-        case Date.LOGICAL_NAME:
         case Time.LOGICAL_NAME:
         case Timestamp.LOGICAL_NAME:
           return schema;
+        case Date.LOGICAL_NAME:
+          return copySchemaBasics(schema, SchemaBuilder.int64()).build();
         default:
           // User type or unknown logical type
           break;
@@ -408,10 +409,11 @@ public class DataConverter {
     switch (schemaName) {
       case Decimal.LOGICAL_NAME:
         return ((BigDecimal) value).doubleValue();
-      case Date.LOGICAL_NAME:
       case Time.LOGICAL_NAME:
       case Timestamp.LOGICAL_NAME:
         return value;
+      case Date.LOGICAL_NAME:
+        return ((java.util.Date) value).getTime();
       default:
         // User-defined type or unknown built-in
         return null;


### PR DESCRIPTION
## Problem

Lets consider the following kafka schema:

```json
{
      "name": "dateOfBirth",
      "type": [ "null", {"type": "int", "logicalType": "date"}],
      "default": null
}
```

And the target index field:


```json
  "dateOfBirth": {
      "type": "date"
    }
```


Currently the date type (org.apache.kafka.connect.data.Date) is being converted to int (epoch days) and ends up in Elasticsearch being interpreted as epoch millis turning it into some datetime long in the past.

Elasticsearch does not suport epoch days type for `date` fields.


## Solution

Assuming the field is properly indexed as `date` we should pass some of default supported formats like `epoch_millis`.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [x] Integration tests
- [x] System tests
- [x ] Manual tests

## Release Plan

Bugfix, it might be have some incompatibles with existing user workarounds though.
