### PR TITLE
CC-42849: stop logging sensitive data in the Elasticsearch sink

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ConfigCallbackHandler.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ConfigCallbackHandler.java
@@ -22,7 +22,10 @@ import java.security.PrivilegedExceptionAction;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
 import javax.security.auth.Subject;
@@ -106,16 +109,34 @@ public class ConfigCallbackHandler implements HttpClientConfigCallback {
     }
 
     if (config.isKerberosEnabled() && config.isSslEnabled()) {
-      log.info("Using Kerberos and SSL connection to {}.", config.connectionUrls());
+      log.info("Using Kerberos and SSL connection to {}.", redactedConnectionUrls());
     } else if (config.isKerberosEnabled()) {
-      log.info("Using Kerberos connection to {}.", config.connectionUrls());
+      log.info("Using Kerberos connection to {}.", redactedConnectionUrls());
     } else if (config.isSslEnabled()) {
-      log.info("Using SSL connection to {}.", config.connectionUrls());
+      log.info("Using SSL connection to {}.", redactedConnectionUrls());
     } else {
-      log.info("Using unsecured connection to {}.", config.connectionUrls());
+      log.info("Using unsecured connection to {}.", redactedConnectionUrls());
     }
 
     return builder;
+  }
+
+  /**
+   * Returns the configured connection URLs with any embedded {@code user:password@} credential
+   * stripped out, so they are safe to log. Credentials should normally be supplied via the
+   * dedicated {@code connection.username}/{@code connection.password} configs, but nothing
+   * prevents a URL from carrying them directly.
+   */
+  private Set<String> redactedConnectionUrls() {
+    return config.connectionUrls().stream()
+        .map(ConfigCallbackHandler::redactUserInfo)
+        .collect(Collectors.toCollection(LinkedHashSet::new));
+  }
+
+  private static String redactUserInfo(String url) {
+    int authorityStart = url.indexOf("://") >= 0 ? url.indexOf("://") + 3 : 0;
+    int atIndex = url.indexOf('@', authorityStart);
+    return atIndex < 0 ? url : url.substring(0, authorityStart) + url.substring(atIndex + 1);
   }
 
   /**

--- a/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
@@ -268,8 +268,11 @@ public class DataConverter {
           //fromConnectHeader byte output is UTF_8
           request.version(Long.parseLong(new String(versionValue, StandardCharsets.UTF_8)));
         } catch (NumberFormatException e) {
-          throw new ConnectException("Error converting to long: "
-                  + new String(versionValue, StandardCharsets.UTF_8), e);
+          // Do not include the raw header value here: it is record-derived content and
+          // this exception can propagate uncaught to the Connect worker's error log.
+          throw new ConnectException(
+              "Error converting external version header '" + versionHeader.key()
+                  + "' to long for " + recordString(record), e);
         }
       } else {
         request.version(record.kafkaOffset());

--- a/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
@@ -268,11 +268,12 @@ public class DataConverter {
           //fromConnectHeader byte output is UTF_8
           request.version(Long.parseLong(new String(versionValue, StandardCharsets.UTF_8)));
         } catch (NumberFormatException e) {
-          // Do not include the raw header value here: it is record-derived content and
-          // this exception can propagate uncaught to the Connect worker's error log.
+          // Do not include the raw header value, nor the original exception, here: this
+          // exception can propagate uncaught to the Connect worker's error log, and
+          // NumberFormatException's own message embeds the invalid (record-derived) value.
           throw new ConnectException(
               "Error converting external version header '" + versionHeader.key()
-                  + "' to long for " + recordString(record), e);
+                  + "' to long for " + recordString(record));
         }
       } else {
         request.version(record.kafkaOffset());

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
@@ -585,11 +585,10 @@ public class ElasticsearchClient {
         // and thus can be ignored, since the newer value (higher offset) should
         // remain the key's value in any case.
         if (request == null || request.versionType() != VersionType.EXTERNAL) {
-          log.warn("{} version conflict for operation {} on document '{}' version {}"
+          log.warn("{} version conflict for operation {} version {}"
                           + " in index '{}'.",
                   request != null ? request.versionType() : "UNKNOWN",
                   response.getOpType(),
-                  response.getId(),
                   response.getVersion(),
                   response.getIndex()
           );
@@ -612,10 +611,9 @@ public class ElasticsearchClient {
           // Note: For external version conflicts, response.getVersion() will be returned as -1,
           // but we have the actual version number for this record because we set it in
           // the request.
-          log.debug("Ignoring EXTERNAL version conflict for operation {} on"
-                          + " document '{}' version {} in index '{}'.",
+          log.debug("Ignoring EXTERNAL version conflict for operation {}"
+                          + " version {} in index '{}'.",
                   response.getOpType(),
-                  response.getId(),
                   request.version(),
                   response.getIndex()
           );

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -291,7 +291,10 @@ public class ElasticsearchSinkTask extends SinkTask {
       reportBadRecord(sinkRecord, convertException);
 
       if (config.dropInvalidMessage()) {
-        log.error("Can't convert {}.", recordString(sinkRecord), convertException);
+        // Log only the exception type, not the exception itself: its message may originate
+        // from a third-party converter and could echo back raw record content.
+        log.error("Can't convert {}. Failure type: {}",
+            recordString(sinkRecord), convertException.getClass().getName());
         offsetState.markProcessed();
       } else {
         throw convertException;

--- a/src/test/java/io/confluent/connect/elasticsearch/DataConverterTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/DataConverterTest.java
@@ -18,6 +18,7 @@ package io.confluent.connect.elasticsearch;
 import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BehaviorOnNullValues;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.connect.data.*;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.elasticsearch.action.DocWriteRequest;
@@ -43,6 +44,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class DataConverterTest {
@@ -404,6 +406,31 @@ public class DataConverterTest {
     assertEquals(key, actualRecord.id());
     assertEquals(index, actualRecord.index());
     assertEquals(expectedExternalVersion, actualRecord.version());
+  }
+
+  @Test
+  public void externalVersionHeaderInvalidValueDoesNotLeakHeaderValueOrCause() {
+    String externalVersionHeader = "version";
+    String invalidVersionValue = "not-a-long-CANARY";
+
+    props.put(ElasticsearchSinkConnectorConfig.IGNORE_KEY_CONFIG, "false");
+    props.put(ElasticsearchSinkConnectorConfig.IGNORE_SCHEMA_CONFIG, "false");
+    props.put(ElasticsearchSinkConnectorConfig.EXTERNAL_VERSION_HEADER_CONFIG, externalVersionHeader);
+    converter = new DataConverter(new ElasticsearchSinkConnectorConfig(props));
+
+    Schema preProcessedSchema = converter.preProcessSchema(schema);
+    Struct struct = new Struct(preProcessedSchema).put("string", "myValue");
+    SinkRecord sinkRecord = createSinkRecordWithValue(struct);
+    sinkRecord.headers().addString(externalVersionHeader, invalidVersionValue);
+
+    ConnectException exception = assertThrows(
+        ConnectException.class,
+        () -> converter.convertRecord(sinkRecord, index)
+    );
+
+    assertNull(exception.getCause());
+    assertFalse(exception.getMessage().contains(invalidVersionValue));
+    assertTrue(exception.getMessage().contains(externalVersionHeader));
   }
 
   @Test


### PR DESCRIPTION
## Summary
Combines #924 and #925 into one PR. A log-leak audit of this repo found several places where sensitive data (Kafka record keys, header values, and a connection URL) could reach connector logs:

- `ElasticsearchClient`: the version-conflict handler in `handleResponse` logged `response.getId()` at WARN and DEBUG, which for `key.ignore=false` is the raw Kafka record key (customer-controlled data such as user ids, emails, order ids). Removed the record key from the WARN (L588) and DEBUG (L615) log lines, keeping only safe fields (`opType`, `version`, `index`). The existing TRACE log line (L597) is left unchanged, since it retains the document-id detail for troubleshooting when explicitly enabled.
- `ConfigCallbackHandler`: `connection.url` is logged at INFO on every client build with no check for an embedded `user:pass@` credential. Strips any user-info before logging.
- `ElasticsearchSinkTask`: the ERROR log for a failed record conversion logged the full caught `DataException`, whose message can originate from Kafka's own `JsonConverter` (not in this repo) and could echo record content. Now logs only the exception class plus topic/partition/offset.
- `DataConverter`: the `ConnectException` thrown when an external-version header fails to parse as a `long` embedded the raw decoded header bytes. Since `ConnectException` is `DataException`'s superclass, this exception isn't caught by the sink task's `catch (DataException)` and can propagate to the Connect worker's own error log. The header value is now dropped from the message.

Only the first item (`ElasticsearchClient`) was a confirmed pattern already known to leak (per [CC-42849](https://confluentinc.atlassian.net/browse/CC-42849)); the other three were found via static analysis and verified against 30 days of production logs (`logs.json.connect`) with no sensitive content observed, but are real leak paths worth closing as defense in depth.

## Test plan
- [x] `mvn clean compile` succeeds (checkstyle: 0 violations)
- [x] `mvn test -Dtest=DataConverterTest,ElasticsearchSinkTaskTest` — 80 tests pass
- [ ] `mvn test` — `ElasticsearchClientTest` requires a Docker-backed Elasticsearch testcontainer, unavailable in the local dev environment; will run in CI
- [x] Confirmed no test asserts on the exact log/exception message text changed here

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CC-42849]: https://confluentinc.atlassian.net/browse/CC-42849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ