### PR TITLE
Redact connection-URL credentials from exceptions; stop echoing ES failure detail to DLQ

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ConfigCallbackHandler.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ConfigCallbackHandler.java
@@ -151,6 +151,20 @@ public class ConfigCallbackHandler implements HttpClientConfigCallback {
   }
 
   /**
+   * Parses {@code url} into an {@link HttpHost}, redacting any embedded {@code user:password@}
+   * credential from the thrown exception's message if parsing fails. {@link HttpHost#create}
+   * otherwise echoes the raw url verbatim in a malformed-url {@link IllegalArgumentException}.
+   */
+  static HttpHost createRedactedHttpHost(String url) {
+    try {
+      return HttpHost.create(url);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException(
+          "Invalid Elasticsearch connection URL: " + redactUserInfo(url));
+    }
+  }
+
+  /**
    * Configures HTTP authentication and proxy authentication according to the client configuration.
    *
    * @param builder the HttpAsyncClientBuilder
@@ -159,7 +173,7 @@ public class ConfigCallbackHandler implements HttpClientConfigCallback {
     CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
     if (config.isAuthenticatedConnection()) {
       config.connectionUrls().forEach(url -> credentialsProvider.setCredentials(
-              new AuthScope(HttpHost.create(url)),
+              new AuthScope(createRedactedHttpHost(url)),
               new UsernamePasswordCredentials(config.username(), config.password().value())
           )
       );

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
@@ -151,7 +151,7 @@ public class ElasticsearchClient {
         .builder(
             config.connectionUrls()
                 .stream()
-                .map(HttpHost::create)
+                .map(ConfigCallbackHandler::createRedactedHttpHost)
                 .collect(toList())
                 .toArray(new HttpHost[config.connectionUrls().size()])
         ).setHttpClientConfigCallback(configCallbackHandler).build();
@@ -722,9 +722,16 @@ public class ElasticsearchClient {
           ? sinkRecords.get(response.getItemId())
           : null;
       if (original != null) {
+        // Elasticsearch's own failure message (e.g. for document_parsing_exception) can include
+        // a preview of the offending field's value, so it isn't included here; enable DEBUG on
+        // this class to see it.
+        log.debug("Indexing failed for operation {} in index '{}': {}",
+            response.getOpType(), response.getIndex(), response.getFailureMessage());
         reporter.report(
             original.sinkRecord,
-            new ReportingException("Indexing failed: " + response.getFailureMessage())
+            new ReportingException("Indexing failed for operation " + response.getOpType()
+                + " in index '" + response.getIndex() + "'. Enable DEBUG logging on "
+                + ElasticsearchClient.class.getName() + " to see the full Elasticsearch response.")
         );
       }
     }

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -1373,8 +1373,16 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
         try {
           new URI(url);
         } catch (URISyntaxException e) {
+          // Redact any embedded user:password@ credential before it reaches the ConfigException
+          // message (both the custom message below and Kafka's own generated message, which
+          // renders the `value` argument verbatim).
+          List<String> redactedUrls = urls.stream()
+              .map(ConfigCallbackHandler::redactUserInfo)
+              .collect(Collectors.toList());
           throw new ConfigException(
-              name, value, "The provided url '" + url + "' is not a valid url."
+              name, redactedUrls,
+              "The provided url '" + ConfigCallbackHandler.redactUserInfo(url)
+                  + "' is not a valid url."
           );
         }
       }

--- a/src/main/java/io/confluent/connect/elasticsearch/Validator.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/Validator.java
@@ -639,7 +639,7 @@ public class Validator {
             .builder(
                 config.connectionUrls()
                     .stream()
-                    .map(HttpHost::create)
+                    .map(ConfigCallbackHandler::createRedactedHttpHost)
                     .collect(Collectors.toList())
                     .toArray(new HttpHost[config.connectionUrls().size()])
             )

--- a/src/test/java/io/confluent/connect/elasticsearch/ConfigCallbackHandlerTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ConfigCallbackHandlerTest.java
@@ -16,7 +16,11 @@
 package io.confluent.connect.elasticsearch;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
+import org.apache.http.HttpHost;
 import org.junit.Test;
 
 public class ConfigCallbackHandlerTest {
@@ -71,5 +75,25 @@ public class ConfigCallbackHandlerTest {
         "host:9243",
         ConfigCallbackHandler.redactUserInfo("user:password@host:9243")
     );
+  }
+
+  @Test
+  public void createRedactedHttpHostParsesValidUrl() {
+    HttpHost host = ConfigCallbackHandler.createRedactedHttpHost("https://host:9243");
+    assertEquals("host", host.getHostName());
+    assertEquals(9243, host.getPort());
+  }
+
+  @Test
+  public void createRedactedHttpHostRedactsCredentialOnParseFailure() {
+    // A space is illegal in a URI authority and forces HttpHost.create() to throw; the raw
+    // credential must not survive into the resulting exception's message.
+    IllegalArgumentException e = assertThrows(
+        IllegalArgumentException.class,
+        () -> ConfigCallbackHandler.createRedactedHttpHost(
+            "https://user:p@ssw0rd@host name:9243")
+    );
+    assertFalse(e.getMessage().contains("p@ssw0rd"));
+    assertTrue(e.getMessage().contains("host name:9243"));
   }
 }

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchClientTest.java
@@ -78,6 +78,7 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 public class ElasticsearchClientTest {
 
@@ -589,6 +590,55 @@ public class ElasticsearchClientTest {
     }
 
     verify(reporter, times(1)).report(eq(badRecord), any(Throwable.class));
+    client.close();
+  }
+
+  /**
+   * Elasticsearch's own mapper_parsing_exception message can include a "Preview of field's
+   * value" fragment of the offending document. The connector must not pass that fragment
+   * through to the DLQ report verbatim.
+   */
+  @Test
+  public void testReporterDoesNotLeakElasticsearchFailureMessage() throws Exception {
+    props.put(IGNORE_KEY_CONFIG, "false");
+    props.put(BEHAVIOR_ON_MALFORMED_DOCS_CONFIG, BehaviorOnMalformedDoc.IGNORE.name());
+    config = new ElasticsearchSinkConnectorConfig(props);
+    converter = new DataConverter(config);
+
+    ErrantRecordReporter reporter = mock(ErrantRecordReporter.class);
+    when(reporter.report(any(), any()))
+            .thenReturn(CompletableFuture.completedFuture(null));
+    ElasticsearchClient client = new ElasticsearchClient(config, reporter, () -> offsetTracker.updateOffsets(), 1, "elasticsearch-sink");
+    client.createIndexOrDataStream(index);
+    client.createMapping(index, schema());
+
+    Schema schema = SchemaBuilder
+            .struct()
+            .name("record")
+            .field("offset", SchemaBuilder.bool().defaultValue(false).build())
+            .build();
+    Struct value = new Struct(schema).put("offset", false);
+    SinkRecord badRecord = sinkRecord("key0", schema, value, 1);
+
+    writeRecord(sinkRecord("key0", 0), client);
+    client.flush();
+    waitUntilRecordsInES(1);
+
+    writeRecord(badRecord, client);
+    client.flush();
+
+    // failed requests take a bit longer
+    for (int i = 2; i < 7; i++) {
+      writeRecord(sinkRecord("key" + i, i + 1), client);
+      client.flush();
+      waitUntilRecordsInES(i);
+    }
+
+    ArgumentCaptor<Throwable> exceptionCaptor = ArgumentCaptor.forClass(Throwable.class);
+    verify(reporter, times(1)).report(eq(badRecord), exceptionCaptor.capture());
+    String reportedMessage = exceptionCaptor.getValue().getMessage();
+    assertFalse(reportedMessage.contains("Preview of field's value"));
+    assertTrue(reportedMessage.contains("Enable DEBUG logging"));
     client.close();
   }
 

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
@@ -5,6 +5,7 @@ import static org.apache.kafka.common.config.SslConfigs.SSL_ENDPOINT_IDENTIFICAT
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SecurityProtocol;
@@ -205,6 +206,19 @@ public class ElasticsearchSinkConnectorConfigTest {
   public void shouldNotAllowInvalidUrl() {
     props.put(CONNECTION_URL_CONFIG, ".com:/bbb/dfs,http://valid.com");
     new ElasticsearchSinkConnectorConfig(props);
+  }
+
+  @Test
+  public void shouldRedactCredentialFromInvalidUrlErrorMessage() {
+    // A space is illegal in a URI authority and forces new URI(url) to throw; the raw credential
+    // must not survive into the ConfigException's own message or its `value` field, since Kafka's
+    // own config-validation machinery renders that value verbatim in its generated message too.
+    props.put(CONNECTION_URL_CONFIG, "https://user:p@ssw0rd@bad host.com");
+    ConfigException e = assertThrows(
+        ConfigException.class,
+        () -> new ElasticsearchSinkConnectorConfig(props)
+    );
+    assertFalse(e.getMessage().contains("p@ssw0rd"));
   }
 
   @Test(expected = ConfigException.class)


### PR DESCRIPTION
## Summary

Two latent (defense-in-depth, not currently-observed-with-sensitive-content) log-leak paths found by a systematic log-leak audit of this connector on `15.0.x`, confirmed to also exist unchanged on `14.1.x`. Both are follow-ups adjacent to the CC-42849/CC-36331 fixes, but outside the scope of what those covered.

### 1. Connection-URL credentials can reach exception messages via 4 unredacted `HttpHost.create()`/`new URI()` call sites

`connection.url` can carry an embedded `user:pass@host` credential (the code already documents this — see `ConfigCallbackHandler`'s `redactedConnectionUrls()` javadoc). Four places parsed the raw URL with no redaction, so a malformed credentialed URL would echo the raw credential into an exception message:

- `ElasticsearchClient`'s constructor (the initial `HttpHost[]` build, unguarded, fires on every task start)
- `ConfigCallbackHandler.configureAuthentication()` (same call, only reached when username/password auth is configured)
- `Validator.createClient()` (validation-time client build — logged at ERROR *and* returned via the Connect config-validate REST API)
- `ElasticsearchSinkConnectorConfig`'s `UrlListValidator` (wrapped and rethrown uncaught by `ElasticsearchSinkConnector.start()`)

Added `ConfigCallbackHandler.createRedactedHttpHost()`, which reuses the existing (already-correct, from CC-42849) `redactUserInfo()` helper to redact the URL before it can appear in a parse-failure exception's message, and applied it at all four sites. `UrlListValidator` also now passes a redacted URL list to `ConfigException` itself, since Kafka's own config-validation framework renders that argument verbatim in its generated message.

**Production check:** queried `logs.json.connect` (prod OpenSearch) for the last 30 days. The general catch-all this feeds into fired ~104,651 times at ERROR; sampled >99.9% of that volume (top 50 distinct exception messages, including 3 confirmed `HttpHost.create()` parse failures) — no embedded credential in any observed instance. Latent, not an incident, but real: customers who embed a credential in a malformed URL are exposed today across 4 code paths, one of which is directly returned by the REST API validate response, not just logs.

### 2. `ElasticsearchClient`'s DLQ report echoed Elasticsearch's raw failure message

For bulk items failing with a malformed-document error (`document_parsing_exception`, `mapper_parsing_exception`, etc.), the connector reported `"Indexing failed: " + response.getFailureMessage()` to the errant-record reporter verbatim. Elasticsearch's own `document_parsing_exception` can include a preview of the offending field's value in that message. The DLQ report now includes only the op-type and index name; the full ES failure detail is still available at DEBUG (matching the existing DEBUG/TRACE precedent from CC-42849).

**Production check:** zero hits for `"Indexing failed:"` across the whole index in the last 30 days — not observed firing recently.

## Test plan
- [x] `mvn clean compile` and `mvn test-compile` succeed
- [x] `mvn test` (excluding the Docker-dependent `ElasticsearchClientTest`) — 196/196 pass
- [x] New unit tests: `ConfigCallbackHandlerTest` (`createRedactedHttpHost` parses valid URLs, redacts credential on parse failure), `ElasticsearchSinkConnectorConfigTest` (`UrlListValidator` redacts credential in `ConfigException` message)
- [x] New integration test added to `ElasticsearchClientTest` (`testReporterDoesNotLeakElasticsearchFailureMessage`, modeled on the existing `testReporterWithFail`) — compiles cleanly but couldn't be run locally (no Docker in this environment); will run in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)