### PR TITLE
Add KDP Docker Playground PR-gating block to 14.1.x

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -74,6 +74,29 @@ blocks:
           commands:
             - git clone --branch master --single-branch git@github.com:confluentinc/connect-releases.git
             - ./connect-releases/tasks/release-connect-plugins/generate-connect-changelogs.sh
+  # This is auto-managed by connect-ci-cd-pipelines semaphore task, to disable please reach out on slack #connect-testability
+  - name: Connector Kafka Docker Playground Test
+    dependencies: []
+    run:
+      # Run this block only for pull requests
+      when: "pull_request =~ '.*'"
+    task:
+      jobs:
+        - name: Trigger Kafka Docker Playground Test
+          commands:
+            # Don't run this block if target branch for PR is not a nightly branch or master branch
+            - |
+              if [[ "$SEMAPHORE_GIT_BRANCH" =~ ^[0-9]+\.[0-9]+\.x$ ]] || [[ "$SEMAPHORE_GIT_BRANCH" == "master" ]] ; then \
+                echo "PR is targeted to ${SEMAPHORE_GIT_BRANCH} branch which is feature or master branch. Triggering run-kdp-matrix-on-pr-builds task."; \
+                sem-trigger -p connect-ci-cd-pipelines \
+                  -t run-kdp-matrix-on-pr-builds \
+                  -b master \
+                  -i "REPO_NAME:$(basename $SEMAPHORE_GIT_REPO_SLUG)" \
+                  -i "BRANCH_NAME:${SEMAPHORE_GIT_PR_BRANCH}" \
+                  -w
+              else \
+                echo "PR is targeted to ${SEMAPHORE_GIT_BRANCH} branch which is not feature or master branch. Skipping Kafka Docker Playground Test Task."; \
+              fi;
 
 after_pipeline:
   task:


### PR DESCRIPTION
## Summary
The KDP PR-gating block ("Connector Kafka Docker Playground Test") was added to `master` in #935, but `14.1.x` (and `15.0.x`, `15.1.x`) never received it since pint-merge only flows forward (`14.1.x -> 15.0.x -> 15.1.x -> master`), not backward from master.

This PR adds the identical block directly to `14.1.x`, so PRs targeting this branch also get KDP gating.

Note: since master already has this identical block via a separate commit, pint-merge's forward-merge chain to master may hit a benign context-adjacency conflict on an unrelated nearby block (not on this content itself). If pint-merge opens a `pr_merge_from_*_to_master`-style conflict-resolution PR because of this, the correct resolution is a no-op `git merge -s ours` (keeping master's current, already-correct file content) per the standard pint-merge conflict-resolution process — not a manual re-authoring of this change.

## Test plan
- [ ] Confirm this pipeline block triggers `run-kdp-matrix-on-pr-builds` correctly on the next PR opened against `14.1.x`