### PR TITLE
Add missing distributionManagement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>kafka-connect-elasticsearch</artifactId>
-    <version>15.0.1-SNAPSHOT</version>
+    <version>15.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>kafka-connect-elasticsearch</name>
     <organization>

--- a/pom.xml
+++ b/pom.xml
@@ -319,6 +319,19 @@
         </dependencies>
     </dependencyManagement>
 
+  <distributionManagement>
+    <repository>
+      <id>aws-release</id>
+      <name>AWS Release Repository</name>
+      <url>${confluent.release.repo}</url>
+    </repository>
+    <snapshotRepository>
+      <id>aws-snapshot</id>
+      <name>AWS Snapshot Repository</name>
+      <url>${confluent.snapshot.repo}</url>
+    </snapshotRepository>
+  </distributionManagement>
+
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
## Problem
`common` versions 7.0.15+ do not bring in `distributionManagement`.
They are necessary for the build when releasing the connector.
This has happened before - https://confluent.slack.com/archives/C04GUEGCNG0/p1724936392760469

## Solution
Add `distributionManagement` explicitly.
Reset version to 15.0.0

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
