### PR TITLE
CC-36331: differentiate user vs system errors in Validator client init

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/Validator.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/Validator.java
@@ -169,10 +169,19 @@ public class Validator {
         validateResourceExists(client);
       } catch (IOException e) {
         log.warn("Closing the client failed.", e);
-      } catch (Throwable e) {
-        log.error("Failed to create client to verify connection. ", e);
-        addErrorMessage(CONNECTION_URL_CONFIG, "Failed to create client to verify connection. "
-            + e.getMessage());
+      } catch (ConfigException e) {
+        log.error("Invalid configuration encountered while building Elasticsearch client.", e);
+        addErrorMessage(CONNECTION_URL_CONFIG,
+            "Invalid Elasticsearch client configuration: " + e.getMessage());
+      } catch (IllegalArgumentException e) {
+        log.error("Malformed connection URL.", e);
+        addErrorMessage(CONNECTION_URL_CONFIG,
+            "Malformed Elasticsearch connection URL: " + e.getMessage());
+      } catch (RuntimeException e) {
+        log.error("Failed to initialize Elasticsearch client.", e);
+        addErrorMessage(CONNECTION_URL_CONFIG,
+            "Could not initialize the Elasticsearch client. This may indicate the cluster is "
+                + "unreachable or there is a transient infrastructure issue: " + e.getMessage());
       }
     }
 

--- a/src/test/java/io/confluent/connect/elasticsearch/ValidatorTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ValidatorTest.java
@@ -61,6 +61,7 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.kafka.common.config.Config;
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.ConfigValue;
 import org.apache.kafka.common.config.SslConfigs;
 import org.elasticsearch.ElasticsearchStatusException;
@@ -151,6 +152,36 @@ public class ValidatorTest {
     validator = new Validator(props, () -> mockClient);
     Config result = validator.validate();
     assertHasErrorMessage(result, CONNECTION_URL_CONFIG, "Could not connect to Elasticsearch. Error message: Deleted resource.");
+  }
+
+  @Test
+  public void testClientFactoryThrowsConfigException() {
+    validator = new Validator(props, () -> {
+      throw new ConfigException("bad keystore path");
+    });
+    Config result = validator.validate();
+    assertHasErrorMessage(result, CONNECTION_URL_CONFIG,
+        "Invalid Elasticsearch client configuration: ");
+  }
+
+  @Test
+  public void testClientFactoryThrowsIllegalArgumentException() {
+    validator = new Validator(props, () -> {
+      throw new IllegalArgumentException("malformed url");
+    });
+    Config result = validator.validate();
+    assertHasErrorMessage(result, CONNECTION_URL_CONFIG,
+        "Malformed Elasticsearch connection URL: malformed url");
+  }
+
+  @Test
+  public void testClientFactoryThrowsGenericRuntimeException() {
+    validator = new Validator(props, () -> {
+      throw new RuntimeException("tls handshake failed");
+    });
+    Config result = validator.validate();
+    assertHasErrorMessage(result, CONNECTION_URL_CONFIG,
+        "Could not initialize the Elasticsearch client.");
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Replace `catch (Throwable)` in `Validator.validate()` with specific branches for `ConfigException`, `IllegalArgumentException`, and `RuntimeException` so misconfiguration surfaces a user-worded message while infrastructure failures during client construction stop blaming the user's connection URL.
- `Error` subclasses (`OutOfMemoryError`, `NoClassDefFoundError`, etc.) now propagate instead of being swallowed into a `ConfigValue` error.
- Scope intentionally limited to the outer catch site in `validate()`. Related cleanups in `validateConnection()`, `validateVersion()`, and `validateResourceExists()` are tracked as follow-ups (the last one overlaps with CC-35254).

## Behavior change

Before: every failure escaping `clientFactory.client()` produced *"Failed to create client to verify connection. {message}"* pinned to `connection.url`, regardless of root cause.

After (all messages on `connection.url`):
- `ConfigException` (e.g. bad keystore path from `ConfigCallbackHandler`) → *"Invalid Elasticsearch client configuration: …"*
- `IllegalArgumentException` (e.g. malformed URL from `HttpHost.create`) → *"Malformed Elasticsearch connection URL: …"*
- Other `RuntimeException` (e.g. transient TLS / handshake failures) → *"Could not initialize the Elasticsearch client. This may indicate the cluster is unreachable or there is a transient infrastructure issue: …"*

Related: [CC-36331](https://confluentinc.atlassian.net/browse/CC-36331), motivated by [CC-35254](https://confluentinc.atlassian.net/browse/CC-35254).

## Test plan

- [x] Three new `ValidatorTest` cases cover the new branches (`testClientFactoryThrowsConfigException`, `testClientFactoryThrowsIllegalArgumentException`, `testClientFactoryThrowsGenericRuntimeException`).
- [x] Identical change validated on master locally: 57/57 `ValidatorTest` cases pass (54 existing + 3 new).
- [ ] CI green on 14.1.x (local mvn invocation on 14.1.x has a pre-existing bytebuddy/JDK incompatibility unrelated to this change; CI uses the right setup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CC-36331]: https://confluentinc.atlassian.net/browse/CC-36331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ