### PR TITLE
ES Client patch version uptick for cve fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     </scm>
 
     <properties>
-        <es.version>7.17.23</es.version>
+        <es.version>7.17.24</es.version>
         <hamcrest.version>1.3</hamcrest.version>
         <mockito.version>2.28.2</mockito.version>
         <gson.version>2.9.0</gson.version>


### PR DESCRIPTION
## Problem
Upticking version from 7.17.23 to 7.17.24 as required by two CVE's mentioned below:
- https://confluentinc.atlassian.net/browse/CVE-5719
- https://confluentinc.atlassian.net/browse/CVE-5825

## Solution
The release notes for 7.17.24 does not mention any breaking changes that could potentially fail our functionality: 
- https://www.elastic.co/guide/en/elasticsearch/reference/7.17/release-notes-7.17.24.html

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy
All changes are compatible, the entire connector creation logic and patching updated image will be tested. 


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
These changes are marked to release for CP & CC