### PR TITLE
Bump log4j to 2.25.4 and jackson to 2.18.6; exclude EOL log4j 1.x from hadoop-minikdc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,6 +234,13 @@
             <artifactId>hadoop-minikdc</artifactId>
             <version>${hadoop.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <!-- log4j 1.x is end-of-life and the 1.2.17 artifact is no longer reliably resolvable from upstream mirrors. reload4j (declared explicitly in test scope) provides drop-in org.apache.log4j.* classes for slf4j-log4j12. -->
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -47,16 +47,16 @@
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
         <hadoop.version>3.3.1</hadoop.version>
         <apacheds-jdbm1.version>2.0.0-M2</apacheds-jdbm1.version>
-        <!-- TODO: Remove the version pin after releasing https://github.com/confluentinc/common/pull/494 -->
-        <jackson.databind.version>2.15.2</jackson.databind.version>
-        <jackson.version>2.15.2</jackson.version>
+        <log4j.version>2.25.4</log4j.version>
+        <!-- Pinned to address GHSA-72hv-8253-57qq in jackson-core. -->
+        <jackson.databind.version>2.18.6</jackson.databind.version>
+        <jackson.version>2.18.6</jackson.version>
         <!-- temporary fix by pinning the version until we upgrade to a version of common that contains this or newer version.
             See https://github.com/confluentinc/common/pull/332 for details (common-parent 7.0.0-0) -->
         <dependency.check.version>6.1.6</dependency.check.version>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
         <commons.codec.version>1.15</commons.codec.version>
         <confluent.version>${io.confluent.common.version}</confluent.version>
-        <jackson.version>2.16.0</jackson.version>
         <dependency.check.skip>true</dependency.check.skip>
     </properties>
 
@@ -108,7 +108,6 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.17.1</version>
         </dependency>
         <!-- pin jackson-dataformat-cbor for CVE - the version comes from confluentinc/common -->
         <dependency>
@@ -331,6 +330,14 @@
                 <groupId>com.fasterxml.jackson.dataformat</groupId>
                 <artifactId>jackson-dataformat-cbor</artifactId>
                 <version>${jackson.version}</version>
+            </dependency>
+            <!-- Align all log4j artifacts (incl. transitive log4j-core via elasticsearch) to ${log4j.version}. -->
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-bom</artifactId>
+                <version>${log4j.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,6 @@
         <hadoop.version>3.3.1</hadoop.version>
         <apacheds-jdbm1.version>2.0.0-M2</apacheds-jdbm1.version>
         <log4j.version>2.25.4</log4j.version>
-        <jackson.databind.version>2.18.6</jackson.databind.version>
         <jackson.version>2.18.6</jackson.version>
         <!-- temporary fix by pinning the version until we upgrade to a version of common that contains this or newer version.
             See https://github.com/confluentinc/common/pull/332 for details (common-parent 7.0.0-0) -->
@@ -319,11 +318,6 @@
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
                 <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>${jackson.databind.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,6 @@
         <hadoop.version>3.3.1</hadoop.version>
         <apacheds-jdbm1.version>2.0.0-M2</apacheds-jdbm1.version>
         <log4j.version>2.25.4</log4j.version>
-        <!-- Pinned to address GHSA-72hv-8253-57qq in jackson-core. -->
         <jackson.databind.version>2.18.6</jackson.databind.version>
         <jackson.version>2.18.6</jackson.version>
         <!-- temporary fix by pinning the version until we upgrade to a version of common that contains this or newer version.


### PR DESCRIPTION
## Problem

Three dependency-related issues affect `kafka-connect-elasticsearch` on the `14.1.x` line.

| Library | Issue | Severity |
|---|---|---|
| `org.apache.logging.log4j:log4j-core` 2.17.1 | Multiple log4j 2.x CVEs published since 2.17.1, including [CVE-2025-68161](https://nvd.nist.gov/vuln/detail/CVE-2025-68161), [CVE-2026-34477](https://nvd.nist.gov/vuln/detail/CVE-2026-34477), CVE-2026-34478/34479/34480/34481 | Medium |
| `com.fasterxml.jackson.core:jackson-core` 2.16.0 | [GHSA-72hv-8253-57qq](https://github.com/advisories/GHSA-72hv-8253-57qq) — the async JSON parser ignores `StreamReadConstraints.maxNumberLength`, enabling a DoS / memory-exhaustion via long numeric tokens | Medium (CVSS 6.9) |
| `log4j:log4j` 1.2.17 (transitive via `hadoop-minikdc:3.3.1` -> `slf4j-log4j12:1.7.30`) | log4j 1.x has been end-of-life since 2015 and the 1.2.17 artifact is no longer reliably resolvable from upstream Maven mirrors, which can break test-scope dependency resolution even when tests are skipped. | Build break |

Existing PRs #911 and #915 only bump the directly-declared `log4j-api` and leave the **transitive `log4j-core`** (pulled in via `org.elasticsearch:elasticsearch:7.17.24`) at 2.17.1 — they don't actually close the CVEs. This PR aligns both via the BOM.

## Solution

### 1. Bump log4j 2.x to 2.25.4 via `log4j-bom`

- Add a `log4j.version` property and import `org.apache.logging.log4j:log4j-bom:${log4j.version}` into `<dependencyManagement>`.
- Remove the explicit `<version>2.17.1</version>` from the direct `log4j-api` declaration so it inherits from the BOM.
- The BOM also forces the transitive `log4j-core` (via elasticsearch 7.17.24) up to 2.25.4.

Why 2.25.4 (not 2.25.3): closes the additional CVEs that landed in 2.25.4 (CVE-2026-34477/34478/34479/34480/34481) on top of CVE-2025-68161 fixed in 2.25.3. No public-API breaking changes between 2.17.1 and 2.25.4 for code that only uses `LogManager` / `Logger`.

### 2. Bump jackson to 2.18.6

- `<jackson.version>` 2.16.0 -> 2.18.6
- `<jackson.databind.version>` 2.15.2 -> 2.18.6 (was independently pinned and out of sync with `jackson.version`, which Jackson explicitly recommends against)
- Remove a duplicate dead `<jackson.version>2.15.2</jackson.version>` property line (the later 2.16.0 declaration was the effective one).

Why 2.18.6: lowest fix version for GHSA-72hv-8253-57qq listed in the advisory. Conservative jump (one minor) and stays on the 2.x major. The advisory is isolated to `jackson-core`, but Jackson recommends matched versions across `core`/`databind`/`annotations`, so the bump is applied uniformly via the existing `jackson-bom` import.

### 3. Exclude transitive `log4j:log4j` 1.2.17

- Add `<exclusion>log4j:log4j</exclusion>` to the test-scoped `org.apache.hadoop:hadoop-minikdc` dependency.
- `reload4j` is already declared explicitly on the test classpath, so `slf4j-log4j12` still finds its `org.apache.log4j.*` target classes (reload4j is a drop-in replacement) — no `NoClassDefFoundError` risk for the Kerberos ITs.

## Verification

### `mvn dependency:tree`

After this PR:

```
+- org.apache.logging.log4j:log4j-api:jar:2.25.4:compile
   +- (transitive) org.apache.logging.log4j:log4j-core:jar:2.25.4:compile
+- com.fasterxml.jackson.core:jackson-core:jar:2.18.6:compile
+- com.fasterxml.jackson.core:jackson-databind:jar:2.18.6:compile
+- com.fasterxml.jackson.core:jackson-annotations:jar:2.18.6:compile
   (and 12 other jackson-* artifacts: dataformat-{cbor,csv,smile,yaml},
    datatype-{jdk8,guava,joda,jsr310}, module-{scala,jaxb,parameter-names},
    jaxrs-{base,json-provider} — all uniformly at 2.18.6)
```

`log4j:log4j` 1.2.17 is no longer in the resolved graph.

### End-to-end smoke test

Built the connector ZIP from this branch and ran it on Confluent Platform 7.8.0 - 8.2.0 + Elasticsearch via `kafka-docker-playground`:
- Connector installed successfully and task transitioned to `RUNNING`.
- 10 records produced to a Kafka topic were indexed and queryable in Elasticsearch with the expected `_source` payloads.

This confirms the bumped log4j and Jackson versions don't break the runtime path (logging init, JSON serialization through the rest client, bulk indexing).

## Test Strategy

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [x] Manual tests (KDP from 7.8.0 - 8.2.0)
