### PR TITLE
fix: redact connection.url credentials and record content from logs and exceptions

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/ConfigCallbackHandler.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ConfigCallbackHandler.java
@@ -151,6 +151,20 @@ public class ConfigCallbackHandler implements HttpClientConfigCallback {
   }
 
   /**
+   * Parses {@code url} into an {@link HttpHost}, redacting any embedded {@code user:password@}
+   * credential from the thrown exception's message if parsing fails. {@link HttpHost#create}
+   * otherwise echoes the raw url verbatim in a malformed-url {@link IllegalArgumentException}.
+   */
+  static HttpHost createRedactedHttpHost(String url) {
+    try {
+      return HttpHost.create(url);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException(
+          "Invalid Elasticsearch connection URL: " + redactUserInfo(url));
+    }
+  }
+
+  /**
    * Configures HTTP authentication and proxy authentication according to the client configuration.
    *
    * @param builder the HttpAsyncClientBuilder
@@ -159,7 +173,7 @@ public class ConfigCallbackHandler implements HttpClientConfigCallback {
     CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
     if (config.isAuthenticatedConnection()) {
       config.connectionUrls().forEach(url -> credentialsProvider.setCredentials(
-              new AuthScope(HttpHost.create(url)),
+              new AuthScope(createRedactedHttpHost(url)),
               new UsernamePasswordCredentials(config.username(), config.password().value())
           )
       );

--- a/src/main/java/io/confluent/connect/elasticsearch/ConfigCallbackHandler.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ConfigCallbackHandler.java
@@ -135,10 +135,6 @@ public class ConfigCallbackHandler implements HttpClientConfigCallback {
         .collect(Collectors.toCollection(LinkedHashSet::new));
   }
 
-  // Matches the only two ways RFC 3986 introduces an authority component: a real
-  // "scheme://" prefix, or a bare "//" network-path reference. Anything else - including a
-  // malformed single-slash scheme like "https:/host" - does NOT reliably mark where a path
-  // begins, so it must not be trusted as a delimiter (see below).
   private static final Pattern AUTHORITY_PREFIX =
       Pattern.compile("^[A-Za-z][A-Za-z0-9+.-]*://|^//");
 
@@ -147,13 +143,6 @@ public class ConfigCallbackHandler implements HttpClientConfigCallback {
     boolean recognizedPrefix = schemeMatcher.find();
     int authorityStart = recognizedPrefix ? schemeMatcher.end() : 0;
 
-    // '?' and '#' always mark the end of the authority, recognized prefix or not. '/' only
-    // does when we've confirmed a real authority marker above - otherwise a malformed scheme
-    // (or no scheme at all) can put a '/' before the credential that isn't a path separator,
-    // which previously let the credential slip through unredacted (e.g. "//user:pass@host",
-    // "https:/user:pass@host", "user:pass@host" with no scheme at all). When we can't trust
-    // '/' as a boundary, it's safer to search the rest of the string than to risk a false
-    // negative.
     char[] delimiters = recognizedPrefix ? new char[] {'/', '?', '#'} : new char[] {'?', '#'};
     int authorityEnd = url.length();
     for (char delimiter : delimiters) {

--- a/src/main/java/io/confluent/connect/elasticsearch/ConfigCallbackHandler.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ConfigCallbackHandler.java
@@ -25,6 +25,8 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
@@ -133,10 +135,28 @@ public class ConfigCallbackHandler implements HttpClientConfigCallback {
         .collect(Collectors.toCollection(LinkedHashSet::new));
   }
 
+  // Matches the only two ways RFC 3986 introduces an authority component: a real
+  // "scheme://" prefix, or a bare "//" network-path reference. Anything else - including a
+  // malformed single-slash scheme like "https:/host" - does NOT reliably mark where a path
+  // begins, so it must not be trusted as a delimiter (see below).
+  private static final Pattern AUTHORITY_PREFIX =
+      Pattern.compile("^[A-Za-z][A-Za-z0-9+.-]*://|^//");
+
   static String redactUserInfo(String url) {
-    int authorityStart = url.indexOf("://") >= 0 ? url.indexOf("://") + 3 : 0;
+    Matcher schemeMatcher = AUTHORITY_PREFIX.matcher(url);
+    boolean recognizedPrefix = schemeMatcher.find();
+    int authorityStart = recognizedPrefix ? schemeMatcher.end() : 0;
+
+    // '?' and '#' always mark the end of the authority, recognized prefix or not. '/' only
+    // does when we've confirmed a real authority marker above - otherwise a malformed scheme
+    // (or no scheme at all) can put a '/' before the credential that isn't a path separator,
+    // which previously let the credential slip through unredacted (e.g. "//user:pass@host",
+    // "https:/user:pass@host", "user:pass@host" with no scheme at all). When we can't trust
+    // '/' as a boundary, it's safer to search the rest of the string than to risk a false
+    // negative.
+    char[] delimiters = recognizedPrefix ? new char[] {'/', '?', '#'} : new char[] {'?', '#'};
     int authorityEnd = url.length();
-    for (char delimiter : new char[] {'/', '?', '#'}) {
+    for (char delimiter : delimiters) {
       int delimiterIndex = url.indexOf(delimiter, authorityStart);
       if (delimiterIndex >= 0) {
         authorityEnd = Math.min(authorityEnd, delimiterIndex);

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchClient.java
@@ -151,7 +151,7 @@ public class ElasticsearchClient {
         .builder(
             config.connectionUrls()
                 .stream()
-                .map(HttpHost::create)
+                .map(ConfigCallbackHandler::createRedactedHttpHost)
                 .collect(toList())
                 .toArray(new HttpHost[config.connectionUrls().size()])
         ).setHttpClientConfigCallback(configCallbackHandler).build();

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -18,12 +18,12 @@ package io.confluent.connect.elasticsearch;
 import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeMap;
 import java.util.stream.Collectors;
 import java.util.concurrent.TimeUnit;
 import org.apache.kafka.common.config.AbstractConfig;
@@ -35,8 +35,6 @@ import org.apache.kafka.common.config.ConfigDef.Validator;
 import org.apache.kafka.common.config.ConfigDef.Width;
 import org.apache.kafka.common.config.types.Password;
 import org.elasticsearch.common.unit.ByteSizeValue;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static org.apache.kafka.common.config.ConfigDef.Range.between;
 import static org.apache.kafka.common.config.SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG;
@@ -963,46 +961,46 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
 
   public static final ConfigDef CONFIG = baseConfigDef();
 
-  // connection.url is a Type.LIST, so the inherited AbstractConfig.logAll() would print it verbatim
-  // (unlike Type.PASSWORD keys, which render "[hidden]"). A user who embeds credentials directly in
-  // the URL would leak them into the config dump. We suppress the automatic logAll() (doLog=false
-  // in the super(...) calls) and re-emit the same dump with the connection URLs redacted, under
-  // the same AbstractConfig logger so existing log tooling and dashboards are unaffected.
-  private static final Logger CONFIG_LOG = LoggerFactory.getLogger(AbstractConfig.class);
-
   protected ElasticsearchSinkConnectorConfig(ConfigDef config, Map<String, String> properties) {
-    super(config, properties, false);
+    super(config, sanitizeConnectionUrl(properties));
     this.kafkaTopics = getTopicArray(properties);
-    logConfigWithRedactedConnectionUrls();
   }
 
   public ElasticsearchSinkConnectorConfig(Map<String, String> props) {
-    super(CONFIG, props, false);
+    super(CONFIG, sanitizeConnectionUrl(props));
     this.kafkaTopics = getTopicArray(props);
-    logConfigWithRedactedConnectionUrls();
   }
 
   /**
-   * Mirrors {@link AbstractConfig}'s own {@code logAll()} config dump, but redacts any embedded
-   * user-info from the {@code connection.url} values so credentials mistakenly placed in the URL
-   * are not written to the log. Password-typed values still render as {@code [hidden]} because
-   * their stored value is a {@link Password} whose {@code toString()} masks it.
+   * Returns a copy of {@code properties} with any embedded {@code user:password@} credentials
+   * stripped from the {@code connection.url} value(s). Credentials are supplied via the dedicated
+   * {@code connection.username}/{@code connection.password} configs; the client authenticates with
+   * those and never with URL user-info (an {@link org.apache.http.HttpHost} carries none), so this
+   * is functionally a no-op for a correctly configured connector.
+   *
+   * <p>Sanitizing at the source keeps credentials out of the parsed config, so the inherited
+   * {@link AbstractConfig} config dump (and every other consumer of {@code connection.url}) is
+   * safe without having to suppress the framework's automatic {@code logAll()}.
+   * {@code connection.url} is a {@code Type.LIST} — a comma-separated string in the raw
+   * properties — so each element is redacted independently.
    */
-  private void logConfigWithRedactedConnectionUrls() {
-    StringBuilder b = new StringBuilder();
-    b.append(getClass().getSimpleName()).append(" values: ").append(System.lineSeparator());
-    for (Map.Entry<String, ?> entry : new TreeMap<String, Object>(values()).entrySet()) {
-      Object value = entry.getValue();
-      if (CONNECTION_URL_CONFIG.equals(entry.getKey()) && value instanceof List) {
-        value = ((List<?>) value).stream()
-            .map(String::valueOf)
-            .map(ConfigCallbackHandler::redactUserInfo)
-            .collect(Collectors.toList());
-      }
-      b.append('\t').append(entry.getKey()).append(" = ").append(value)
-          .append(System.lineSeparator());
+  private static Map<String, String> sanitizeConnectionUrl(Map<String, String> properties) {
+    if (properties == null) {
+      return properties;
     }
-    CONFIG_LOG.info(b.toString());
+    String rawUrls = properties.get(CONNECTION_URL_CONFIG);
+    if (rawUrls == null || rawUrls.isEmpty()) {
+      return properties;
+    }
+    String sanitized = Arrays.stream(rawUrls.split(","))
+        .map(ConfigCallbackHandler::redactUserInfo)
+        .collect(Collectors.joining(","));
+    if (sanitized.equals(rawUrls)) {
+      return properties;
+    }
+    Map<String, String> copy = new HashMap<>(properties);
+    copy.put(CONNECTION_URL_CONFIG, sanitized);
+    return copy;
   }
 
   private String[] getTopicArray(Map<?, ?> config) {

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 import java.util.concurrent.TimeUnit;
 import org.apache.kafka.common.config.AbstractConfig;
@@ -34,6 +35,8 @@ import org.apache.kafka.common.config.ConfigDef.Validator;
 import org.apache.kafka.common.config.ConfigDef.Width;
 import org.apache.kafka.common.config.types.Password;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.apache.kafka.common.config.ConfigDef.Range.between;
 import static org.apache.kafka.common.config.SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG;
@@ -960,14 +963,46 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
 
   public static final ConfigDef CONFIG = baseConfigDef();
 
+  // connection.url is a Type.LIST, so the inherited AbstractConfig.logAll() would print it verbatim
+  // (unlike Type.PASSWORD keys, which render "[hidden]"). A user who embeds credentials directly in
+  // the URL would leak them into the config dump. We suppress the automatic logAll() (doLog=false
+  // in the super(...) calls) and re-emit the same dump with the connection URLs redacted, under
+  // the same AbstractConfig logger so existing log tooling and dashboards are unaffected.
+  private static final Logger CONFIG_LOG = LoggerFactory.getLogger(AbstractConfig.class);
+
   protected ElasticsearchSinkConnectorConfig(ConfigDef config, Map<String, String> properties) {
-    super(config, properties);
+    super(config, properties, false);
     this.kafkaTopics = getTopicArray(properties);
+    logConfigWithRedactedConnectionUrls();
   }
 
   public ElasticsearchSinkConnectorConfig(Map<String, String> props) {
-    super(CONFIG, props);
+    super(CONFIG, props, false);
     this.kafkaTopics = getTopicArray(props);
+    logConfigWithRedactedConnectionUrls();
+  }
+
+  /**
+   * Mirrors {@link AbstractConfig}'s own {@code logAll()} config dump, but redacts any embedded
+   * user-info from the {@code connection.url} values so credentials mistakenly placed in the URL
+   * are not written to the log. Password-typed values still render as {@code [hidden]} because
+   * their stored value is a {@link Password} whose {@code toString()} masks it.
+   */
+  private void logConfigWithRedactedConnectionUrls() {
+    StringBuilder b = new StringBuilder();
+    b.append(getClass().getSimpleName()).append(" values: ").append(System.lineSeparator());
+    for (Map.Entry<String, ?> entry : new TreeMap<String, Object>(values()).entrySet()) {
+      Object value = entry.getValue();
+      if (CONNECTION_URL_CONFIG.equals(entry.getKey()) && value instanceof List) {
+        value = ((List<?>) value).stream()
+            .map(String::valueOf)
+            .map(ConfigCallbackHandler::redactUserInfo)
+            .collect(Collectors.toList());
+      }
+      b.append('\t').append(entry.getKey()).append(" = ").append(value)
+          .append(System.lineSeparator());
+    }
+    CONFIG_LOG.info(b.toString());
   }
 
   private String[] getTopicArray(Map<?, ?> config) {
@@ -1373,8 +1408,16 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
         try {
           new URI(url);
         } catch (URISyntaxException e) {
+          // Redact any embedded user:password@ credential before it reaches the ConfigException
+          // message (both the custom message below and Kafka's own generated message, which
+          // renders the `value` argument verbatim), including via the Connect config-validate API.
+          List<String> redactedUrls = urls.stream()
+              .map(ConfigCallbackHandler::redactUserInfo)
+              .collect(Collectors.toList());
           throw new ConfigException(
-              name, value, "The provided url '" + url + "' is not a valid url."
+              name, redactedUrls,
+              "The provided url '" + ConfigCallbackHandler.redactUserInfo(url)
+                  + "' is not a valid url."
           );
         }
       }

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -1399,9 +1399,6 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
         try {
           new URI(url);
         } catch (URISyntaxException e) {
-          // Redact any embedded user:password@ credential before it reaches the ConfigException
-          // message (both the custom message below and Kafka's own generated message, which
-          // renders the `value` argument verbatim), including via the Connect config-validate API.
           List<String> redactedUrls = urls.stream()
               .map(ConfigCallbackHandler::redactUserInfo)
               .collect(Collectors.toList());

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfig.java
@@ -972,17 +972,10 @@ public class ElasticsearchSinkConnectorConfig extends AbstractConfig {
   }
 
   /**
-   * Returns a copy of {@code properties} with any embedded {@code user:password@} credentials
-   * stripped from the {@code connection.url} value(s). Credentials are supplied via the dedicated
-   * {@code connection.username}/{@code connection.password} configs; the client authenticates with
-   * those and never with URL user-info (an {@link org.apache.http.HttpHost} carries none), so this
-   * is functionally a no-op for a correctly configured connector.
-   *
-   * <p>Sanitizing at the source keeps credentials out of the parsed config, so the inherited
-   * {@link AbstractConfig} config dump (and every other consumer of {@code connection.url}) is
-   * safe without having to suppress the framework's automatic {@code logAll()}.
-   * {@code connection.url} is a {@code Type.LIST} — a comma-separated string in the raw
-   * properties — so each element is redacted independently.
+   * Strips any embedded {@code user:password@} from {@code connection.url} before the config is
+   * parsed, so it never reaches the config dump or any other consumer. No-op for a correctly
+   * configured connector, which authenticates via {@code connection.username}/
+   * {@code connection.password} instead.
    */
   private static Map<String, String> sanitizeConnectionUrl(Map<String, String> properties) {
     if (properties == null) {

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -297,7 +297,13 @@ public class ElasticsearchSinkTask extends SinkTask {
             recordString(sinkRecord), convertException.getClass().getName());
         offsetState.markProcessed();
       } else {
-        throw convertException;
+        // Don't hand the raw converter exception to the framework: like the sibling log above,
+        // its message may originate from a third-party converter and could echo back raw record
+        // content, which the framework then logs at ERROR and surfaces in the task status. Rethrow
+        // with only the coordinates and failure type; the full exception still reaches the DLQ
+        // above via reportBadRecord.
+        throw new DataException(String.format("Can't convert %s. Failure type: %s",
+            recordString(sinkRecord), convertException.getClass().getName()));
       }
     }
 

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -302,6 +302,8 @@ public class ElasticsearchSinkTask extends SinkTask {
         // content, which the framework then logs at ERROR and surfaces in the task status. Rethrow
         // with only the coordinates and failure type; the full exception still reaches the DLQ
         // above via reportBadRecord.
+        log.trace("Can't convert {}. Failure type: {}",
+            recordString(sinkRecord), convertException.getClass().getName(), convertException);
         throw new DataException(String.format("Can't convert %s. Failure type: %s",
             recordString(sinkRecord), convertException.getClass().getName()));
       }

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -297,11 +297,6 @@ public class ElasticsearchSinkTask extends SinkTask {
             recordString(sinkRecord), convertException.getClass().getName());
         offsetState.markProcessed();
       } else {
-        // Don't hand the raw converter exception to the framework: like the sibling log above,
-        // its message may originate from a third-party converter and could echo back raw record
-        // content, which the framework then logs at ERROR and surfaces in the task status. Rethrow
-        // with only the coordinates and failure type; the full exception still reaches the DLQ
-        // above via reportBadRecord.
         log.trace("Can't convert {}. Failure type: {}",
             recordString(sinkRecord), convertException.getClass().getName(), convertException);
         throw new DataException(String.format("Can't convert %s. Failure type: %s",

--- a/src/main/java/io/confluent/connect/elasticsearch/Validator.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/Validator.java
@@ -639,7 +639,7 @@ public class Validator {
             .builder(
                 config.connectionUrls()
                     .stream()
-                    .map(HttpHost::create)
+                    .map(ConfigCallbackHandler::createRedactedHttpHost)
                     .collect(Collectors.toList())
                     .toArray(new HttpHost[config.connectionUrls().size()])
             )

--- a/src/test/java/io/confluent/connect/elasticsearch/ConfigCallbackHandlerTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ConfigCallbackHandlerTest.java
@@ -16,7 +16,11 @@
 package io.confluent.connect.elasticsearch;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
+import org.apache.http.HttpHost;
 import org.junit.Test;
 
 public class ConfigCallbackHandlerTest {
@@ -71,5 +75,25 @@ public class ConfigCallbackHandlerTest {
         "host:9243",
         ConfigCallbackHandler.redactUserInfo("user:password@host:9243")
     );
+  }
+
+  @Test
+  public void createRedactedHttpHostParsesValidUrl() {
+    HttpHost host = ConfigCallbackHandler.createRedactedHttpHost("https://host:9243");
+    assertEquals("host", host.getHostName());
+    assertEquals(9243, host.getPort());
+  }
+
+  @Test
+  public void createRedactedHttpHostRedactsCredentialOnParseFailure() {
+    // A space is illegal in a URI authority and forces HttpHost.create() to throw; the raw
+    // credential must not survive into the resulting exception's message.
+    IllegalArgumentException e = assertThrows(
+        IllegalArgumentException.class,
+        () -> ConfigCallbackHandler.createRedactedHttpHost(
+            "https://user:p@ssw0rd@host name:9243")
+    );
+    assertFalse(e.getMessage().contains("p@ssw0rd"));
+    assertTrue(e.getMessage().contains("host name:9243"));
   }
 }

--- a/src/test/java/io/confluent/connect/elasticsearch/ConfigCallbackHandlerTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ConfigCallbackHandlerTest.java
@@ -99,9 +99,6 @@ public class ConfigCallbackHandlerTest {
 
   @Test
   public void createRedactedHttpHostRedactsCredentialWhenUnderlyingExceptionEchoesIt() {
-    // Unlike the space case above, HttpHost.create() rejects a URL with any path component
-    // by echoing the *entire* authority - including the credential - verbatim in its message.
-    // This is the failure mode that actually motivated redacting the caught exception at all.
     IllegalArgumentException e = assertThrows(
         IllegalArgumentException.class,
         () -> ConfigCallbackHandler.createRedactedHttpHost(
@@ -113,8 +110,6 @@ public class ConfigCallbackHandlerTest {
 
   @Test
   public void redactUserInfoStripsCredentialsFromSchemeRelativeUrl() {
-    // No "scheme://" prefix, just a bare network-path reference - the leading "//" must not
-    // be mistaken for a path separator, which previously let the credential through unredacted.
     assertEquals(
         "//host:9243",
         ConfigCallbackHandler.redactUserInfo("//user:password@host:9243")
@@ -123,9 +118,6 @@ public class ConfigCallbackHandlerTest {
 
   @Test
   public void redactUserInfoStripsCredentialsFromMalformedSingleSlashScheme() {
-    // A single slash after the scheme colon is not a valid "://" authority marker, but
-    // HttpHost.create() accepts it anyway and treats the whole string as the hostname - so it
-    // must still be redacted even though it isn't a well-formed URL.
     assertEquals(
         "host:9243",
         ConfigCallbackHandler.redactUserInfo("https:/user:password@host:9243")

--- a/src/test/java/io/confluent/connect/elasticsearch/ConfigCallbackHandlerTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ConfigCallbackHandlerTest.java
@@ -96,4 +96,39 @@ public class ConfigCallbackHandlerTest {
     assertFalse(e.getMessage().contains("p@ssw0rd"));
     assertTrue(e.getMessage().contains("host name:9243"));
   }
+
+  @Test
+  public void createRedactedHttpHostRedactsCredentialWhenUnderlyingExceptionEchoesIt() {
+    // Unlike the space case above, HttpHost.create() rejects a URL with any path component
+    // by echoing the *entire* authority - including the credential - verbatim in its message.
+    // This is the failure mode that actually motivated redacting the caught exception at all.
+    IllegalArgumentException e = assertThrows(
+        IllegalArgumentException.class,
+        () -> ConfigCallbackHandler.createRedactedHttpHost(
+            "https://user:p@ssw0rd@host:9243/")
+    );
+    assertFalse(e.getMessage().contains("p@ssw0rd"));
+    assertTrue(e.getMessage().contains("host:9243"));
+  }
+
+  @Test
+  public void redactUserInfoStripsCredentialsFromSchemeRelativeUrl() {
+    // No "scheme://" prefix, just a bare network-path reference - the leading "//" must not
+    // be mistaken for a path separator, which previously let the credential through unredacted.
+    assertEquals(
+        "//host:9243",
+        ConfigCallbackHandler.redactUserInfo("//user:password@host:9243")
+    );
+  }
+
+  @Test
+  public void redactUserInfoStripsCredentialsFromMalformedSingleSlashScheme() {
+    // A single slash after the scheme colon is not a valid "://" authority marker, but
+    // HttpHost.create() accepts it anyway and treats the whole string as the hostname - so it
+    // must still be redacted even though it isn't a well-formed URL.
+    assertEquals(
+        "host:9243",
+        ConfigCallbackHandler.redactUserInfo("https:/user:password@host:9243")
+    );
+  }
 }

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
@@ -5,17 +5,24 @@ import static org.apache.kafka.common.config.SslConfigs.SSL_ENDPOINT_IDENTIFICAT
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.SecurityProtocol;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.config.types.Password;
+import org.apache.log4j.AppenderSkeleton;
+import org.apache.log4j.Level;
+import org.apache.log4j.spi.LoggingEvent;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -205,6 +212,58 @@ public class ElasticsearchSinkConnectorConfigTest {
   public void shouldNotAllowInvalidUrl() {
     props.put(CONNECTION_URL_CONFIG, ".com:/bbb/dfs,http://valid.com");
     new ElasticsearchSinkConnectorConfig(props);
+  }
+
+  @Test
+  public void shouldRedactCredentialFromInvalidUrlErrorMessage() {
+    // A space is illegal in a URI authority and forces new URI(url) to throw; the raw credential
+    // must not survive into the ConfigException's own message or its `value` field, since Kafka's
+    // own config-validation machinery renders that value verbatim in its generated message too.
+    props.put(CONNECTION_URL_CONFIG, "https://user:p@ssw0rd@bad host.com");
+    ConfigException e = assertThrows(
+        ConfigException.class,
+        () -> new ElasticsearchSinkConnectorConfig(props)
+    );
+    assertFalse(e.getMessage().contains("p@ssw0rd"));
+  }
+
+  @Test
+  public void shouldRedactConnectionUrlCredentialsFromConfigLog() {
+    // The inherited AbstractConfig config dump prints connection.url verbatim; an embedded
+    // credential must not appear in it. Capture the dump (emitted under the AbstractConfig logger)
+    // and assert the credential is gone while the host survives.
+    org.apache.log4j.Logger configLogger =
+        org.apache.log4j.Logger.getLogger(AbstractConfig.class.getName());
+    Level previousLevel = configLogger.getLevel();
+    List<String> messages = new ArrayList<>();
+    AppenderSkeleton appender = new AppenderSkeleton() {
+      @Override
+      protected void append(LoggingEvent event) {
+        messages.add(String.valueOf(event.getMessage()));
+      }
+
+      @Override
+      public void close() {
+      }
+
+      @Override
+      public boolean requiresLayout() {
+        return false;
+      }
+    };
+    configLogger.addAppender(appender);
+    configLogger.setLevel(Level.INFO);
+    try {
+      props.put(CONNECTION_URL_CONFIG, "https://user:CANARY_PW@es-host:9243");
+      new ElasticsearchSinkConnectorConfig(props);
+    } finally {
+      configLogger.removeAppender(appender);
+      configLogger.setLevel(previousLevel);
+    }
+    String dump = String.join("\n", messages);
+    assertTrue(dump.contains("ElasticsearchSinkConnectorConfig values"));
+    assertFalse(dump.contains("CANARY_PW"));
+    assertTrue(dump.contains("es-host:9243"));
   }
 
   @Test(expected = ConfigException.class)

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkConnectorConfigTest.java
@@ -16,7 +16,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.config.types.Password;
@@ -229,11 +228,12 @@ public class ElasticsearchSinkConnectorConfigTest {
 
   @Test
   public void shouldRedactConnectionUrlCredentialsFromConfigLog() {
-    // The inherited AbstractConfig config dump prints connection.url verbatim; an embedded
-    // credential must not appear in it. Capture the dump (emitted under the AbstractConfig logger)
-    // and assert the credential is gone while the host survives.
+    // The inherited AbstractConfig config dump would print connection.url verbatim; an embedded
+    // credential must not appear in it. AbstractConfig logs the dump via getLogger(getClass()), so
+    // it is emitted under this config class's own logger. Capture that logger and assert the
+    // credential (sanitized at the source before super()) is gone while the host survives.
     org.apache.log4j.Logger configLogger =
-        org.apache.log4j.Logger.getLogger(AbstractConfig.class.getName());
+        org.apache.log4j.Logger.getLogger(ElasticsearchSinkConnectorConfig.class.getName());
     Level previousLevel = configLogger.getLevel();
     List<String> messages = new ArrayList<>();
     AppenderSkeleton appender = new AppenderSkeleton() {

--- a/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTaskTest.java
@@ -17,6 +17,7 @@ package io.confluent.connect.elasticsearch;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -50,7 +51,9 @@ import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfi
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_KEY_CONFIG;
 import static io.confluent.connect.elasticsearch.ElasticsearchSinkConnectorConfig.IGNORE_SCHEMA_CONFIG;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeFalse;
@@ -313,6 +316,36 @@ public class ElasticsearchSinkTaskTest {
     SinkRecord invalidRecord = record();
     when(assignment.contains(eq(new TopicPartition(TOPIC, 1)))).thenReturn(true);
     task.put(Collections.singletonList(invalidRecord));
+  }
+
+  @Test
+  public void putRethrowsSanitizedConversionExceptionWithoutRecordContent() throws Exception {
+    props.put(DROP_INVALID_MESSAGE_CONFIG, "false");
+    setUpTask();
+
+    // A third-party converter (e.g. JsonConverter) may echo the offending record's field value in
+    // its exception message and cause. Simulate that and prove the framework rethrow carries none
+    // of it — only Kafka coordinates and the failure type.
+    String canary = "SECRET_FIELD_VALUE_9f3a2b";
+    DataConverter failing = mock(DataConverter.class);
+    when(failing.convertRecord(any(), any())).thenThrow(
+        new DataException("boom " + canary, new IllegalStateException("cause " + canary)));
+    Field converterField = ElasticsearchSinkTask.class.getDeclaredField("converter");
+    converterField.setAccessible(true);
+    converterField.set(task, failing);
+
+    SinkRecord record = record();
+    when(assignment.contains(eq(new TopicPartition(TOPIC, 1)))).thenReturn(true);
+
+    DataException thrown = assertThrows(
+        DataException.class, () -> task.put(Collections.singletonList(record)));
+
+    // Sanitised: fixed prefix, no cause, and no record-derived canary anywhere in the chain.
+    assertTrue(thrown.getMessage().startsWith("Can't convert"));
+    assertNull(thrown.getCause());
+    for (Throwable t = thrown; t != null; t = t.getCause()) {
+      assertFalse(t.getMessage() != null && t.getMessage().contains(canary));
+    }
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchSinkTaskIT.java
+++ b/src/test/java/io/confluent/connect/elasticsearch/integration/ElasticsearchSinkTaskIT.java
@@ -250,9 +250,12 @@ public class ElasticsearchSinkTaskIT {
     task.start(props);
     task.open(ImmutableList.of(tp));
 
+    // The framework rethrow is sanitised (coordinates + failure type only); the original converter
+    // message ("Key is used as document id ...") is no longer echoed to the framework — it still
+    // reaches the DLQ via reportBadRecord.
     assertThatThrownBy(() -> task.put(records))
             .isInstanceOf(DataException.class)
-            .hasMessageContaining("Key is used as document id and can not be null");
+            .hasMessageContaining("Can't convert");
 
     currentOffsets = ImmutableMap.of(tp, new OffsetAndMetadata(0));
     assertThat(task.preCommit(currentOffsets).get(tp).offset())
@@ -298,9 +301,12 @@ public class ElasticsearchSinkTaskIT {
     task.initialize(context);
     task.start(props);
 
+    // The framework rethrow is sanitised (coordinates + failure type only); the original converter
+    // message ("... has a null value ...") is no longer echoed to the framework — it still reaches
+    // the DLQ via reportBadRecord.
     assertThatThrownBy(() -> task.put(records))
             .isInstanceOf(DataException.class)
-            .hasMessageContaining("has a null value ");
+            .hasMessageContaining("Can't convert");
     currentOffsets = ImmutableMap.of(tp, new OffsetAndMetadata(0));
     assertThat(task.preCommit(currentOffsets).get(tp).offset())
             .isLessThanOrEqualTo(1);


### PR DESCRIPTION
## What & why

Remediation of the sensitive-log audit findings for **v15.0.5** (`346dd7c`), the shipped Elasticsearch sink (private wrapper `kafka-connect-elasticsearch-private` v0.104.0). All four findings are **internal** severity — three `connection.url` credential-echo paths and one record-conversion exception path. Only the report's flagged findings are changed; Cleared lines are untouched.

Report: https://drive.google.com/file/d/1Ab4J8wiBpCzy6lR2lOdFxhFcsfZAhQGr/view?usp=sharing

## Findings fixed

| Finding | file:line | Fix | Test |
|---|---|---|---|
| **F1** — raw `connection.url` echoed to forwarded ERROR log + config-validate response | `Validator.java:177` (source at `:642`) | Route the `HttpHost.create` call sites through a new `ConfigCallbackHandler.createRedactedHttpHost()` that strips `user:password@`; the `:177` log/`addErrorMessage` are left untouched and simply receive the redacted message | `ConfigCallbackHandlerTest.createRedactedHttpHost*` |
| **F2** — `connection.url` echoed into `ConfigException` message + `value` (also via config-validate REST) | `ElasticsearchSinkConnectorConfig.java:1377` | Redact each URL via `redactUserInfo` before the exception message and pass the redacted list as the `value` argument | `ElasticsearchSinkConnectorConfigTest.shouldRedactCredentialFromInvalidUrlErrorMessage` |
| **F3** — raw record-conversion `DataException` rethrown to the framework | `ElasticsearchSinkTask.java:300` | Rethrow a sanitized `DataException` (Kafka coordinates + failure type, **no cause**); the full exception still reaches the DLQ via `reportBadRecord` | `ElasticsearchSinkTaskTest.putRethrowsSanitizedConversionExceptionWithoutRecordContent` |
| **F4** — `connection.url` printed verbatim by inherited `AbstractConfig.logAll()` | `ElasticsearchSinkConnectorConfig.java:965`/`970` (helper at `:987`) | Strip any embedded `user:password@` from `connection.url` at the source, **before `super()`**, via `sanitizeConnectionUrl()`. The framework's own `logAll()` is left **enabled** — with credentials gone from the parsed config, the dump (and every other `connection.url` consumer) is safe without suppressing it. Auth is unaffected: credentials come from `connection.username`/`connection.password`, never URL user-info (an `HttpHost` carries none). `ElasticsearchSinkTaskConfig` inherits the protected constructor, so it is covered by the same change | `ElasticsearchSinkConnectorConfigTest.shouldRedactConnectionUrlCredentialsFromConfigLog` |

Each test was proven to **fail on the pre-fix code and pass after the fix**. (F1's helper test is green-only: it shares F2's root cause and the helper does not exist pre-fix.)

## Behavior changes (deliberate)
- Malformed-URL messages change prefix (`Invalid HTTP host:` → `Invalid Elasticsearch connection URL:`) and redact embedded credentials — this also changes the Connect config-validate REST response (F1, F2).
- The task-status trace for a conversion failure becomes a fixed `Can't convert <topic-partition-offset>. Failure type: <class>` with no cause (F3). The full exception is still delivered to the DLQ.
- Any embedded `user:password@` in `connection.url` is stripped from the parsed config at the source (F4). It was never used for authentication (the client authenticates via `connection.username`/`connection.password`), so this is a no-op for a correctly configured connector. The framework's `AbstractConfig.logAll()` still runs unchanged — same logger, format and `[hidden]` password masking — and simply no longer contains URL credentials.

## Out of scope
- **DLQ failure-detail stripping** (`ElasticsearchClient` `ReportingException`): the audit classifies the DLQ path as out of scope (trust boundary), so it is not changed here.
- **Log-redaction rules** (handled by the separate add-log-redaction workflow).

## ⚠️ Coordinate with PR #933
The maintainer's open PR #933 (`jjain/log-leak-audit-followup`, base `14.1.x`) already implements the F1/F2 connection-URL redaction — this PR mirrors that approach on `15.0.x`. When #933 forward-merges `14.1.x → 15.0.x` it may conflict with this PR; please coordinate merge order.

## Test
`ConfigCallbackHandlerTest`, `ElasticsearchSinkConnectorConfigTest`, `ElasticsearchSinkTaskTest`, `ValidatorTest` all green on JDK 8; checkstyle clean.

Audited commit: `346dd7ccc43b0706bbaeca1d455d7fdd9f6fbabf`.


## Follow-up: `redactUserInfo` still leaked for non-standard authority markers

Independent review + live repro against a running Connect worker found that `redactUserInfo` (the shared primitive behind F1, F2, and F4 above) only located the authority component via `indexOf("://")`, falling back to offset 0 for anything else — but still trusted a bare `/` as a path boundary even in that fallback case. That let the credential slip through unredacted for:

| `connection.url` shape | Example | Why it leaked |
|---|---|---|
| Scheme-relative (bare `//`) | `//user:pass@badhost:9243` | The URL's own leading `/` was mistaken for a path separator, collapsing the search window before it reached the `@` |
| Malformed single-slash scheme | `https:/user:pass@badhost:9243` | Same root cause — the single `/` after the scheme colon isn't a valid `://` marker, but was still treated as a path boundary |

Both were confirmed live: `HttpHost.create()` accepts both forms without throwing (treating the whole string as the hostname), so the subsequent `UnknownHostException` — surfaced via the same config-validate path as F1/F2 — echoed the raw password.

**Fix:** `redactUserInfo` now only trusts `/` as an authority-boundary when a real RFC 3986 authority marker (`scheme://` or bare `//`) is actually recognized via a new `AUTHORITY_PREFIX` pattern; otherwise it searches the rest of the string for the credential rather than risk a false negative.

**Test:** `redactUserInfoStripsCredentialsFromSchemeRelativeUrl`, `redactUserInfoStripsCredentialsFromMalformedSingleSlashScheme`, and `createRedactedHttpHostRedactsCredentialWhenUnderlyingExceptionEchoesIt` (the existing `createRedactedHttpHostRedactsCredentialOnParseFailure` used a space-in-host input whose failure message never echoed the credential in the first place, so it didn't actually exercise this class of bug).

Verified against a real build of this branch (`15.0.7-SNAPSHOT`) deployed into a Connect worker in kafka-docker-playground: both inputs above leaked the password in the `/config/validate` response before the fix and no longer do after it. Full existing suite still green aside from two pre-existing Testcontainers tests that can't pull `elasticsearch:8.15.2` in this environment (unrelated).
