### PR TITLE
CC-42812: Add KDP gating block to semaphore.yml

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -74,6 +74,29 @@ blocks:
           commands:
             - git clone --branch master --single-branch git@github.com:confluentinc/connect-releases.git
             - ./connect-releases/tasks/release-connect-plugins/generate-connect-changelogs.sh
+  # This is auto-managed by connect-ci-cd-pipelines semaphore task, to disable please reach out on slack #connect-testability
+  - name: Connector Kafka Docker Playground Test
+    dependencies: []
+    run:
+      # Run this block only for pull requests
+      when: "pull_request =~ '.*'"
+    task:
+      jobs:
+        - name: Trigger Kafka Docker Playground Test
+          commands:
+            # Don't run this block if target branch for PR is not a nightly branch or master branch
+            - |
+              if [[ "$SEMAPHORE_GIT_BRANCH" =~ ^[0-9]+\.[0-9]+\.x$ ]] || [[ "$SEMAPHORE_GIT_BRANCH" == "master" ]] ; then \
+                echo "PR is targeted to ${SEMAPHORE_GIT_BRANCH} branch which is feature or master branch. Triggering run-kdp-matrix-on-pr-builds task."; \
+                sem-trigger -p connect-ci-cd-pipelines \
+                  -t run-kdp-matrix-on-pr-builds \
+                  -b master \
+                  -i "REPO_NAME:$(basename $SEMAPHORE_GIT_REPO_SLUG)" \
+                  -i "BRANCH_NAME:${SEMAPHORE_GIT_PR_BRANCH}" \
+                  -w
+              else \
+                echo "PR is targeted to ${SEMAPHORE_GIT_BRANCH} branch which is not feature or master branch. Skipping Kafka Docker Playground Test Task."; \
+              fi;
 
 after_pipeline:
   task:


### PR DESCRIPTION
## Summary
This PR adds the KDP gating block to the semaphore.yml configuration.

This change:
- Adds KDP test gating for pull requests
- Only runs on PRs targeting master or version (`N.N.x`) branches
- Triggers connector jar/zip tests as part of the CI pipeline via `connect-ci-cd-pipelines`'s `run-kdp-matrix-on-pr-builds` task

## Why the public repo, not kafka-connect-elasticsearch-private
CC-42812's description names `confluentinc/kafka-connect-elasticsearch-private` as the target repo. That repo is a release-orchestration wrapper (it pins `kafka-connect-elasticsearch` as a git submodule and drives releases via `make create-release`) — it isn't where feature/fix PRs actually land; this repo is. Gating it here is also what actually protects real PRs, and it matches the existing `connect-ci-cd-pipelines` mapping config (`repo-plugin-mapping.json` / `plugin-test-mapping.json` already key on `kafka-connect-elasticsearch`, pointing at `connect-elasticsearch-sink/elasticsearch-sink.sh` — no changes needed there).

Also worth noting: none of the other `-private` submodule-wrapper repos in the org (jdbc, splunk, s3, bigquery, etc.) have KDP gating configured either — this pattern isn't established anywhere for that repo shape, so targeting the public repo avoids inventing new, untested mechanics for a shared pipeline other teams depend on.

Mirrors the pattern already in place for other connectors (e.g. `kafka-connect-aws-dynamodb#108`).

## Jira
[CC-42812](https://confluentinc.atlassian.net/browse/CC-42812) — Enable PR gating using KDP tests for the Elasticsearch Sink Connector.

Note: for any queries please reach out to #connect-testability

[CC-42812]: https://confluentinc.atlassian.net/browse/CC-42812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ