### PR TITLE
CC-31025: Bump common and pin kafka-clients

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>7.0.12</version>
+        <version>7.9.1-15</version>
     </parent>
 
     <artifactId>kafka-connect-elasticsearch</artifactId>
@@ -39,7 +39,6 @@
     <properties>
         <es.version>7.17.23</es.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <mockito.version>2.28.2</mockito.version>
         <gson.version>2.9.0</gson.version>
         <test.containers.version>1.16.3</test.containers.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
@@ -182,7 +181,8 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>${kafka.version}</version>
+            <!-- https://confluentinc.atlassian.net/browse/CC-31025 -->
+            <version>7.8.0-ccs</version>
             <classifier>test</classifier>
             <type>test-jar</type>
             <scope>test</scope>

--- a/src/main/java/io/confluent/connect/elasticsearch/ConfigCallbackHandler.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ConfigCallbackHandler.java
@@ -54,7 +54,7 @@ import org.apache.http.nio.conn.SchemeIOSessionStrategy;
 import org.apache.http.nio.conn.ssl.SSLIOSessionStrategy;
 import org.apache.http.nio.reactor.ConnectingIOReactor;
 import org.apache.http.nio.reactor.IOReactorException;
-import org.apache.kafka.common.network.Mode;
+import org.apache.kafka.common.network.ConnectionMode;
 import org.apache.kafka.common.security.ssl.SslFactory;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.elasticsearch.client.RestClientBuilder.HttpClientConfigCallback;
@@ -258,7 +258,7 @@ public class ConfigCallbackHandler implements HttpClientConfigCallback {
    * Gets the SslContext for the client.
    */
   private SSLContext sslContext() {
-    SslFactory sslFactory = new SslFactory(Mode.CLIENT, null, false);
+    SslFactory sslFactory = new SslFactory(ConnectionMode.CLIENT, null, false);
     sslFactory.configure(config.sslConfigs());
 
     try {


### PR DESCRIPTION
## Problem
Some connector repositories depend on the org.apache.kafka.common.network.Mode class for connector-specific logic. Recently, this class was refactored to org.apache.kafka.common.network.ConnectionMode, causing connectors to fail with a ClassNotFoundError during startup.

## Solution
Bump up common version

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [X] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [X] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
