### PR TITLE
CC-42849: stop logging sensitive data in the Elasticsearch sink (14.1.x)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <es.version>7.17.24</es.version>
         <lz4.version>1.10.1</lz4.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <mockito.version>2.28.2</mockito.version>
+        <mockito.version>4.6.1</mockito.version>
         <gson.version>2.9.0</gson.version>
         <test.containers.version>1.16.3</test.containers.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-runtime</artifactId>
             <version>${kafka.version}</version>

--- a/src/main/java/io/confluent/connect/elasticsearch/ConfigCallbackHandler.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ConfigCallbackHandler.java
@@ -22,7 +22,10 @@ import java.security.PrivilegedExceptionAction;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
 import javax.security.auth.Subject;
@@ -106,16 +109,34 @@ public class ConfigCallbackHandler implements HttpClientConfigCallback {
     }
 
     if (config.isKerberosEnabled() && config.isSslEnabled()) {
-      log.info("Using Kerberos and SSL connection to {}.", config.connectionUrls());
+      log.info("Using Kerberos and SSL connection to {}.", redactedConnectionUrls());
     } else if (config.isKerberosEnabled()) {
-      log.info("Using Kerberos connection to {}.", config.connectionUrls());
+      log.info("Using Kerberos connection to {}.", redactedConnectionUrls());
     } else if (config.isSslEnabled()) {
-      log.info("Using SSL connection to {}.", config.connectionUrls());
+      log.info("Using SSL connection to {}.", redactedConnectionUrls());
     } else {
-      log.info("Using unsecured connection to {}.", config.connectionUrls());
+      log.info("Using unsecured connection to {}.", redactedConnectionUrls());
     }
 
     return builder;
+  }
+
+  /**
+   * Returns the configured connection URLs with any embedded {@code user:password@} credential
+   * stripped out, so they are safe to log. Credentials should normally be supplied via the
+   * dedicated {@code connection.username}/{@code connection.password} configs, but nothing
+   * prevents a URL from carrying them directly.
+   */
+  private Set<String> redactedConnectionUrls() {
+    return config.connectionUrls().stream()
+        .map(ConfigCallbackHandler::redactUserInfo)
+        .collect(Collectors.toCollection(LinkedHashSet::new));
+  }
+
+  private static String redactUserInfo(String url) {
+    int authorityStart = url.indexOf("://") >= 0 ? url.indexOf("://") + 3 : 0;
+    int atIndex = url.indexOf('@', authorityStart);
+    return atIndex < 0 ? url : url.substring(0, authorityStart) + url.substring(atIndex + 1);
   }
 
   /**

--- a/src/main/java/io/confluent/connect/elasticsearch/ConfigCallbackHandler.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ConfigCallbackHandler.java
@@ -133,10 +133,21 @@ public class ConfigCallbackHandler implements HttpClientConfigCallback {
         .collect(Collectors.toCollection(LinkedHashSet::new));
   }
 
-  private static String redactUserInfo(String url) {
+  static String redactUserInfo(String url) {
     int authorityStart = url.indexOf("://") >= 0 ? url.indexOf("://") + 3 : 0;
-    int atIndex = url.indexOf('@', authorityStart);
-    return atIndex < 0 ? url : url.substring(0, authorityStart) + url.substring(atIndex + 1);
+    int authorityEnd = url.length();
+    for (char delimiter : new char[] {'/', '?', '#'}) {
+      int delimiterIndex = url.indexOf(delimiter, authorityStart);
+      if (delimiterIndex >= 0) {
+        authorityEnd = Math.min(authorityEnd, delimiterIndex);
+      }
+    }
+    // The user-info/host separator is the LAST '@' within the authority component, since a
+    // password (unlike a host) may itself contain '@' characters.
+    int atIndex = url.lastIndexOf('@', authorityEnd - 1);
+    return atIndex < authorityStart
+        ? url
+        : url.substring(0, authorityStart) + url.substring(atIndex + 1);
   }
 
   /**

--- a/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
@@ -268,8 +268,11 @@ public class DataConverter {
           //fromConnectHeader byte output is UTF_8
           request.version(Long.parseLong(new String(versionValue, StandardCharsets.UTF_8)));
         } catch (NumberFormatException e) {
-          throw new ConnectException("Error converting to long: "
-                  + new String(versionValue, StandardCharsets.UTF_8), e);
+          // Do not include the raw header value here: it is record-derived content and
+          // this exception can propagate uncaught to the Connect worker's error log.
+          throw new ConnectException(
+              "Error converting external version header '" + versionHeader.key()
+                  + "' to long for " + recordString(record), e);
         }
       } else {
         request.version(record.kafkaOffset());

--- a/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
@@ -268,11 +268,12 @@ public class DataConverter {
           //fromConnectHeader byte output is UTF_8
           request.version(Long.parseLong(new String(versionValue, StandardCharsets.UTF_8)));
         } catch (NumberFormatException e) {
-          // Do not include the raw header value here: it is record-derived content and
-          // this exception can propagate uncaught to the Connect worker's error log.
+          // Do not include the raw header value, nor the original exception, here: this
+          // exception can propagate uncaught to the Connect worker's error log, and
+          // NumberFormatException's own message embeds the invalid (record-derived) value.
           throw new ConnectException(
               "Error converting external version header '" + versionHeader.key()
-                  + "' to long for " + recordString(record), e);
+                  + "' to long for " + recordString(record));
         }
       } else {
         request.version(record.kafkaOffset());

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
@@ -585,11 +585,10 @@ public class ElasticsearchClient {
         // and thus can be ignored, since the newer value (higher offset) should
         // remain the key's value in any case.
         if (request == null || request.versionType() != VersionType.EXTERNAL) {
-          log.warn("{} version conflict for operation {} on document '{}' version {}"
+          log.warn("{} version conflict for operation {} version {}"
                           + " in index '{}'.",
                   request != null ? request.versionType() : "UNKNOWN",
                   response.getOpType(),
-                  response.getId(),
                   response.getVersion(),
                   response.getIndex()
           );
@@ -612,10 +611,9 @@ public class ElasticsearchClient {
           // Note: For external version conflicts, response.getVersion() will be returned as -1,
           // but we have the actual version number for this record because we set it in
           // the request.
-          log.debug("Ignoring EXTERNAL version conflict for operation {} on"
-                          + " document '{}' version {} in index '{}'.",
+          log.debug("Ignoring EXTERNAL version conflict for operation {}"
+                          + " version {} in index '{}'.",
                   response.getOpType(),
-                  response.getId(),
                   request.version(),
                   response.getIndex()
           );

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -291,7 +291,10 @@ public class ElasticsearchSinkTask extends SinkTask {
       reportBadRecord(sinkRecord, convertException);
 
       if (config.dropInvalidMessage()) {
-        log.error("Can't convert {}.", recordString(sinkRecord), convertException);
+        // Log only the exception type, not the exception itself: its message may originate
+        // from a third-party converter and could echo back raw record content.
+        log.error("Can't convert {}. Failure type: {}",
+            recordString(sinkRecord), convertException.getClass().getName());
         offsetState.markProcessed();
       } else {
         throw convertException;

--- a/src/test/java/io/confluent/connect/elasticsearch/ConfigCallbackHandlerTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ConfigCallbackHandlerTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.elasticsearch;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class ConfigCallbackHandlerTest {
+
+  @Test
+  public void redactUserInfoStripsCredentials() {
+    assertEquals(
+        "https://host:9243",
+        ConfigCallbackHandler.redactUserInfo("https://user:password@host:9243")
+    );
+  }
+
+  @Test
+  public void redactUserInfoStripsCredentialsContainingAtSign() {
+    // A password containing '@' must not leave any trailing credential fragment behind:
+    // the separator between user-info and host is the LAST '@' in the authority, not the first.
+    assertEquals(
+        "https://host:9243",
+        ConfigCallbackHandler.redactUserInfo("https://user:p@ssw0rd@host:9243")
+    );
+  }
+
+  @Test
+  public void redactUserInfoStripsCredentialsWithMultipleAtSigns() {
+    assertEquals(
+        "https://host:9243",
+        ConfigCallbackHandler.redactUserInfo("https://user:p@ss@w@rd@host:9243")
+    );
+  }
+
+  @Test
+  public void redactUserInfoLeavesUrlWithoutCredentialsUnchanged() {
+    assertEquals(
+        "https://host:9243",
+        ConfigCallbackHandler.redactUserInfo("https://host:9243")
+    );
+  }
+
+  @Test
+  public void redactUserInfoDoesNotStripAtSignInPath() {
+    // An '@' appearing after the authority component (e.g. in the path) is not a credential
+    // separator and must be left alone.
+    assertEquals(
+        "https://host:9243/index/user@example.com",
+        ConfigCallbackHandler.redactUserInfo("https://host:9243/index/user@example.com")
+    );
+  }
+
+  @Test
+  public void redactUserInfoHandlesUrlWithoutScheme() {
+    assertEquals(
+        "host:9243",
+        ConfigCallbackHandler.redactUserInfo("user:password@host:9243")
+    );
+  }
+}

--- a/src/test/java/io/confluent/connect/elasticsearch/DataConverterTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/DataConverterTest.java
@@ -18,6 +18,7 @@ package io.confluent.connect.elasticsearch;
 import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.BehaviorOnNullValues;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.connect.data.*;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.elasticsearch.action.DocWriteRequest;
@@ -43,6 +44,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class DataConverterTest {
@@ -404,6 +406,31 @@ public class DataConverterTest {
     assertEquals(key, actualRecord.id());
     assertEquals(index, actualRecord.index());
     assertEquals(expectedExternalVersion, actualRecord.version());
+  }
+
+  @Test
+  public void externalVersionHeaderInvalidValueDoesNotLeakHeaderValueOrCause() {
+    String externalVersionHeader = "version";
+    String invalidVersionValue = "not-a-long-CANARY";
+
+    props.put(ElasticsearchSinkConnectorConfig.IGNORE_KEY_CONFIG, "false");
+    props.put(ElasticsearchSinkConnectorConfig.IGNORE_SCHEMA_CONFIG, "false");
+    props.put(ElasticsearchSinkConnectorConfig.EXTERNAL_VERSION_HEADER_CONFIG, externalVersionHeader);
+    converter = new DataConverter(new ElasticsearchSinkConnectorConfig(props));
+
+    Schema preProcessedSchema = converter.preProcessSchema(schema);
+    Struct struct = new Struct(preProcessedSchema).put("string", "myValue");
+    SinkRecord sinkRecord = createSinkRecordWithValue(struct);
+    sinkRecord.headers().addString(externalVersionHeader, invalidVersionValue);
+
+    ConnectException exception = assertThrows(
+        ConnectException.class,
+        () -> converter.convertRecord(sinkRecord, index)
+    );
+
+    assertNull(exception.getCause());
+    assertFalse(exception.getMessage().contains(invalidVersionValue));
+    assertTrue(exception.getMessage().contains(externalVersionHeader));
   }
 
   @Test


### PR DESCRIPTION
## Summary
Cherry-pick of #928 (backport of #926 to 14.1.x) onto `jjain/log_sev1_ficx`.

A log-leak audit of this repo found several places where sensitive data (Kafka record keys, header values, and a connection URL) could reach connector logs:

- `ElasticsearchClient`: the version-conflict handler in `handleResponse` logged `response.getId()` at WARN and DEBUG, which for `key.ignore=false` is the raw Kafka record key (customer-controlled data such as user ids, emails, order ids). Removed the record key from the WARN and DEBUG log lines, keeping only safe fields (`opType`, `version`, `index`). The existing TRACE log line is left unchanged, since it retains the document-id detail for troubleshooting when explicitly enabled.
- `ConfigCallbackHandler`: `connection.url` is logged at INFO on every client build with no check for an embedded `user:pass@` credential. Strips any user-info before logging.
- `ElasticsearchSinkTask`: the ERROR log for a failed record conversion logged the full caught `DataException`, whose message can originate from Kafka's own `JsonConverter` (not in this repo) and could echo record content. Now logs only the exception class plus topic/partition/offset.
- `DataConverter`: the `ConnectException` thrown when an external-version header fails to parse as a `long` embedded the raw decoded header bytes. Since `ConnectException` is `DataException`'s superclass, this exception isn't caught by the sink task's `catch (DataException)` and can propagate to the Connect worker's own error log. The header value is now dropped from the message.
- `DataConverter` (follow-up): the above fix still chained the original `NumberFormatException` as the cause, and that exception's own message embeds the invalid header value. Since the outer exception propagates uncaught and Connect logs the full cause chain on task failure, the value was still leaking one level down. The cause is now dropped entirely.

Also fixed two pre-existing local test-infrastructure gaps found while verifying this branch, both invisible before because surefire was silently discovering 0 tests:
- Added `junit-vintage-engine` (test scope) — `junit-jupiter-api` being present made surefire select the JUnit Platform provider, but with no vintage engine to bridge it, every JUnit4-style test in the module silently ran 0 assertions.
- Bumped `mockito.version` from `2.28.2` to `4.6.1` (matching 15.1.x/master) — `2.28.2`'s bundled Byte Buddy can't instrument classes under JDK 17, which broke every test mocking a final/interface type once tests actually started running.

## Test plan
- [x] `mvn clean compile` succeeds
- [x] `mvn test` (excluding the Docker-dependent `ElasticsearchClientTest`) — 187/187 pass
- [x] Cherry-picked cleanly from #928 with no conflicts (merge-base matched 14.1.x tip exactly)

See #928 for the original end-to-end verification against a live Elasticsearch Cloud cluster via kafka-docker-playground.

🤖 Generated with [Claude Code](https://claude.com/claude-code)