### PR TITLE
Guard stop() against a task whose start() never completed

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -144,7 +144,11 @@ public class ElasticsearchSinkTask extends SinkTask {
   @Override
   public void stop() {
     log.debug("Stopping Elasticsearch client.");
-    client.close();
+    // The framework can call stop() on a task whose start() never ran or never completed
+    // (e.g. a sibling task's startup failure aborts this one first), leaving client unset.
+    if (client != null) {
+      client.close();
+    }
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -144,8 +144,6 @@ public class ElasticsearchSinkTask extends SinkTask {
   @Override
   public void stop() {
     log.debug("Stopping Elasticsearch client.");
-    // The framework can call stop() on a task whose start() never ran or never completed
-    // (e.g. a sibling task's startup failure aborts this one first), leaving client unset.
     if (client != null) {
       client.close();
     }

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
@@ -344,8 +344,11 @@ public class ElasticsearchSinkTaskTest {
   public void testStopBeforeStartDoesNotThrow() {
     // The framework can call stop() on a task whose start() never ran or never completed
     // (e.g. a sibling task's startup failure aborts this one first), leaving client unset.
-    task = new ElasticsearchSinkTask();
-    task.stop();
+    // Uses a local task so the shared fixture is left untouched, and initialize() to match how
+    // Connect builds a task before start().
+    ElasticsearchSinkTask neverStarted = new ElasticsearchSinkTask();
+    neverStarted.initialize(context);
+    neverStarted.stop();
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
@@ -341,6 +341,14 @@ public class ElasticsearchSinkTaskTest {
   }
 
   @Test
+  public void testStopBeforeStartDoesNotThrow() {
+    // The framework can call stop() on a task whose start() never ran or never completed
+    // (e.g. a sibling task's startup failure aborts this one first), leaving client unset.
+    task = new ElasticsearchSinkTask();
+    task.stop();
+  }
+
+  @Test
   public void testVersion() {
     setUpTask();
     assertNotEquals("0.0.0.0", task.version());

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
@@ -342,10 +342,6 @@ public class ElasticsearchSinkTaskTest {
 
   @Test
   public void testStopBeforeStartDoesNotThrow() {
-    // The framework can call stop() on a task whose start() never ran or never completed
-    // (e.g. a sibling task's startup failure aborts this one first), leaving client unset.
-    // Uses a local task so the shared fixture is left untouched, and initialize() to match how
-    // Connect builds a task before start().
     ElasticsearchSinkTask neverStarted = new ElasticsearchSinkTask();
     neverStarted.initialize(context);
     neverStarted.stop();


### PR DESCRIPTION
## Problem

Kafka Connect's framework can call `stop()` on a task whose `start()` never ran or never completed (e.g. a sibling task's startup failure aborts the whole connector before this task finishes starting). `ElasticsearchSinkTask.stop()` unconditionally dereferenced `client`, which is only assigned near the end of `start()`. Earlier statements in `start()` can throw first (`new ElasticsearchSinkTaskConfig(props)` can throw `ConfigException`; the topic-to-resource-map parsing block explicitly rethrows as `ConnectException`). If either throws, `client` stays null and a framework-invoked `stop()` throws an uncaught `NullPointerException` instead of shutting down cleanly.

## Fix

Added a null check for `client` before `client.close()`.

## Test

Added `testStopBeforeStartDoesNotThrow`, which constructs an `ElasticsearchSinkTask` directly (never started) and calls `.stop()`, asserting it doesn't throw.

## Verification note

`mvn compile test-compile` succeeds cleanly. Running the full test suite (`mvn test -Dtest=ElasticsearchSinkTaskTest`) currently fails in this environment for all 28 pre-existing tests (confirmed unrelated to this change by reverting and re-running), due to Mockito's inline mock agent being unable to instrument classes on this environment's JDK 25 with the pinned Mockito version. This is a pre-existing, unrelated environment limitation, not something introduced by this change. Compilation was verified; full test execution was not.

## Precedent

Same bug pattern and fix shape as confluentinc/kafka-connect-azure-blob-storage#531 and confluentinc/kafka-connect-aws-dynamodb#157.
