### PR TITLE
Upgrade Elasticsearch version to 7.17.25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     </scm>
 
     <properties>
-        <es.version>7.17.24</es.version>
+        <es.version>7.17.25</es.version>
         <hamcrest.version>1.3</hamcrest.version>
         <gson.version>2.9.0</gson.version>
         <test.containers.version>1.16.3</test.containers.version>


### PR DESCRIPTION


## Problem

Fixes CVE-2024-52979

## Solution

Upgrades the Elasticsearch version to 7.17.25 as that's the minimum recommended version 
Closes https://github.com/confluentinc/kafka-connect-elasticsearch/issues/902


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [x] System tests
- [x] Manual tests


