### PR TITLE
fix: CVE-2025-12183 - Migrate to at.yawk.lz4:lz4-java 1.10.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
 
     <properties>
         <es.version>7.17.24</es.version>
+        <lz4.version>1.10.1</lz4.version>
         <hamcrest.version>1.3</hamcrest.version>
         <mockito.version>2.28.2</mockito.version>
         <gson.version>2.9.0</gson.version>
@@ -72,6 +73,12 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-api</artifactId>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.lz4</groupId>
+                    <artifactId>lz4-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
@@ -91,6 +98,10 @@
                 <exclusion>
                     <groupId>org.yaml</groupId>
                     <artifactId>snakeyaml</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.lz4</groupId>
+                    <artifactId>lz4-java</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -120,6 +131,12 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>4.5.13</version>
+        </dependency>
+        <!-- pin lz4-java for CVE-2025-12183 - use actively maintained fork -->
+        <dependency>
+            <groupId>at.yawk.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
+            <version>${lz4.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
@@ -186,6 +203,12 @@
             <classifier>test</classifier>
             <type>test-jar</type>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.lz4</groupId>
+                    <artifactId>lz4-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>


### PR DESCRIPTION
## Summary
  Fixes CVE-2025-12183 (HIGH severity) by migrating from the deprecated `org.lz4:lz4-java` to the actively maintained fork `at.yawk.lz4:lz4-java` version 1.10.1.

  ## Vulnerability Details
  - **CVE ID**: CVE-2025-12183
  - **Severity**: HIGH
  - **Issue**: Out-of-bounds memory operations allowing denial of service and adjacent memory reads via untrusted compressed input
  - **Affected Versions**: org.lz4:lz4-java ≤ 1.8.0
  - **JIRA Tickets**: [CC-38107](https://confluentinc.atlassian.net/browse/CC-38107) (14.1.5), [CC-38106](https://confluentinc.atlassian.net/browse/CC-38106) (15.1.0)

  ## Changes Made

  ### 1. Added Secure Dependency
  - Added `at.yawk.lz4:lz4-java:1.10.1` as direct dependency
  - This is an actively maintained fork that addresses CVE-2025-12183
  - Binary compatible with org.lz4:lz4-java (no code changes required)

  ### 2. Excluded Vulnerable Transitive Dependencies
  Added exclusions for `org.lz4:lz4-java` to three dependencies that were pulling in vulnerable versions:

  1. **connect-api** (provided scope)
     - Was pulling org.lz4:lz4-java:1.7.1 via kafka-clients

  2. **elasticsearch** (compile scope)
     - Was pulling org.lz4:lz4-java:1.8.0 via elasticsearch-lz4

  3. **kafka-clients:test-jar** (test scope)
     - Was pulling org.lz4:lz4-java:1.7.1 for test dependencies

  ### 3. Added Version Property
  - Added `lz4.version=1.10.1` property for centralized version management

  ## Verification

  Confirmed resolution using `mvn dependency:tree`:
  ```bash
  # No vulnerable versions present
  mvn dependency:tree | grep "org.lz4:lz4-java"
  # (no output - vulnerable versions removed)

  # Only secure version present
  mvn dependency:tree | grep "at.yawk.lz4"
  [INFO] +- at.yawk.lz4:lz4-java:jar:1.10.1:compile
```

## Testing
- Performed KDP Tests on version 8.1.0, 8.0.0, 7.9.0 & 7.8.0

[CC-38107]: https://confluentinc.atlassian.net/browse/CC-38107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CC-38106]: https://confluentinc.atlassian.net/browse/CC-38106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ