### PR TITLE
Add github_write_targets for docs repo + quote lang_version

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -1,6 +1,6 @@
 name: kafka-connect-elasticsearch
 lang: java
-lang_version: 8
+lang_version: "8"
 git:
   enable: true
 codeowners:
@@ -13,6 +13,8 @@ semaphore:
   extra_build_args: "-Dcloud -Pjenkins"
   run_pint_merge: true
   generate_connect_changelogs: true
+  github_write_targets:
+    - confluentinc/docs-kafka-connect-elasticsearch
 code_artifact:
   enable: true
   package_paths:


### PR DESCRIPTION
Required so the Generate Release Notes CI step can git-push to confluentinc/docs-kafka-connect-elasticsearch. Without this, the write-token Lambda issues a token without that repo in scope and the push fails with "remote: Repository not found".

Also quote lang_version (8 -> "8") so the service-bot manifest validator accepts it; the unquoted integer trips
"lang_version: Input should be a valid string [type=string_type, input_value=8, input_type=int]" when service-bot runs on this repo.

After this lands on master, trigger service-bot manually to populate the github-write-targets DynamoDB table:
  https://semaphore.ci.confluent.io/projects/cc-service-bot/schedulers/8e6d9eb0-1276-4ec7-b67a-31ace4b95717/just_run

## Problem


## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
