### PR TITLE
CC-42331: Upgrade jackson-databind to 2.21.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,9 @@
         <hadoop.version>3.3.1</hadoop.version>
         <apacheds-jdbm1.version>2.0.0-M2</apacheds-jdbm1.version>
         <log4j.version>2.25.4</log4j.version>
-        <jackson.version>2.18.6</jackson.version>
+        <jackson.version>2.21.5</jackson.version>
+        <!-- jackson-annotations dropped patch-level versioning starting with the 2.20 line -->
+        <jackson.annotations.version>2.21</jackson.annotations.version>
         <!-- temporary fix by pinning the version until we upgrade to a version of common that contains this or newer version.
             See https://github.com/confluentinc/common/pull/332 for details (common-parent 7.0.0-0) -->
         <dependency.check.version>6.1.6</dependency.check.version>
@@ -303,7 +305,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson.annotations.version}</version>
         </dependency>
     </dependencies>
 
@@ -317,7 +319,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>${jackson.version}</version>
+                <version>${jackson.annotations.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
@@ -330,6 +332,12 @@
                 <groupId>com.fasterxml.jackson.dataformat</groupId>
                 <artifactId>jackson-dataformat-cbor</artifactId>
                 <version>${jackson.version}</version>
+            </dependency>
+            <!-- jackson-datatype-jsr310 2.21.5 is not yet available via the internal artifact mirror; 2.21.4 is compatible and unaffected by the CVEs this bump addresses (test scope only). -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jsr310</artifactId>
+                <version>2.21.4</version>
             </dependency>
             <!-- Align all log4j artifacts (incl. transitive log4j-core via elasticsearch) to ${log4j.version}. -->
             <dependency>


### PR DESCRIPTION
## Summary
- Bumped `com.fasterxml.jackson.core:jackson-databind` from `2.18.6` to `2.21.5` to fix multiple jackson-databind CVEs
- `jackson-core` and `jackson-annotations` are bumped alongside `databind` for version consistency; `jackson-annotations` no longer follows patch-level versioning as of the 2.20 line, so it now tracks its own `jackson.annotations.version` property
- `jackson-datatype-jsr310` (test scope only) is pinned to `2.21.4` because `2.21.5` is not yet available via the internal artifact mirror; it is unaffected by these CVEs since it's a test-only dependency
- Root cause: direct dependency, pinned via the `jackson.version` property in `pom.xml` (not shaded)

## CVE Details
- **Jira**: [CC-42331](https://confluentinc.atlassian.net/browse/CC-42331)
- **Linked CVEs**: CVE-2026-54512, CVE-2026-54513, CVE-2026-54514, CVE-2026-54515
- **Impacted versions**: `kafka-connect-elasticsearch:14.1.7`, `kafka-connect-elasticsearch:15.1.2`
- **Vulnerable**: `com.fasterxml.jackson.core:jackson-databind:2.18.6`
- **Fixed**: `com.fasterxml.jackson.core:jackson-databind:2.21.5` (via `jackson.version` property bump in `pom.xml`)

## Test Results

### Trivy CVE Scan
**Command**: `trivy rootfs --scanners vuln .`

Before (jackson-databind 2.18.6):
~~~
com.fasterxml.jackson.core:jackson-databind  CVE-2026-54512  HIGH    fixed  2.18.6  2.18.8, 3.1.4, 2.21.4          jackson-databind: Arbitrary code execution via PolymorphicTypeValidator bypass
com.fasterxml.jackson.core:jackson-databind  CVE-2026-54513          fixed  2.18.6  2.18.8, 2.21.4, 3.1.4          Jackson-databind: Security bypass allows arbitrary code execution
com.fasterxml.jackson.core:jackson-databind  CVE-2026-54514  MEDIUM  fixed  2.18.6  2.18.8, 2.21.4, 3.1.4          jackson-databind: Information Disclosure via Eager DNS Resolution
com.fasterxml.jackson.core:jackson-databind  CVE-2026-54515          fixed  2.18.6  3.1.4, 2.18.9, 2.21.5, 2.22.1  jackson-databind: Ignored properties can be unexpectedly modified
~~~

After (jackson-databind 2.21.5):
~~~
target/kafka-connect-elasticsearch-14.1.8-SNAPSHOT-development/share/java/kafka-connect-elasticsearch/jackson-core-2.21.5.jar          0
target/kafka-connect-elasticsearch-14.1.8-SNAPSHOT-development/share/java/kafka-connect-elasticsearch/jackson-databind-2.21.5.jar      0
target/kafka-connect-elasticsearch-14.1.8-SNAPSHOT-development/share/java/kafka-connect-elasticsearch/jackson-dataformat-cbor-2.21.5.jar   0
target/kafka-connect-elasticsearch-14.1.8-SNAPSHOT-package/share/java/kafka-connect-elasticsearch/jackson-core-2.21.5.jar              0
target/kafka-connect-elasticsearch-14.1.8-SNAPSHOT-package/share/java/kafka-connect-elasticsearch/jackson-databind-2.21.5.jar          0
target/kafka-connect-elasticsearch-14.1.8-SNAPSHOT-package/share/java/kafka-connect-elasticsearch/jackson-dataformat-cbor-2.21.5.jar       0
~~~
**Result: CLEAN — 0 jackson-databind vulnerabilities detected** (all four CVEs resolved)

### Unit Tests — 0 tests, 0 failures (pre-existing, unchanged from base branch)
**Command**: `mvn test`
~~~
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] BUILD SUCCESS
~~~
Note: `mvn test` runs 0 tests on `14.1.x` before this change too (confirmed by diffing against base branch) — unit tests in this module live under the integration-test (failsafe) phase.

### Integration Tests — 25 tests, 0 failures, 4 pre-existing errors, 2 skipped (identical to base branch)
**Command**: `mvn verify -DskipIntegrationTests=false -Dtest=none -DfailIfNoTests=false`
~~~
[WARNING] Tests run: 7, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 42.083 s - in io.confluent.connect.elasticsearch.integration.ElasticsearchConnectorNetworkIT
[WARNING] Tests run: 14, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 10.999 s - in io.confluent.connect.elasticsearch.integration.ElasticsearchSinkTaskIT

[ERROR] io.confluent.connect.elasticsearch.integration.ElasticsearchConnectorIT
[ERROR]   Run 1: ElasticsearchConnectorIT.setupBeforeAll:79 » ContainerFetch Can't get Docker i...
[ERROR] io.confluent.connect.elasticsearch.integration.ElasticsearchConnectorKerberosIT
[ERROR]   Run 1: ElasticsearchConnectorKerberosIT.setupBeforeAll:36 » ContainerFetch Can't get ...
[ERROR] io.confluent.connect.elasticsearch.integration.ElasticsearchConnectorKerberosWithSslIT
[ERROR]   Run 1: ElasticsearchConnectorKerberosWithSslIT.setupBeforeAll:24 » ContainerFetch Can...
[ERROR] io.confluent.connect.elasticsearch.integration.ElasticsearchConnectorSslIT
[ERROR]   Run 1: ElasticsearchConnectorSslIT.setupBeforeAll:48 » ContainerFetch Can't get Docke...

Tests run: 25, Failures: 0, Errors: 4, Skipped: 2
~~~
The 4 errors are pre-existing local-environment Docker image pull failures (`ContainerFetch`), confirmed identical (same 4 tests, same failure type) when run against the unmodified `14.1.x` base branch — unrelated to this dependency bump.

### KDP Sink Test
**Command**: `playground run -f ./elasticsearch-sink.sh --connector-jar /path/to/kafka-connect-elasticsearch-14.1.8-SNAPSHOT.jar --environment plaintext`
~~~
🎯☕ CONNECTOR_JAR (--connector-jar option) is set with .../kafka-connect-elasticsearch-14.1.8-SNAPSHOT.jar
✅ 🌎onprem connector elasticsearch-sink was successfully created

Name                           Status       Tasks                        Stack Trace
-------------------------------------------------------------------------------------------------------------
elasticsearch-sink             ✅ RUNNING  0:🟢 RUNNING                 -
-------------------------------------------------------------------------------------------------------------

✅ RESULT: SUCCESS for elasticsearch-sink.sh (took: 5min 6sec - )
~~~
Additionally verified end-to-end via direct API checks: all 10 test records were correctly indexed into Elasticsearch (`GET /test-elasticsearch-sink/_count` → `{"count":10}`), and the connector/task remained in `RUNNING` state throughout with no errors in the Connect logs.


[CC-42331]: https://confluentinc.atlassian.net/browse/CC-42331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ