### PR TITLE
CC-42849: stop logging raw Kafka record key in version-conflict WARN/DEBUG logs

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
@@ -585,11 +585,10 @@ public class ElasticsearchClient {
         // and thus can be ignored, since the newer value (higher offset) should
         // remain the key's value in any case.
         if (request == null || request.versionType() != VersionType.EXTERNAL) {
-          log.warn("{} version conflict for operation {} on document '{}' version {}"
+          log.warn("{} version conflict for operation {} version {}"
                           + " in index '{}'.",
                   request != null ? request.versionType() : "UNKNOWN",
                   response.getOpType(),
-                  response.getId(),
                   response.getVersion(),
                   response.getIndex()
           );
@@ -612,10 +611,9 @@ public class ElasticsearchClient {
           // Note: For external version conflicts, response.getVersion() will be returned as -1,
           // but we have the actual version number for this record because we set it in
           // the request.
-          log.debug("Ignoring EXTERNAL version conflict for operation {} on"
-                          + " document '{}' version {} in index '{}'.",
+          log.debug("Ignoring EXTERNAL version conflict for operation {}"
+                          + " version {} in index '{}'.",
                   response.getOpType(),
-                  response.getId(),
                   request.version(),
                   response.getIndex()
           );


### PR DESCRIPTION
## Summary
- Fixes [CC-42849](https://confluentinc.atlassian.net/browse/CC-42849): the version-conflict handler in `ElasticsearchClient.handleResponse` logged `response.getId()` at WARN and DEBUG, which for `key.ignore=false` is the raw Kafka record key (customer-controlled data such as user ids, emails, order ids) written to connector logs in cleartext.
- Removes the record key from the WARN (L588) and DEBUG (L615) log lines, keeping only safe fields (`opType`, `version`, `index`).
- Leaves the existing TRACE log line (L597) unchanged, since it retains the document-id detail for troubleshooting when explicitly enabled, per the ticket's recommendation.

## Test plan
- [x] `mvn compile` succeeds
- [ ] `mvn test` — `ElasticsearchClientTest` requires a Docker-backed Elasticsearch testcontainer, unavailable in the local dev environment; will run in CI
- [x] Confirmed no test asserts on the exact WARN/DEBUG log message text

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CC-42849]: https://confluentinc.atlassian.net/browse/CC-42849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ