### PR TITLE
update log4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,10 +105,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+	<!-- update log4j version to currently defined in common, this should be removed after update of pom parent to something more modern -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.17.1</version>
+            <version>2.25.3</version>
         </dependency>
         <!-- pin jackson-dataformat-cbor for CVE - the version comes from confluentinc/common -->
         <dependency>


### PR DESCRIPTION
## Problem
Kafka-connect-elasticsearch uses an outdated, pinned version of log4j.

## Solution
 Update to version used in common

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
