### PR TITLE
CC-42849: redact remaining sensitive-data logging paths in the ES sink

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ConfigCallbackHandler.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ConfigCallbackHandler.java
@@ -22,7 +22,10 @@ import java.security.PrivilegedExceptionAction;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
 import javax.security.auth.Subject;
@@ -106,16 +109,34 @@ public class ConfigCallbackHandler implements HttpClientConfigCallback {
     }
 
     if (config.isKerberosEnabled() && config.isSslEnabled()) {
-      log.info("Using Kerberos and SSL connection to {}.", config.connectionUrls());
+      log.info("Using Kerberos and SSL connection to {}.", redactedConnectionUrls());
     } else if (config.isKerberosEnabled()) {
-      log.info("Using Kerberos connection to {}.", config.connectionUrls());
+      log.info("Using Kerberos connection to {}.", redactedConnectionUrls());
     } else if (config.isSslEnabled()) {
-      log.info("Using SSL connection to {}.", config.connectionUrls());
+      log.info("Using SSL connection to {}.", redactedConnectionUrls());
     } else {
-      log.info("Using unsecured connection to {}.", config.connectionUrls());
+      log.info("Using unsecured connection to {}.", redactedConnectionUrls());
     }
 
     return builder;
+  }
+
+  /**
+   * Returns the configured connection URLs with any embedded {@code user:password@} credential
+   * stripped out, so they are safe to log. Credentials should normally be supplied via the
+   * dedicated {@code connection.username}/{@code connection.password} configs, but nothing
+   * prevents a URL from carrying them directly.
+   */
+  private Set<String> redactedConnectionUrls() {
+    return config.connectionUrls().stream()
+        .map(ConfigCallbackHandler::redactUserInfo)
+        .collect(Collectors.toCollection(LinkedHashSet::new));
+  }
+
+  private static String redactUserInfo(String url) {
+    int authorityStart = url.indexOf("://") >= 0 ? url.indexOf("://") + 3 : 0;
+    int atIndex = url.indexOf('@', authorityStart);
+    return atIndex < 0 ? url : url.substring(0, authorityStart) + url.substring(atIndex + 1);
   }
 
   /**

--- a/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
@@ -268,8 +268,11 @@ public class DataConverter {
           //fromConnectHeader byte output is UTF_8
           request.version(Long.parseLong(new String(versionValue, StandardCharsets.UTF_8)));
         } catch (NumberFormatException e) {
-          throw new ConnectException("Error converting to long: "
-                  + new String(versionValue, StandardCharsets.UTF_8), e);
+          // Do not include the raw header value here: it is record-derived content and
+          // this exception can propagate uncaught to the Connect worker's error log.
+          throw new ConnectException(
+              "Error converting external version header '" + versionHeader.key()
+                  + "' to long for " + recordString(record), e);
         }
       } else {
         request.version(record.kafkaOffset());

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -291,7 +291,10 @@ public class ElasticsearchSinkTask extends SinkTask {
       reportBadRecord(sinkRecord, convertException);
 
       if (config.dropInvalidMessage()) {
-        log.error("Can't convert {}.", recordString(sinkRecord), convertException);
+        // Log only the exception type, not the exception itself: its message may originate
+        // from a third-party converter and could echo back raw record content.
+        log.error("Can't convert {}. Failure type: {}",
+            recordString(sinkRecord), convertException.getClass().getName());
         offsetState.markProcessed();
       } else {
         throw convertException;


### PR DESCRIPTION
## Summary
Stacks on top of #924. A log-leak audit of this repo (comparable to the fix in #924) surfaced three more real-but-currently-unfired leak paths, closed here:

- `ConfigCallbackHandler`: `connection.url` is logged at INFO on every client build with no check for an embedded `user:pass@` credential. Strips any user-info before logging.
- `ElasticsearchSinkTask`: the ERROR log for a failed record conversion logged the full caught `DataException`, whose message can originate from Kafka's own `JsonConverter` (not in this repo) and could echo record content. Now logs only the exception class plus topic/partition/offset.
- `DataConverter`: the `ConnectException` thrown when an external-version header fails to parse as a `long` embedded the raw decoded header bytes. Since `ConnectException` is `DataException`'s superclass, this exception isn't caught by the sink task's `catch (DataException)` and can propagate to the Connect worker's own error log. The header value is now dropped from the message.

None of these were confirmed as active incidents — verified against 30 days of production logs (`logs.json.connect`) with no sensitive content observed for any of the three — but all three are genuine leak paths worth closing as defense in depth.

## Test plan
- [x] `mvn clean compile` succeeds (checkstyle: 0 violations)
- [x] `mvn test -Dtest=DataConverterTest,ElasticsearchSinkTaskTest` — 80 tests pass
- [x] Confirmed no test asserts on the exact log/exception message text changed here

🤖 Generated with [Claude Code](https://claude.com/claude-code)