### PR TITLE
CC-32762: Set threadName with "taskId" prefix

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
@@ -118,17 +118,15 @@ public class ElasticsearchClient {
   private final Lock inFlightRequestLock = new ReentrantLock();
   private final Condition inFlightRequestsUpdated = inFlightRequestLock.newCondition();
   private final String esVersion;
-  private final String connectorName;
-  private final int taskId;
 
   @SuppressWarnings("deprecation")
   public ElasticsearchClient(
       ElasticsearchSinkConnectorConfig config,
       ErrantRecordReporter reporter,
-      Runnable afterBulkCallback
+      Runnable afterBulkCallback,
+      int taskId,
+      String connectorName
   ) {
-    connectorName = config.connectorName();
-    taskId = config.taskNumber();
     this.bulkExecutorService = Executors.newFixedThreadPool(config.maxInFlightRequests(),
       new ThreadFactory() {
         private final AtomicInteger threadNumber = new AtomicInteger(1);

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnector.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnector.java
@@ -58,10 +58,10 @@ public class ElasticsearchSinkConnector extends SinkConnector {
   @Override
   public List<Map<String, String>> taskConfigs(int maxTasks) {
     List<Map<String, String>> taskConfigs = new ArrayList<>();
-    Map<String, String> taskProps = new HashMap<>();
-    taskProps.putAll(configProperties);
     for (int i = 0; i < maxTasks; i++) {
-      taskConfigs.add(taskProps);
+      HashMap<String, String> taskConfig = new HashMap<>(configProperties);
+      taskConfig.put(ElasticsearchSinkTaskConfig.TASK_ID_CONFIG, Integer.toString(i));
+      taskConfigs.add(taskConfig);
     }
     return taskConfigs;
   }

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -407,6 +407,13 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   private static final String KERBEROS_GROUP = "Kerberos";
   private static final String DATA_STREAM_GROUP = "Data Stream";
 
+  private final int taskId;
+  private final String connectorName;
+
+  public static final String TASK_ID_CONFIG =                   "taskId";
+  private static final ConfigDef.Type TASK_ID_TYPE =            ConfigDef.Type.INT;
+  public static final ConfigDef.Importance TASK_ID_IMPORTANCE = ConfigDef.Importance.LOW;
+
   public enum BehaviorOnMalformedDoc {
     IGNORE,
     WARN,
@@ -443,6 +450,7 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
     addSslConfigs(configDef);
     addKerberosConfigs(configDef);
     addDataStreamConfigs(configDef);
+    addInternalConfigs(configDef);
     return configDef;
   }
 
@@ -889,10 +897,30 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
     );
   }
 
+  private static void addInternalConfigs(ConfigDef configDef) {
+    configDef
+        .defineInternal(
+            TASK_ID_CONFIG,
+            TASK_ID_TYPE,
+            ConfigDef.NO_DEFAULT_VALUE,
+            TASK_ID_IMPORTANCE
+    );
+  }
+
   public static final ConfigDef CONFIG = baseConfigDef();
 
   public ElasticsearchSinkConnectorConfig(Map<String, String> props) {
     super(CONFIG, props);
+    taskId = getInt(TASK_ID_CONFIG);
+    connectorName = originalsStrings().get("name");
+  }
+
+  public int taskNumber() {
+    return taskId;
+  }
+
+  public String connectorName() {
+    return connectorName;
   }
 
   public boolean isAuthenticatedConnection() {

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -407,13 +407,6 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   private static final String KERBEROS_GROUP = "Kerberos";
   private static final String DATA_STREAM_GROUP = "Data Stream";
 
-  private final int taskId;
-  private final String connectorName;
-
-  public static final String TASK_ID_CONFIG =                   "taskId";
-  private static final ConfigDef.Type TASK_ID_TYPE =            ConfigDef.Type.INT;
-  public static final ConfigDef.Importance TASK_ID_IMPORTANCE = ConfigDef.Importance.LOW;
-
   public enum BehaviorOnMalformedDoc {
     IGNORE,
     WARN,
@@ -450,7 +443,6 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
     addSslConfigs(configDef);
     addKerberosConfigs(configDef);
     addDataStreamConfigs(configDef);
-    addInternalConfigs(configDef);
     return configDef;
   }
 
@@ -897,30 +889,14 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
     );
   }
 
-  private static void addInternalConfigs(ConfigDef configDef) {
-    configDef
-        .defineInternal(
-            TASK_ID_CONFIG,
-            TASK_ID_TYPE,
-            ConfigDef.NO_DEFAULT_VALUE,
-            TASK_ID_IMPORTANCE
-    );
-  }
-
   public static final ConfigDef CONFIG = baseConfigDef();
+
+  protected ElasticsearchSinkConnectorConfig(ConfigDef config, Map<String, String> properties) {
+    super(config, properties);
+  }
 
   public ElasticsearchSinkConnectorConfig(Map<String, String> props) {
     super(CONFIG, props);
-    taskId = getInt(TASK_ID_CONFIG);
-    connectorName = originalsStrings().get("name");
-  }
-
-  public int taskNumber() {
-    return taskId;
-  }
-
-  public String connectorName() {
-    return connectorName;
   }
 
   public boolean isAuthenticatedConnection() {

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -42,7 +42,7 @@ public class ElasticsearchSinkTask extends SinkTask {
 
   private DataConverter converter;
   private ElasticsearchClient client;
-  private ElasticsearchSinkConnectorConfig config;
+  private ElasticsearchSinkTaskConfig config;
   private ErrantRecordReporter reporter;
   private Set<String> existingMappings;
   private Set<String> indexCache;
@@ -58,7 +58,7 @@ public class ElasticsearchSinkTask extends SinkTask {
   protected void start(Map<String, String> props, ElasticsearchClient client) {
     log.info("Starting ElasticsearchSinkTask.");
 
-    this.config = new ElasticsearchSinkConnectorConfig(props);
+    this.config = new ElasticsearchSinkTaskConfig(props);
     this.converter = new DataConverter(config);
     this.existingMappings = new HashSet<>();
     this.indexCache = new HashSet<>();
@@ -80,7 +80,8 @@ public class ElasticsearchSinkTask extends SinkTask {
     }
     Runnable afterBulkCallback = () -> offsetTracker.updateOffsets();
     this.client = client != null ? client
-        : new ElasticsearchClient(config, reporter, afterBulkCallback);
+        : new ElasticsearchClient(config, reporter, afterBulkCallback,
+            config.taskNumber(), config.connectorName());
 
     if (!config.flushSynchronously()) {
       this.offsetTracker = new AsyncOffsetTracker(context);

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -81,7 +81,7 @@ public class ElasticsearchSinkTask extends SinkTask {
     Runnable afterBulkCallback = () -> offsetTracker.updateOffsets();
     this.client = client != null ? client
         : new ElasticsearchClient(config, reporter, afterBulkCallback,
-            config.taskNumber(), config.connectorName());
+            config.getTaskId(), config.getConnectorName());
 
     if (!config.flushSynchronously()) {
       this.offsetTracker = new AsyncOffsetTracker(context);

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskConfig.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.elasticsearch;
+
+import org.apache.kafka.common.config.ConfigDef;
+import java.util.Map;
+
+public class ElasticsearchSinkTaskConfig extends ElasticsearchSinkConnectorConfig {
+
+  private final int taskId;
+  private final String connectorName;
+
+  public static final String TASK_ID_CONFIG =                   "taskId";
+  private static final ConfigDef.Type TASK_ID_TYPE =            ConfigDef.Type.INT;
+  public static final ConfigDef.Importance TASK_ID_IMPORTANCE = ConfigDef.Importance.LOW;
+
+  /**
+   * Return a ConfigDef object used to define this config's fields.
+   *
+   * @return A ConfigDef object used to define this config's fields.
+   */
+  public static ConfigDef config() {
+    return ElasticsearchSinkConnectorConfig.baseConfigDef()
+            .defineInternal(
+                    TASK_ID_CONFIG,
+                    TASK_ID_TYPE,
+                    ConfigDef.NO_DEFAULT_VALUE,
+                    TASK_ID_IMPORTANCE
+            );
+  }
+
+  /**
+   * @param properties A Map detailing configuration properties and their respective values.
+   */
+  public ElasticsearchSinkTaskConfig(Map<String, String> properties) {
+    super(config(), properties);
+    taskId = getInt(TASK_ID_CONFIG);
+    connectorName = originalsStrings().get("name");
+  }
+
+  public int taskNumber() {
+    return taskId;
+  }
+
+  public String connectorName() {
+    return connectorName;
+  }
+}

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskConfig.java
@@ -51,11 +51,11 @@ public class ElasticsearchSinkTaskConfig extends ElasticsearchSinkConnectorConfi
     connectorName = originalsStrings().get("name");
   }
 
-  public int taskNumber() {
+  public int getTaskId() {
     return taskId;
   }
 
-  public String connectorName() {
+  public String getConnectorName() {
     return connectorName;
   }
 }

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientSslTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientSslTest.java
@@ -71,7 +71,7 @@ public class ElasticsearchClientSslTest extends ElasticsearchClientTestBase {
   @Test
   public void testSsl() throws Exception {
     ElasticsearchClient client = new ElasticsearchClient(config, null, 
-    () -> offsetTracker.updateOffsets());
+    () -> offsetTracker.updateOffsets(), 1, "elasticsearch-sink");
     client.createIndexOrDataStream(index);
 
     writeRecord(sinkRecord(0), client);

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
@@ -100,8 +100,7 @@ public class ElasticsearchClientTest extends ElasticsearchClientTestBase {
 
   @Test
   public void testClose() {
-
-    ElasticsearchClient client = new ElasticsearchClient(config, null, () -> offsetTracker.updateOffsets());
+    ElasticsearchClient client = new ElasticsearchClient(config, null, () -> offsetTracker.updateOffsets(), 1, "elasticsearch-sink");
     client.close();
   }
 
@@ -109,7 +108,7 @@ public class ElasticsearchClientTest extends ElasticsearchClientTestBase {
   public void testCloseFails() throws Exception {
     props.put(BATCH_SIZE_CONFIG, "1");
     props.put(MAX_IN_FLIGHT_REQUESTS_CONFIG, "1");
-    ElasticsearchClient client = new ElasticsearchClient(config, null, () -> offsetTracker.updateOffsets()) {
+    ElasticsearchClient client = new ElasticsearchClient(config, null, () -> offsetTracker.updateOffsets(), 1, "elasticsearch-sink") {
       @Override
       public void close() {
         try {
@@ -131,7 +130,7 @@ public class ElasticsearchClientTest extends ElasticsearchClientTestBase {
 
   @Test
   public void testCreateIndex() throws IOException {
-    ElasticsearchClient client = new ElasticsearchClient(config, null, () -> offsetTracker.updateOffsets());
+    ElasticsearchClient client = new ElasticsearchClient(config, null, () -> offsetTracker.updateOffsets(), 1, "elasticsearch-sink");
     assertFalse(helperClient.indexExists(index));
 
     client.createIndexOrDataStream(index);
@@ -145,7 +144,7 @@ public class ElasticsearchClientTest extends ElasticsearchClientTestBase {
     props.put(DATA_STREAM_DATASET_CONFIG, DATA_STREAM_DATASET);
     config = new ElasticsearchSinkConnectorConfig(props);
     index = createIndexName(TOPIC);
-    ElasticsearchClient client = new ElasticsearchClient(config, null, () -> offsetTracker.updateOffsets());
+    ElasticsearchClient client = new ElasticsearchClient(config, null, () -> offsetTracker.updateOffsets(), 1, "elasticsearch-sink");
     index = createIndexName(TOPIC);
 
     assertTrue(client.createIndexOrDataStream(index));
@@ -160,7 +159,7 @@ public class ElasticsearchClientTest extends ElasticsearchClientTestBase {
     props.put(DATA_STREAM_DATASET_CONFIG, DATA_STREAM_DATASET);
     config = new ElasticsearchSinkConnectorConfig(props);
     index = createIndexName(TOPIC);
-    ElasticsearchClient client = new ElasticsearchClient(config, null, () -> offsetTracker.updateOffsets());
+    ElasticsearchClient client = new ElasticsearchClient(config, null, () -> offsetTracker.updateOffsets(), 1, "elasticsearch-sink");
     index = createIndexName(TOPIC);
 
     assertTrue(client.createIndexOrDataStream(index));
@@ -170,7 +169,7 @@ public class ElasticsearchClientTest extends ElasticsearchClientTestBase {
 
   @Test
   public void testDoesNotCreateAlreadyExistingIndex() throws IOException {
-    ElasticsearchClient client = new ElasticsearchClient(config, null, () -> offsetTracker.updateOffsets());
+    ElasticsearchClient client = new ElasticsearchClient(config, null, () -> offsetTracker.updateOffsets(), 1, "elasticsearch-sink");
     assertFalse(helperClient.indexExists(index));
 
     assertTrue(client.createIndexOrDataStream(index));
@@ -183,7 +182,7 @@ public class ElasticsearchClientTest extends ElasticsearchClientTestBase {
 
   @Test
   public void testIndexExists() throws IOException {
-    ElasticsearchClient client = new ElasticsearchClient(config, null, () -> offsetTracker.updateOffsets());
+    ElasticsearchClient client = new ElasticsearchClient(config, null, () -> offsetTracker.updateOffsets(), 1, "elasticsearch-sink");
     assertFalse(helperClient.indexExists(index));
 
     assertTrue(client.createIndexOrDataStream(index));
@@ -193,7 +192,7 @@ public class ElasticsearchClientTest extends ElasticsearchClientTestBase {
 
   @Test
   public void testIndexDoesNotExist() throws IOException {
-    ElasticsearchClient client = new ElasticsearchClient(config, null, () -> offsetTracker.updateOffsets());
+    ElasticsearchClient client = new ElasticsearchClient(config, null, () -> offsetTracker.updateOffsets(), 1, "elasticsearch-sink");
     assertFalse(helperClient.indexExists(index));
 
     assertFalse(client.indexExists(index));
@@ -203,7 +202,7 @@ public class ElasticsearchClientTest extends ElasticsearchClientTestBase {
   @Test
   @SuppressWarnings("unchecked")
   public void testCreateMapping() throws IOException {
-    ElasticsearchClient client = new ElasticsearchClient(config, null, () -> offsetTracker.updateOffsets());
+    ElasticsearchClient client = new ElasticsearchClient(config, null, () -> offsetTracker.updateOffsets(), 1, "elasticsearch-sink");
     client.createIndexOrDataStream(index);
 
     client.createMapping(index, schema());
@@ -226,7 +225,7 @@ public class ElasticsearchClientTest extends ElasticsearchClientTestBase {
 
   @Test
   public void testHasMapping() {
-    ElasticsearchClient client = new ElasticsearchClient(config, null, () -> offsetTracker.updateOffsets());
+    ElasticsearchClient client = new ElasticsearchClient(config, null, () -> offsetTracker.updateOffsets(), 1, "elasticsearch-sink");
     client.createIndexOrDataStream(index);
 
     client.createMapping(index, schema());
@@ -237,7 +236,7 @@ public class ElasticsearchClientTest extends ElasticsearchClientTestBase {
 
   @Test
   public void testDoesNotHaveMapping() {
-    ElasticsearchClient client = new ElasticsearchClient(config, null, () -> offsetTracker.updateOffsets());
+    ElasticsearchClient client = new ElasticsearchClient(config, null, () -> offsetTracker.updateOffsets(), 1, "elasticsearch-sink");
     client.createIndexOrDataStream(index);
 
     assertFalse(client.hasMapping(index));
@@ -249,7 +248,7 @@ public class ElasticsearchClientTest extends ElasticsearchClientTestBase {
     props.put(MAX_IN_FLIGHT_REQUESTS_CONFIG, "1");
     props.put(MAX_BUFFERED_RECORDS_CONFIG, "1");
     config = new ElasticsearchSinkConnectorConfig(props);
-    ElasticsearchClient client = new ElasticsearchClient(config, null, () -> offsetTracker.updateOffsets());
+    ElasticsearchClient client = new ElasticsearchClient(config, null, () -> offsetTracker.updateOffsets(), 1, "elasticsearch-sink");
     client.createIndexOrDataStream(index);
 
     writeRecord(sinkRecord(0), client);
@@ -275,7 +274,7 @@ public class ElasticsearchClientTest extends ElasticsearchClientTestBase {
   public void testFlush() throws Exception {
     props.put(LINGER_MS_CONFIG, String.valueOf(TimeUnit.DAYS.toMillis(1)));
     config = new ElasticsearchSinkConnectorConfig(props);
-    ElasticsearchClient client = new ElasticsearchClient(config, null, () -> offsetTracker.updateOffsets());
+    ElasticsearchClient client = new ElasticsearchClient(config, null, () -> offsetTracker.updateOffsets(), 1, "elasticsearch-sink");
     client.createIndexOrDataStream(index);
 
     writeRecord(sinkRecord(0), client);
@@ -290,7 +289,7 @@ public class ElasticsearchClientTest extends ElasticsearchClientTestBase {
 
   @Test
   public void testIndexRecord() throws Exception {
-    ElasticsearchClient client = new ElasticsearchClient(config, null, () -> offsetTracker.updateOffsets());
+    ElasticsearchClient client = new ElasticsearchClient(config, null, () -> offsetTracker.updateOffsets(), 1, "elasticsearch-sink");
     client.createIndexOrDataStream(index);
 
     writeRecord(sinkRecord(0), client);
@@ -307,7 +306,7 @@ public class ElasticsearchClientTest extends ElasticsearchClientTestBase {
     props.put(IGNORE_KEY_CONFIG, "false");
     config = new ElasticsearchSinkConnectorConfig(props);
     converter = new DataConverter(config);
-    ElasticsearchClient client = new ElasticsearchClient(config, null, () -> offsetTracker.updateOffsets());
+    ElasticsearchClient client = new ElasticsearchClient(config, null, () -> offsetTracker.updateOffsets(), 1, "elasticsearch-sink");
     client.createIndexOrDataStream(index);
 
     writeRecord(sinkRecord("key0", 0), client);
@@ -330,7 +329,7 @@ public class ElasticsearchClientTest extends ElasticsearchClientTestBase {
     props.put(IGNORE_KEY_CONFIG, "false");
     config = new ElasticsearchSinkConnectorConfig(props);
     converter = new DataConverter(config);
-    ElasticsearchClient client = new ElasticsearchClient(config, null, () -> offsetTracker.updateOffsets());
+    ElasticsearchClient client = new ElasticsearchClient(config, null, () -> offsetTracker.updateOffsets(), 1, "elasticsearch-sink");
     client.createIndexOrDataStream(index);
 
     writeRecord(sinkRecord("key0", 0), client);
@@ -375,7 +374,7 @@ public class ElasticsearchClientTest extends ElasticsearchClientTestBase {
     config = new ElasticsearchSinkConnectorConfig(props);
     converter = new DataConverter(config);
 
-    ElasticsearchClient client = new ElasticsearchClient(config, null, () -> offsetTracker.updateOffsets());
+    ElasticsearchClient client = new ElasticsearchClient(config, null, () -> offsetTracker.updateOffsets(), 1, "elasticsearch-sink");
     client.createIndexOrDataStream(index);
     client.createMapping(index, schema());
 
@@ -403,7 +402,7 @@ public class ElasticsearchClientTest extends ElasticsearchClientTestBase {
 
   @Test(expected = ConnectException.class)
   public void testFailOnBadRecord() throws Exception {
-    ElasticsearchClient client = new ElasticsearchClient(config, null, () -> offsetTracker.updateOffsets());
+    ElasticsearchClient client = new ElasticsearchClient(config, null, () -> offsetTracker.updateOffsets(), 1, "elasticsearch-sink");
     client.createIndexOrDataStream(index);
     client.createMapping(index, schema());
 
@@ -446,7 +445,7 @@ public class ElasticsearchClientTest extends ElasticsearchClientTestBase {
     converter = new DataConverter(config);
 
     // mock bulk processor to throw errors
-    ElasticsearchClient client = new ElasticsearchClient(config, null, () -> offsetTracker.updateOffsets());
+    ElasticsearchClient client = new ElasticsearchClient(config, null, () -> offsetTracker.updateOffsets(), 1, "elasticsearch-sink");
     client.createIndexOrDataStream(index);
 
     // bring down ES service
@@ -483,7 +482,7 @@ public class ElasticsearchClientTest extends ElasticsearchClientTestBase {
     ErrantRecordReporter reporter = mock(ErrantRecordReporter.class);
     when(reporter.report(any(), any()))
             .thenReturn(CompletableFuture.completedFuture(null));
-    ElasticsearchClient client = new ElasticsearchClient(config, reporter, () -> offsetTracker.updateOffsets());
+    ElasticsearchClient client = new ElasticsearchClient(config, reporter, () -> offsetTracker.updateOffsets(), 1, "elasticsearch-sink");
     client.createIndexOrDataStream(index);
     client.createMapping(index, schema());
 
@@ -530,7 +529,7 @@ public class ElasticsearchClientTest extends ElasticsearchClientTestBase {
     ErrantRecordReporter reporter = mock(ErrantRecordReporter.class);
     when(reporter.report(any(), any()))
             .thenReturn(CompletableFuture.completedFuture(null));
-    ElasticsearchClient client = new ElasticsearchClient(config, reporter, () -> offsetTracker.updateOffsets());
+    ElasticsearchClient client = new ElasticsearchClient(config, reporter, () -> offsetTracker.updateOffsets(), 1, "elasticsearch-sink");
     client.createIndexOrDataStream(index);
     client.createMapping(index, schema());
 
@@ -563,7 +562,7 @@ public class ElasticsearchClientTest extends ElasticsearchClientTestBase {
   @Test
   public void testReporterNotCalled() throws Exception {
     ErrantRecordReporter reporter = mock(ErrantRecordReporter.class);
-    ElasticsearchClient client = new ElasticsearchClient(config, reporter, () -> offsetTracker.updateOffsets());
+    ElasticsearchClient client = new ElasticsearchClient(config, reporter, () -> offsetTracker.updateOffsets(), 1, "elasticsearch-sink");
     client.createIndexOrDataStream(index);
 
     writeRecord(sinkRecord(0), client);
@@ -635,7 +634,7 @@ public class ElasticsearchClientTest extends ElasticsearchClientTestBase {
     converter = new DataConverter(config);
 
     ErrantRecordReporter reporter = mock(ErrantRecordReporter.class);
-    ElasticsearchClient client = new ElasticsearchClient(config, reporter, () -> offsetTracker.updateOffsets());
+    ElasticsearchClient client = new ElasticsearchClient(config, reporter, () -> offsetTracker.updateOffsets(), 1, "elasticsearch-sink");
 
     List<SinkRecord> duplicate_records = causeExternalVersionConflictError(client);
 
@@ -667,7 +666,7 @@ public class ElasticsearchClientTest extends ElasticsearchClientTestBase {
     // correctly reports the error when it interprets the version conflict as
     // "INTERNAL" (version maintained by Elasticsearch) rather than
     // "EXTERNAL" (version maintained by the connector as kafka offset)
-    ElasticsearchClient client = new ElasticsearchClient(config, reporter, () -> offsetTracker.updateOffsets()) {
+    ElasticsearchClient client = new ElasticsearchClient(config, reporter, () -> offsetTracker.updateOffsets(), 1, "elasticsearch-sink") {
       protected boolean handleResponse(BulkItemResponse response, DocWriteRequest<?> request,
                                     long executionId) {
         // Make it think it was an internal version conflict.
@@ -696,8 +695,8 @@ public class ElasticsearchClientTest extends ElasticsearchClientTestBase {
 
     ErrantRecordReporter reporter = mock(ErrantRecordReporter.class);
     ErrantRecordReporter reporter2 = mock(ErrantRecordReporter.class);
-    ElasticsearchClient client = new ElasticsearchClient(config, reporter, () -> offsetTracker.updateOffsets());
-    ElasticsearchClient client2 = new ElasticsearchClient(config, reporter2, () -> offsetTracker.updateOffsets());
+    ElasticsearchClient client = new ElasticsearchClient(config, reporter, () -> offsetTracker.updateOffsets(), 1, "elasticsearch-sink");
+    ElasticsearchClient client2 = new ElasticsearchClient(config, reporter2, () -> offsetTracker.updateOffsets(), 1, "elasticsearch-sink");
 
     client.createIndexOrDataStream(index);
 
@@ -722,7 +721,7 @@ public class ElasticsearchClientTest extends ElasticsearchClientTestBase {
     props.put(DATA_STREAM_DATASET_CONFIG, DATA_STREAM_DATASET);
     config = new ElasticsearchSinkConnectorConfig(props);
     converter = new DataConverter(config);
-    ElasticsearchClient client = new ElasticsearchClient(config, null, () -> offsetTracker.updateOffsets());
+    ElasticsearchClient client = new ElasticsearchClient(config, null, () -> offsetTracker.updateOffsets(), 1, "elasticsearch-sink");
     index = createIndexName(TOPIC);
 
     assertTrue(client.createIndexOrDataStream(index));
@@ -741,7 +740,7 @@ public class ElasticsearchClientTest extends ElasticsearchClientTestBase {
   public void testConnectionUrlExtraSlash() {
     props.put(CONNECTION_URL_CONFIG, container.getConnectionUrl() + "/");
     config = new ElasticsearchSinkConnectorConfig(props);
-    ElasticsearchClient client = new ElasticsearchClient(config, null, () -> offsetTracker.updateOffsets());
+    ElasticsearchClient client = new ElasticsearchClient(config, null, () -> offsetTracker.updateOffsets(), 1, "elasticsearch-sink");
     client.close();
   }
 }

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorTest.java
@@ -33,9 +33,14 @@ public class ElasticsearchSinkConnectorTest {
   public void shouldGenerateValidTaskConfigs() {
     connector.start(settings);
     List<Map<String, String>> taskConfigs = connector.taskConfigs(2);
-    assertFalse("zero task configs provided", taskConfigs.isEmpty());
-    for (Map<String, String> taskConfig : taskConfigs) {
-      assertEquals(settings, taskConfig);
+    assertEquals("Should generate exactly 2 task configs", 2, taskConfigs.size());
+    for (int i = 0; i < taskConfigs.size(); i++) {
+      Map<String, String> taskConfig = taskConfigs.get(i);
+      // Create expected config for this task
+      Map<String, String> expectedConfig = new HashMap<>(settings);
+      expectedConfig.put(ElasticsearchSinkTaskConfig.TASK_ID_CONFIG, String.valueOf(i));
+
+      assertEquals("Task config " + i + " should match expected", expectedConfig, taskConfig);
     }
   }
 

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
@@ -98,6 +98,7 @@ public class ElasticsearchSinkTaskTest {
     props = ElasticsearchSinkConnectorConfigTest.addNecessaryProps(new HashMap<>());
     props.put(IGNORE_KEY_CONFIG, "true");
     props.put(FLUSH_SYNCHRONOUSLY_CONFIG, Boolean.toString(flushSynchronously));
+    props.put(ElasticsearchSinkTaskConfig.TASK_ID_CONFIG, "1");
 
     client = mock(ElasticsearchClient.class);
     context = mock(SinkTaskContext.class);

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchSinkTaskIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchSinkTaskIT.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import io.confluent.connect.elasticsearch.ElasticsearchSinkTaskConfig;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.errors.ConnectException;
@@ -498,6 +499,7 @@ public class ElasticsearchSinkTaskIT {
     props.put(IGNORE_SCHEMA_CONFIG, "true");
     props.put(WRITE_METHOD_CONFIG, WriteMethod.UPSERT.toString());
     props.put(FLUSH_SYNCHRONOUSLY_CONFIG, Boolean.toString(synchronousFlush));
+    props.put(ElasticsearchSinkTaskConfig.TASK_ID_CONFIG, "1");
 
     return props;
   }


### PR DESCRIPTION
## Problem
The Elasticsearch connector spawns additional threads (via bulkExecutorService) to offload bulk processing from the primary task thread. The overall resource consumption is underestimated as these additional threads are not being tracked. This can lead to inaccurate task placement decisions, causing some workers to become overloaded while others remain underutilized.

Jira Ticket: https://confluentinc.atlassian.net/browse/CC-32762

## Solution
Implement a thread naming convention that allows the runtime to accurately track CPU time across all threads associated with a specific task by setting the thread name with a `connectorName + taskId` prefix. The thread naming pattern follows: {connectorName}-{taskId}-elasticsearch-bulk-{threadNumber}

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [x] System tests
- [x] Manual tests

## Release Plan
This change is backward compatible and is targeted for both CP and CC
