### PR TITLE
CC-31025: Upgrade kafka to 7.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>7.0.12</version>
+        <version>[7.9.0, 7.9.1)</version>
     </parent>
 
     <artifactId>kafka-connect-elasticsearch</artifactId>
@@ -39,7 +39,6 @@
     <properties>
         <es.version>7.17.23</es.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <mockito.version>2.28.2</mockito.version>
         <gson.version>2.9.0</gson.version>
         <test.containers.version>1.16.3</test.containers.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
@@ -54,7 +53,7 @@
         <dependency.check.version>6.1.6</dependency.check.version>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
         <commons.codec.version>1.15</commons.codec.version>
-        <confluent.version>${io.confluent.common.version}</confluent.version>
+        <confluent.version>[7.9.0,7.9.1)</confluent.version>
         <jackson.version>2.16.0</jackson.version>
         <dependency.check.skip>true</dependency.check.skip>
     </properties>
@@ -182,7 +181,15 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>${kafka.version}</version>
+            <version>7.8.0-ccs</version>
+            <classifier>test</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-server-common</artifactId>
+            <version>7.8.0-ccs</version>
             <classifier>test</classifier>
             <type>test-jar</type>
             <scope>test</scope>

--- a/src/main/java/io/confluent/connect/elasticsearch/ConfigCallbackHandler.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ConfigCallbackHandler.java
@@ -54,7 +54,7 @@ import org.apache.http.nio.conn.SchemeIOSessionStrategy;
 import org.apache.http.nio.conn.ssl.SSLIOSessionStrategy;
 import org.apache.http.nio.reactor.ConnectingIOReactor;
 import org.apache.http.nio.reactor.IOReactorException;
-import org.apache.kafka.common.network.Mode;
+import org.apache.kafka.common.network.ConnectionMode;
 import org.apache.kafka.common.security.ssl.SslFactory;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.elasticsearch.client.RestClientBuilder.HttpClientConfigCallback;
@@ -258,7 +258,7 @@ public class ConfigCallbackHandler implements HttpClientConfigCallback {
    * Gets the SslContext for the client.
    */
   private SSLContext sslContext() {
-    SslFactory sslFactory = new SslFactory(Mode.CLIENT, null, false);
+    SslFactory sslFactory = new SslFactory(ConnectionMode.CLIENT, null, false);
     sslFactory.configure(config.sslConfigs());
 
     try {

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/BaseConnectorIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/BaseConnectorIT.java
@@ -15,6 +15,7 @@
 
 package io.confluent.connect.elasticsearch.integration;
 
+import java.util.HashMap;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
@@ -41,8 +42,11 @@ public abstract class BaseConnectorIT {
   protected RestApp restApp;
 
   protected void startConnect() {
+    HashMap<String, String> workerProps = new HashMap<>();
+    workerProps.put("plugin.discovery", "hybrid_warn");
     connect = new EmbeddedConnectCluster.Builder()
         .name("elasticsearch-it-connect-cluster")
+        .workerProps(workerProps)
         .build();
 
     // start the clusters


### PR DESCRIPTION
## Problem
https://confluentinc.atlassian.net/browse/CC-31025: 
In kafka 7.9.0, the class `org.apache.kafka.common.network.Mode` class was refactored to `org.apache.kafka.common.network.ConnectionMode`,
causing connectors to fail with a `ClassNotFoundError` during startup.

## Solution
Upgrade parent common to 7.9.0.
Replace `Mode` with `ConnectionMode`
Followed similar short term fixes as done in https://confluentinc.atlassian.net/wiki/spaces/OAAC/pages/4008607989/2025-01-06+Connect+Cloud+Release+Issues

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [X] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [X] Unit tests
- [X] Integration tests
- [ ] System tests
- [X] Manual tests - Ran on playground with CP 7.9.0

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
